### PR TITLE
Center modals and disable background scroll

### DIFF
--- a/Chrono-frontend/src/components/ChangelogModal.jsx
+++ b/Chrono-frontend/src/components/ChangelogModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ModalOverlay from './ModalOverlay';
 import ReactMarkdown from 'react-markdown';
 import '../styles/Changelog.css';
 import { useTranslation } from '../context/LanguageContext';
@@ -14,7 +15,7 @@ const ChangelogModal = ({ changelog, onClose }) => {
     };
 
     return (
-        <div className="changelog-backdrop" onClick={handleBackdropClick}>
+        <ModalOverlay visible className="changelog-backdrop" onClick={handleBackdropClick}>
             <div className="changelog-modal">
                 <div className="changelog-header">
                     <h2>{t('changelogModal.whatsNew')} {changelog.version}?</h2>
@@ -33,7 +34,7 @@ const ChangelogModal = ({ changelog, onClose }) => {
                     <button onClick={onClose}>{t('changelogModal.close')}</button>
                 </div>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/components/ModalOverlay.jsx
+++ b/Chrono-frontend/src/components/ModalOverlay.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useModalOpen from '../utils/useModalOpen';
+
+const ModalOverlay = ({ visible = true, children, className = '', ...props }) => {
+  useModalOpen(visible);
+  if (!visible) return null;
+
+  return (
+    <div className={`modal-overlay ${className}`} {...props}> 
+      {children}
+    </div>
+  );
+};
+
+ModalOverlay.propTypes = {
+  visible: PropTypes.bool,
+  className: PropTypes.string,
+  // Allow any other props like onClick
+  children: PropTypes.node.isRequired,
+};
+
+export default ModalOverlay;

--- a/Chrono-frontend/src/components/PrintReportModal.jsx
+++ b/Chrono-frontend/src/components/PrintReportModal.jsx
@@ -1,5 +1,6 @@
 // src/components/PrintReportModal.jsx
-import "react";
+import React from "react";
+import ModalOverlay from './ModalOverlay';
 import PropTypes from "prop-types";
 import "../styles/PrintReportScoped.css";          // optional – Styles für alle Dashboards
 
@@ -19,7 +20,7 @@ const PrintReportModal = ({
     const cls = cssScope ? ` ${cssScope}-print-modal` : "";
 
     return (
-        <div className={`modal-overlay${cls}`}>
+        <ModalOverlay visible={visible} className={cls.trim()}>
             <div className="modal-content">
                 <h3>{t("selectPeriod")}</h3>
 
@@ -46,7 +47,7 @@ const PrintReportModal = ({
                     <button onClick={onClose}>{t("cancel")}</button>
                 </div>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/components/VacationCalendar.jsx
+++ b/Chrono-frontend/src/components/VacationCalendar.jsx
@@ -1,5 +1,6 @@
 // src/components/VacationCalendar.jsx
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import ModalOverlay from './ModalOverlay';
 import PropTypes from 'prop-types';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
@@ -334,7 +335,7 @@ function VacationCalendar({ vacationRequests, userProfile, onRefreshVacations })
             </div>
 
             {showVacationModal && (
-                <div className="vacation-modal-overlay">
+                <ModalOverlay visible className="vacation-modal-overlay">
                     <div className="vacation-modal-content">
                         <h3>{t('vacationModalTitle', 'Urlaubsantrag stellen')}</h3>
                         <form onSubmit={handleVacationSubmit}>
@@ -383,11 +384,11 @@ function VacationCalendar({ vacationRequests, userProfile, onRefreshVacations })
                             </div>
                         </form>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
 
             {showSickLeaveModal && (
-                <div className="vacation-modal-overlay sick-leave-modal-overlay">
+                <ModalOverlay visible className="vacation-modal-overlay sick-leave-modal-overlay">
                     <div className="vacation-modal-content sick-leave-modal-content">
                         <h3>{t('sickLeave.modalTitle', 'Krankheit melden')}</h3>
                         <form onSubmit={handleSickLeaveSubmit}>
@@ -413,7 +414,7 @@ function VacationCalendar({ vacationRequests, userProfile, onRefreshVacations })
                             </div>
                         </form>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
         </div>
     );

--- a/Chrono-frontend/src/components/VacationCalendarAdmin.jsx
+++ b/Chrono-frontend/src/components/VacationCalendarAdmin.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import ModalOverlay from './ModalOverlay';
 import PropTypes from 'prop-types';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
@@ -425,7 +426,7 @@ const VacationCalendarAdmin = ({ vacationRequests, onReloadVacations, companyUse
             </div>
 
             {showVacationModal && (
-                <div className="modal-overlay">
+                <ModalOverlay visible>
                     <div className="modal-content">
                         <h3>{t('adminVacation.modalTitle', 'Neuen Urlaub für Mitarbeiter anlegen')}</h3>
                         <form onSubmit={(e) => { e.preventDefault(); handleCreateVacation(); }}>
@@ -465,11 +466,11 @@ const VacationCalendarAdmin = ({ vacationRequests, onReloadVacations, companyUse
                             </div>
                         </form>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
 
             {showSickLeaveModal && (
-                <div className="modal-overlay">
+                <ModalOverlay visible>
                     <div className="modal-content">
                         <h3>{t('adminSickLeave.modalTitle', 'Krankheit für Benutzer melden')}</h3>
                         <form onSubmit={(e) => { e.preventDefault(); handleReportSickLeave(); }}>
@@ -502,7 +503,7 @@ const VacationCalendarAdmin = ({ vacationRequests, onReloadVacations, companyUse
                             </div>
                         </form>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
         </div>
     );

--- a/Chrono-frontend/src/context/NotificationContext.jsx
+++ b/Chrono-frontend/src/context/NotificationContext.jsx
@@ -1,5 +1,6 @@
 // src/context/NotificationContext.jsx
 import React, { createContext, useState, useContext } from 'react';
+import ModalOverlay from '../components/ModalOverlay';
 import { useTranslation } from './LanguageContext';
 import "../styles/Notification.css"; // Pfad anpassen
 
@@ -27,12 +28,12 @@ export function NotificationProvider({ children }) {
             {children}
 
             {visible && (
-                <div className="notification-overlay">
+                <ModalOverlay visible className="notification-overlay">
                     <div className="notification-modal">
                         <p>{message}</p>
                         <button onClick={closeNotification}>{t('ok')}</button>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
         </NotificationContext.Provider>
     );

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatDate } from './adminDashboardUtils';
 import api from '../../utils/api';
@@ -165,7 +166,7 @@ const AdminVacationRequests = ({
 
             {/* Modal zum Bestätigen des Löschens */}
             {showDeleteModal && vacationToDelete && (
-                <div className="modal-overlay"> {/* Wiederverwendung aus VacationCalendarAdmin */}
+                <ModalOverlay visible className="">
                     <div className="modal-content delete-confirmation-modal"> {/* Eigene Klasse für spezifisches Styling */}
                         <h3>{t('adminVacation.delete.confirmTitle', 'Urlaub löschen bestätigen')}</h3>
                         <p>
@@ -195,7 +196,7 @@ const AdminVacationRequests = ({
                             </button>
                         </div>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
         </div>
     );

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -1,5 +1,6 @@
 // src/pages/AdminDashboard/AdminWeekSection.jsx
 import React, { useState, useMemo, useEffect, useRef, useCallback } from "react";
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from "prop-types";
 import "../../styles/AdminDashboardScoped.css";
 import api from "../../utils/api"; // Assuming api is configured
@@ -660,7 +661,7 @@ const AdminWeekSection = ({
             </section>
             {/* Modal for deleting sick leave */}
             {showDeleteSickLeaveModal && sickLeaveToDelete && (
-                <div className="modal-overlay fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                <ModalOverlay visible className="bg-black bg-opacity-50">
                     <div className="modal-content delete-confirmation-modal bg-white p-6 rounded-lg shadow-xl max-w-md w-full">
                         <h3 className="text-lg font-semibold mb-4">{t('adminDashboard.deleteSickLeaveConfirmTitle', 'Krankmeldung löschen bestätigen')}</h3>
                         <p className="mb-4 text-sm">
@@ -679,7 +680,7 @@ const AdminWeekSection = ({
                             </button>
                         </div>
                     </div>
-                </div>
+                </ModalOverlay>
             )}
         </div>
     );

--- a/Chrono-frontend/src/pages/AdminDashboard/CorrectionDecisionModal.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/CorrectionDecisionModal.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ModalOverlay from '../../components/ModalOverlay';
 import { useTranslation } from "../../context/LanguageContext";
 import PropTypes from "prop-types";
 import "../../styles/AdminDashboardScoped.css";
@@ -22,7 +23,7 @@ const CorrectionDecisionModal = ({
     const btnLabel = isApprove ? t('adminDashboard.acceptButton') : t('adminDashboard.rejectButton');
 
     return (
-        <div className="modal-overlay">
+        <ModalOverlay visible={visible}>
             <div className="modal-content">
                 <h3>{header}</h3>
 
@@ -41,7 +42,7 @@ const CorrectionDecisionModal = ({
                     <button onClick={onClose} className="secondary">{t('cancel')}</button>
                 </div>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/pages/AdminDashboard/EditTimeModal.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/EditTimeModal.jsx
@@ -1,5 +1,6 @@
 // src/pages/AdminDashboard/EditTimeModal.jsx
 import React, { useState, useEffect } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatLocalDateYMD } from './adminDashboardUtils';
 
@@ -249,7 +250,7 @@ const EditTimeModal = ({
 
     return (
         <div className="admin-dashboard scoped-dashboard">
-            <div className="modal-overlay">
+            <ModalOverlay visible={visible}>
                 <div className="modal-content edit-time-modal-content">
                     <h3>
                         {t("adminDashboard.editTrackingTitle", "Zeiterfassung bearbeiten für")} {targetUsername} <br />
@@ -305,7 +306,7 @@ const EditTimeModal = ({
                         </div>
                     </form>
                 </div>
-            </div>
+            </ModalOverlay>
         </div>
     );
 };

--- a/Chrono-frontend/src/pages/AdminDashboard/PrintUserTimesModal.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/PrintUserTimesModal.jsx
@@ -1,4 +1,5 @@
-import 'react';
+import React from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from "prop-types";
 
 const PrintUserTimesModal = ({
@@ -16,7 +17,7 @@ const PrintUserTimesModal = ({
 
     return (
         <div className="admin-dashboard scoped-dashboard">
-            <div className="modal-overlay">
+            <ModalOverlay visible={printUserModalVisible}>
                 <div className="modal-content">
                     <h3>{t('adminDashboard.printUserTimesTitle', 'Zeiten drucken für')} {printUser}</h3>
                     <div className="form-group">
@@ -44,7 +45,7 @@ const PrintUserTimesModal = ({
                         </button>
                     </div>
                 </div>
-            </div>
+            </ModalOverlay>
         </div>
     );
 };

--- a/Chrono-frontend/src/pages/AdminUserManagement/DeleteConfirmModal.jsx
+++ b/Chrono-frontend/src/pages/AdminUserManagement/DeleteConfirmModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { useTranslation } from '../../context/LanguageContext';
 
@@ -19,7 +20,7 @@ function DeleteConfirmModal({
     if (!visible) return null;
 
     return (
-        <div className="modal-overlay">
+        <ModalOverlay visible={visible}>
             <div className="modal-content delete-confirm-modal">
                 <h3>{title}</h3>
                 <p>
@@ -47,7 +48,7 @@ function DeleteConfirmModal({
                     </button>
                 </div>
             </div>
-        </div>
+        </ModalOverlay>
     );
 }
 

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyCorrectionModal.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyCorrectionModal.jsx
@@ -1,5 +1,6 @@
 // src/pages/HourlyDashboard/HourlyCorrectionModal.jsx
 import  { useState, useEffect } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatTime, formatDate } from './hourDashUtils';
 
@@ -57,7 +58,7 @@ const HourlyCorrectionModal = ({
     };
 
     return (
-        <div className="modal-overlay">
+        <ModalOverlay visible={visible}>
             <div className="modal-content user-correction-modal-content">
                 <form onSubmit={handleSubmit}>
                     <h3>{t('correctionFor')} {formatDate(correctionDate)}</h3>
@@ -91,7 +92,7 @@ const HourlyCorrectionModal = ({
                     </div>
                 </form>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionModal.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionModal.jsx
@@ -1,5 +1,6 @@
 // src/pages/PercentageDashboard/PercentageCorrectionModal.jsx
 import React, { useState, useEffect } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatTime, formatDate } from './percentageDashUtils';
 
@@ -57,7 +58,7 @@ const PercentageCorrectionModal = ({
     };
 
     return (
-        <div className="modal-backdrop">
+        <ModalOverlay visible={visible} className="modal-backdrop">
             <div className="modal-content">
                 <form onSubmit={handleSubmit}>
                     <h3>{t('correctionFor')} {formatDate(correctionDate)}</h3>
@@ -86,7 +87,7 @@ const PercentageCorrectionModal = ({
                     </div>
                 </form>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 PercentageCorrectionModal.propTypes = {

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionsPanel.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionsPanel.jsx
@@ -1,5 +1,6 @@
 // src/pages/PercentageDashboard/PercentageCorrectionModal.jsx
 import React, { useState, useEffect } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatLocalDate, formatTime } from './percentageDashUtils'; // Eigene Utils verwenden
 
@@ -79,7 +80,7 @@ const PercentageCorrectionModal = ({
     };
 
     return (
-        <div className="modal-overlay percentage-dashboard scoped-dashboard"> {/* Scope hinzugefügt */}
+        <ModalOverlay visible={visible} className="percentage-dashboard scoped-dashboard">
             <div className="modal-content user-correction-modal-content"> {/* Klasse für konsistentes Styling */}
                 <h3>
                     {t("userCorrectionModal.title", "Korrekturantrag für")} {formatDate(correctionDate)}
@@ -150,7 +151,7 @@ const PercentageCorrectionModal = ({
                     </div>
                 </form>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/pages/UserDashboard/UserCorrectionModal.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserCorrectionModal.jsx
@@ -1,5 +1,6 @@
 // src/pages/UserDashboard/UserCorrectionModal.jsx
 import React, { useState, useEffect } from 'react';
+import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
 import { formatTime, formatDate } from './userDashUtils';
 
@@ -57,7 +58,7 @@ const UserCorrectionModal = ({
     };
 
     return (
-        <div className="modal-backdrop">
+        <ModalOverlay visible={visible} className="modal-backdrop">
             <div className="modal-content">
                 <form onSubmit={handleSubmit}>
                     <h3>{t('correctionFor')} {formatDate(correctionDate)}</h3>
@@ -86,7 +87,7 @@ const UserCorrectionModal = ({
                     </div>
                 </form>
             </div>
-        </div>
+        </ModalOverlay>
     );
 };
 

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -155,11 +155,19 @@ a:hover {
 .sick-leave-modal-overlay,
 .changelog-backdrop {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000; /* Popup immer über dem Seiteninhalt */
+  overflow-y: auto; /* Bei sehr hohen Inhalten scrollen */
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 /* Innerhalb Ihres Light-Theme Blocks */
 html[data-theme="light"] {

--- a/Chrono-frontend/src/utils/useModalOpen.js
+++ b/Chrono-frontend/src/utils/useModalOpen.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+
+export default function useModalOpen(active) {
+  useEffect(() => {
+    if (active) {
+      document.body.classList.add('modal-open');
+    } else {
+      document.body.classList.remove('modal-open');
+    }
+    return () => {
+      document.body.classList.remove('modal-open');
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- centralize modal CSS rules
- add ModalOverlay helper component with scroll locking hook
- use ModalOverlay for all modal dialogs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a887449e48325b2053361d32927b7