### PR TITLE
Display overtime totals on all dashboards

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
+++ b/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
@@ -272,6 +272,24 @@ export function computeDayTotalMinutes(dayEntries) {
     }
     return Math.max(0, totalMins);
 }
+
+export function computeTotalMinutesInRange(allEntries, startDate, endDate) {
+    const filtered = allEntries.filter(e => {
+        const d = new Date(e.startTime);
+        return d >= startDate && d <= endDate;
+    });
+    const dayMap = {};
+    filtered.forEach(entry => {
+        const ds = entry.startTime.slice(0, 10);
+        if (!dayMap[ds]) dayMap[ds] = [];
+        dayMap[ds].push(entry);
+    });
+    let total = 0;
+    Object.keys(dayMap).forEach(ds => {
+        total += computeDayTotalMinutes(dayMap[ds]);
+    });
+    return total;
+}
 // /utils/timeUtils.js
 export function isLateTime(timeString) {
     const time = new Date(`1970-01-01T${timeString}`);

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -298,6 +298,12 @@ const PercentageDashboard = () => {
                     <p>
                         <strong>Arbeits‑%:</strong> {profile.workPercentage}%
                     </p>
+                    <p>
+                        <strong>{t('expected')}:</strong> {minutesToHours(weeklyExpected)}
+                    </p>
+                    <p>
+                        <strong>{t('weekBalance')}:</strong> {minutesToHours(weeklyDiff)}
+                    </p>
                     {profile.trackingBalanceInMinutes != null && (
                         <p className="overtime-info">
                             <strong>{t('overtimeBalance')}:</strong> {minutesToHours(profile.trackingBalanceInMinutes)}

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -16,6 +16,8 @@ const PercentageWeekOverview = ({
                                     entries,
                                     monday,
                                     setMonday,
+                                    weeklyWorked,
+                                    weeklyExpected,
                                     weeklyDiff,
                                     handleManualPunch,
                                     punchMessage,
@@ -72,6 +74,18 @@ const PercentageWeekOverview = ({
                 <button onClick={nextWeek}>
                     {t('nextWeek')} →
                 </button>
+            </div>
+
+            <div className="weekly-summary">
+                <p>
+                    <strong>{t('weeklyHours')}:</strong> {minutesToHours(weeklyWorked)}
+                </p>
+                <p>
+                    <strong>{t('expected')}:</strong> {minutesToHours(weeklyExpected)}
+                </p>
+                <p>
+                    <strong>{t('weekBalance')}:</strong> {minutesToHours(weeklyDiff)}
+                </p>
             </div>
 
             {/* Darstellung der Einträge */}
@@ -150,6 +164,8 @@ PercentageWeekOverview.propTypes = {
     entries: PropTypes.array.isRequired,
     monday: PropTypes.instanceOf(Date).isRequired,
     setMonday: PropTypes.func.isRequired,
+    weeklyWorked: PropTypes.number,
+    weeklyExpected: PropTypes.number,
     weeklyDiff: PropTypes.number,
     handleManualPunch: PropTypes.func.isRequired,
     punchMessage: PropTypes.string,

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -28,6 +28,7 @@ import {
     groupEntriesByDay,
     isLateTime
 } from './userDashUtils';
+import { minutesToHours } from '../PercentageDashboard/percentageDashUtils';
 
 import UserCorrectionModal from './UserCorrectionModal';
 import UserCorrectionsPanel from './UserCorrectionsPanel';
@@ -440,6 +441,11 @@ function UserDashboard() {
     const overtimeBalanceStr = formatDiffDecimal(userProfile?.trackingBalanceInMinutes || 0);
 
     const weekDates = Array.from({ length: 7 }, (_, i) => addDays(selectedMonday, i));
+    const weeklyExpectedMins = weekDates.reduce((sum, d) => {
+        const exp = getExpectedHoursForDay(d, userProfile, defaultExpectedHours);
+        return sum + (exp ?? 0) * 60;
+    }, 0);
+    const weeklyExpectedStr = minutesToHours(weeklyExpectedMins);
 
     // Korrekturen
     const correctionsForWeek = correctionRequests.filter(req => {
@@ -481,10 +487,12 @@ function UserDashboard() {
                 <h2>{t("title")}</h2>
                 <div className="personal-info">
                     <p><strong>{t("usernameLabel")}:</strong> {userProfile?.username || t("notLoggedIn")}</p>
-                    <p><strong>{t("weekBalance")}:</strong> {weeklyDiffStr}</p>
-                    <p><strong>{t("monthBalance")}:</strong> {monthlyDiffStr}</p>
-                    <p><strong>{t("overallBalance")}:</strong> {overallDiffStr}</p>
-                    <p><strong>{t("overtimeBalance")}:</strong> {overtimeBalanceStr}</p>
+                    <p>
+                        <strong>{t('expected')}:</strong> {weeklyExpectedStr}
+                    </p>
+                    <p>
+                        <strong>{t('overtimeBalance')}:</strong> {overtimeBalanceStr}
+                    </p>
                 </div>
             </header>
 


### PR DESCRIPTION
## Summary
- show weekly expected hours and overtime balance on the regular user dashboard
- display weekly expected hours and current week balance on the percentage dashboard
- adjust admin dashboard summaries per user type

## Testing
- `npm test` *(fails: vitest not found)*