### PR TITLE
Fix popup centering

### DIFF
--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -127,6 +127,25 @@ a:hover {
     white-space: nowrap;
     border: 0;
 }
+
+/* ---------- 4.1) Popup Overlay Helper ------------------------------- */
+/*
+   Vereinheitlicht die Positionierung aller Popup-Overlays.
+   Popups werden damit immer zentriert im aktuellen Viewport angezeigt,
+   unabhängig von der Scrollposition der Seite.
+*/
+.modal-overlay,
+.modal-backdrop,
+.notification-overlay,
+.vacation-modal-overlay,
+.sick-leave-modal-overlay,
+.changelog-backdrop {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
 /* Innerhalb Ihres Light-Theme Blocks */
 html[data-theme='light'] {
     /* ... Ihre bestehenden Variablen ... */


### PR DESCRIPTION
## Summary
- center all popup overlays from any page scroll location by adding a helper in global.css

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685877c38474832590b8f1e99d3175be