### PR TITLE
Display overtime totals on all dashboards

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -11,6 +11,8 @@ import {
     getExpectedHoursForDay,
     computeDailyDiffValue,
     computeDailyDiff,
+    computeDayTotalMinutes,
+    computeTotalMinutesInRange,
     isLateTime,
 } from "./adminDashboardUtils";
 
@@ -194,6 +196,22 @@ const AdminWeekSection = ({
                             const weekH = Math.floor(weekAbs / 60);
                             const weekM = weekAbs % 60;
 
+                            // Arbeitszeit-Summen für Stundenlöhner
+                            let weekWorked = 0;
+                            let monthWorked = 0;
+                            if (userConfig.isHourly) {
+                                weekDates.forEach((d) => {
+                                    const iso = formatLocalDateYMD(d);
+                                    const dayEntries = dayMap[iso] || [];
+                                    weekWorked += computeDayTotalMinutes(dayEntries);
+                                });
+
+                                const monthStart = new Date(selectedMonday.getFullYear(), selectedMonday.getMonth(), 1);
+                                const monthEnd = new Date(selectedMonday.getFullYear(), selectedMonday.getMonth() + 1, 0, 23, 59, 59);
+                                const userEntries = allTracks.filter(tt => tt.username === username);
+                                monthWorked = computeTotalMinutesInRange(userEntries, monthStart, monthEnd);
+                            }
+
                             /* Globale Tracking-Bilanz */
                             const tb =
                                 weeklyBalances.find((wb) => wb.username === username)
@@ -233,6 +251,19 @@ const AdminWeekSection = ({
                                                 {tbSign}
                                                 {tbH}h {tbM}m
                                             </div>
+
+                                            {userConfig.isHourly && (
+                                                <div className="hourly-summary">
+                                                    <p>
+                                                        <strong>{t('weeklyHours')}:</strong>{' '}
+                                                        {Math.floor(weekWorked / 60)}h {weekWorked % 60}m
+                                                    </p>
+                                                    <p>
+                                                        <strong>{t('monthlyHours')}:</strong>{' '}
+                                                        {Math.floor(monthWorked / 60)}h {monthWorked % 60}m
+                                                    </p>
+                                                </div>
+                                            )}
 
                                             {/* Tage der Woche */}
                                             {weekDates.map((d, idx) => {

--- a/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
+++ b/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
@@ -272,6 +272,24 @@ export function computeDayTotalMinutes(dayEntries) {
     }
     return Math.max(0, totalMins);
 }
+
+export function computeTotalMinutesInRange(allEntries, startDate, endDate) {
+    const filtered = allEntries.filter(e => {
+        const d = new Date(e.startTime);
+        return d >= startDate && d <= endDate;
+    });
+    const dayMap = {};
+    filtered.forEach(entry => {
+        const ds = entry.startTime.slice(0, 10);
+        if (!dayMap[ds]) dayMap[ds] = [];
+        dayMap[ds].push(entry);
+    });
+    let total = 0;
+    Object.keys(dayMap).forEach(ds => {
+        total += computeDayTotalMinutes(dayMap[ds]);
+    });
+    return total;
+}
 // /utils/timeUtils.js
 export function isLateTime(timeString) {
     const time = new Date(`1970-01-01T${timeString}`);

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -16,6 +16,8 @@ const PercentageWeekOverview = ({
                                     entries,
                                     monday,
                                     setMonday,
+                                    weeklyWorked,
+                                    weeklyExpected,
                                     weeklyDiff,
                                     handleManualPunch,
                                     punchMessage,
@@ -72,6 +74,18 @@ const PercentageWeekOverview = ({
                 <button onClick={nextWeek}>
                     {t('nextWeek')} →
                 </button>
+            </div>
+
+            <div className="weekly-summary">
+                <p>
+                    <strong>{t('weeklyHours')}:</strong> {minutesToHours(weeklyWorked)}
+                </p>
+                <p>
+                    <strong>{t('expected')}:</strong> {minutesToHours(weeklyExpected)}
+                </p>
+                <p>
+                    <strong>{t('weekBalance')}:</strong> {minutesToHours(weeklyDiff)}
+                </p>
             </div>
 
             {/* Darstellung der Einträge */}
@@ -150,6 +164,8 @@ PercentageWeekOverview.propTypes = {
     entries: PropTypes.array.isRequired,
     monday: PropTypes.instanceOf(Date).isRequired,
     setMonday: PropTypes.func.isRequired,
+    weeklyWorked: PropTypes.number,
+    weeklyExpected: PropTypes.number,
     weeklyDiff: PropTypes.number,
     handleManualPunch: PropTypes.func.isRequired,
     punchMessage: PropTypes.string,


### PR DESCRIPTION
## Summary
- show worked hours per week and month on admin dashboard for hourly users
- add helper to compute minutes within a date range
- display weekly totals and balance on Percentage dashboard

## Testing
- `npm test` *(fails: vitest not found)*