### PR TITLE
Ensure popups always open centered

### DIFF
--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -616,9 +616,13 @@
 
 /* Globale Stile für Modal (EditTimeModal, PrintUserTimesModal, CorrectionDecisionModal) */
 .modal-overlay {
-    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    position: fixed;
+    inset: 0; /* zentriert unabhängig von der Scrollposition */
     background: rgba(0,0,0,0.75); /* Etwas dunkleres Overlay für besseren Fokus */
-    z-index: 10000; display: flex; align-items: center; justify-content: center;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     backdrop-filter: blur(4px); /* Etwas stärkerer Blur */
     padding: var(--u-gap-sm);
 }

--- a/Chrono-frontend/src/styles/AdminUserManagementPageScoped.css
+++ b/Chrono-frontend/src/styles/AdminUserManagementPageScoped.css
@@ -475,10 +475,7 @@
 /* --------------------------- Modals (DeleteConfirmModal) --------------------------- */
 .modal-overlay {
     position: fixed; /* Wichtig: positioniert relativ zum Viewport */
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0; /* sorgt für zentrierte Platzierung im sichtbaren Bereich */
     background: rgba(0,0,0,0.65); /* Oder eine CSS-Variable wie var(--c-overlay-bg) */
     z-index: 10000; /* Oder eine passende z-index Variable */
     display: flex;

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -402,12 +402,16 @@
    Modals (PrintReportModal, HourlyCorrectionModal) - Übernahme von UserDashboard
    ========================================================================= */
 .hourly-dashboard.scoped-dashboard .modal-overlay {
-    position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+    position: fixed;
+    inset: 0; /* Fixierte Platzierung im gesamten Viewport */
     background: rgba(var(--ud-c-bg-rgb, 14,16,28), 0.75);
     backdrop-filter: blur(10px) saturate(150%);
     -webkit-backdrop-filter: blur(10px) saturate(150%);
-    display: flex; align-items: center; justify-content: center;
-    z-index: 10000; padding: var(--ud-gap-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: var(--ud-gap-md);
     animation: modalFadeIn 0.3s ease-out;
 }
 .hourly-dashboard.scoped-dashboard .modal-content {

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -362,11 +362,15 @@
    Modals (Korrektur, Drucken)
    ========================================================================= */
 .percentage-dashboard.scoped-dashboard .modal-overlay {
-    position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+    position: fixed;
+    inset: 0; /* Vollständige Überdeckung des Viewports */
     background: rgba(var(--ud-c-bg-rgb, 20,20,25), 0.65); /* Verwendet --ud-c-bg-rgb falls definiert, sonst Fallback */
     backdrop-filter: blur(8px);
-    display: flex; align-items: center; justify-content: center;
-    z-index: 10000; padding: var(--ud-gap-lg, 2rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: var(--ud-gap-lg, 2rem);
     animation: modalFadeIn var(--u-dur, 0.25s) var(--u-ease, ease);
 }
 [data-theme="dark"] .percentage-dashboard.scoped-dashboard .modal-overlay {

--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -380,11 +380,15 @@
    ========================================================================= */
 /* WICHTIGE KORREKTUR: Umbenannt von .modal-overlay zu .modal-backdrop, um mit JSX übereinzustimmen */
 .user-dashboard.scoped-dashboard .modal-backdrop {
-    position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+    position: fixed;
+    inset: 0; /* Overlay über den gesamten Viewport */
     background: rgba(var(--c-bg-rgb, 20,20,25), 0.65);
     backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
-    display: flex; align-items: center; justify-content: center;
-    z-index: 10000; padding: var(--ud-gap-lg, 2rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: var(--ud-gap-lg, 2rem);
     animation: modalFadeIn 0.4s var(--u-ease, ease);
 }
 [data-theme="dark"] .user-dashboard.scoped-dashboard .modal-backdrop {

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -145,6 +145,7 @@ a:hover {
     display: flex;
     align-items: center;
     justify-content: center;
+    z-index: 1000; /* Popup immer über dem Seiteninhalt */
 }
 /* Innerhalb Ihres Light-Theme Blocks */
 html[data-theme='light'] {


### PR DESCRIPTION
## Summary
- center all popup overlays using `inset: 0`
- raise default z-index and add centering comment

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587cd3e1c48325bb65b640a8da2934