### PR TITLE
Add translation keys and apply in UI

### DIFF
--- a/Chrono-frontend/src/components/ChangelogModal.jsx
+++ b/Chrono-frontend/src/components/ChangelogModal.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import '../styles/Changelog.css'; // Wir erstellen diese CSS-Datei als Nächstes
+import '../styles/Changelog.css';
+import { useTranslation } from '../context/LanguageContext';
 
 const ChangelogModal = ({ changelog, onClose }) => {
+    const { t } = useTranslation();
     if (!changelog) return null;
 
     const handleBackdropClick = (e) => {
@@ -15,20 +17,20 @@ const ChangelogModal = ({ changelog, onClose }) => {
         <div className="changelog-backdrop" onClick={handleBackdropClick}>
             <div className="changelog-modal">
                 <div className="changelog-header">
-                    <h2>Was ist neu in Version {changelog.version}?</h2>
+                    <h2>{t('changelogModal.whatsNew')} {changelog.version}?</h2>
                     <button onClick={onClose} className="changelog-close-btn">&times;</button>
                 </div>
                 <div className="changelog-content">
                     <h3>{changelog.title}</h3>
                     <p className="changelog-date">
-                        Veröffentlicht am: {new Date(changelog.createdAt).toLocaleDateString()}
+                        {t('changelogModal.published')}: {new Date(changelog.createdAt).toLocaleDateString()}
                     </p>
                     <div className="changelog-body">
                         <ReactMarkdown>{changelog.content}</ReactMarkdown>
                     </div>
                 </div>
                 <div className="changelog-footer">
-                    <button onClick={onClose}>Schließen</button>
+                    <button onClick={onClose}>{t('changelogModal.close')}</button>
                 </div>
             </div>
         </div>

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -389,6 +389,22 @@ const translations = {
         lightMode: "Light Mode",
         impressum: "Impressum",
         agb: "AGB",
+        changelogModal: {
+            whatsNew: "Was ist neu in Version",
+            published: "Veröffentlicht am",
+            close: "Schließen",
+        },
+        whatsNewPage: {
+            title: "Alle Änderungen und Updates",
+            loading: "Lade Verlauf...",
+        },
+        notFound: {
+            pageNotFound: "404 - Seite nicht gefunden",
+        },
+        hourlyDashboard: {
+            addEntryFirst: "Bitte fügen Sie mindestens einen Korrektureintrag hinzu.",
+            userNotFound: "Benutzer nicht gefunden, bitte neu anmelden.",
+        },
     },
 
     // =============== ENGLISCH ===============
@@ -777,6 +793,22 @@ const translations = {
         lightMode: "Light Mode",
         impressum: "Impressum",
         agb: "Terms",
+        changelogModal: {
+            whatsNew: "What's new in version",
+            published: "Published on",
+            close: "Close",
+        },
+        whatsNewPage: {
+            title: "All changes and updates",
+            loading: "Loading history...",
+        },
+        notFound: {
+            pageNotFound: "404 - Page not found",
+        },
+        hourlyDashboard: {
+            addEntryFirst: "Please add at least one correction entry.",
+            userNotFound: "User not found, please log in again.",
+        },
     },
 };
 

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -152,11 +152,11 @@ const HourlyDashboard = () => {
 
     const handleCorrectionSubmit = async (entries, reason) => {
         if (!correctionDate || !entries || entries.length === 0) {
-            notify('Bitte fügen Sie mindestens einen Korrektureintrag hinzu.', 'error');
+            notify(t('hourlyDashboard.addEntryFirst'), 'error');
             return;
         }
         if (!currentUser || !currentUser.username) {
-            notify('Benutzer nicht gefunden, bitte neu anmelden.', 'error');
+            notify(t('hourlyDashboard.userNotFound'), 'error');
             return;
         }
         const correctionPromises = entries.map(entry => {

--- a/Chrono-frontend/src/pages/NotFound.jsx
+++ b/Chrono-frontend/src/pages/NotFound.jsx
@@ -1,9 +1,11 @@
 import 'react';
+import { useTranslation } from '../context/LanguageContext';
 
 const NotFound = () => {
+    const { t } = useTranslation();
     return (
         <div>
-            <h2>404 - Page not found</h2>
+            <h2>{t('notFound.pageNotFound')}</h2>
         </div>
     );
 };

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -258,11 +258,11 @@ const PercentageDashboard = () => {
     const handleCorrectionSubmit = async (entries, reason) => {
         // Prüfen, ob alle notwendigen Daten vorhanden sind
         if (!correctionDate || !entries || entries.length === 0) {
-            notify('Bitte fügen Sie mindestens einen Korrektureintrag hinzu.', 'error');
+            notify(t('hourlyDashboard.addEntryFirst'), 'error');
             return;
         }
         if (!currentUser || !currentUser.username) {
-            notify('Benutzer nicht gefunden, bitte neu anmelden.', 'error');
+            notify(t('hourlyDashboard.userNotFound'), 'error');
             return;
         }
 

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -254,11 +254,11 @@ function UserDashboard() {
     const handleCorrectionSubmit = async (entries, reason) => {
         // Prüfen, ob alle notwendigen Daten vorhanden sind
         if (!correctionDate || !entries || entries.length === 0) {
-            notify('Bitte fügen Sie mindestens einen Korrektureintrag hinzu.', 'error');
+            notify(t('hourlyDashboard.addEntryFirst'), 'error');
             return;
         }
         if (!currentUser || !currentUser.username) {
-            notify('Benutzer nicht gefunden, bitte neu anmelden.', 'error');
+            notify(t('hourlyDashboard.userNotFound'), 'error');
             return;
         }
 

--- a/Chrono-frontend/src/pages/WhatsNewPage.jsx
+++ b/Chrono-frontend/src/pages/WhatsNewPage.jsx
@@ -2,9 +2,11 @@ import React, { useState, useEffect } from 'react';
 import Navbar from '../components/Navbar';
 import api from '../utils/api';
 import ReactMarkdown from 'react-markdown';
-import '../styles/Changelog.css'; // Wir verwenden dieselbe CSS-Datei
+import '../styles/Changelog.css';
+import { useTranslation } from '../context/LanguageContext';
 
 const WhatsNewPage = () => {
+    const { t } = useTranslation();
     const [changelogs, setChangelogs] = useState([]);
     const [loading, setLoading] = useState(true);
 
@@ -26,9 +28,9 @@ const WhatsNewPage = () => {
         <div>
             <Navbar />
             <div className="page-container">
-                <h1>Alle Änderungen und Updates</h1>
+                <h1>{t('whatsNewPage.title')}</h1>
                 {loading ? (
-                    <p>Lade Verlauf...</p>
+                    <p>{t('whatsNewPage.loading')}</p>
                 ) : (
                     <div className="changelog-history">
                         {changelogs.map(log => (


### PR DESCRIPTION
## Summary
- add missing translation keys for various pages
- translate ChangelogModal and update changelog view
- translate NotFound page
- use translations for correction error messages
- show translations on the "What's New" page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685874e53fb883258e2f1cbbc1f5edf0