### PR TITLE
Add progress and integrations

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/CalendarIntegrationController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/CalendarIntegrationController.java
@@ -1,0 +1,38 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.services.TimeTrackingService;
+import com.chrono.chrono.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarIntegrationController {
+
+    @Autowired
+    private TimeTrackingService timeTrackingService;
+
+    @GetMapping("/{username}.ics")
+    public ResponseEntity<byte[]> exportCalendar(@PathVariable String username,
+                                                 @RequestParam String start,
+                                                 @RequestParam String end) {
+        LocalDate startDate = LocalDate.parse(start);
+        LocalDate endDate = LocalDate.parse(end);
+        String ics = timeTrackingService.generateIcs(username, startDate, endDate);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("text/calendar"));
+        headers.setContentDisposition(ContentDisposition.attachment().filename(username + ".ics").build());
+        return ResponseEntity.ok().headers(headers).body(ics.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ChatbotTimeTrackingController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ChatbotTimeTrackingController.java
@@ -1,0 +1,28 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.services.SlackService;
+import com.chrono.chrono.services.TimeTrackingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+public class ChatbotTimeTrackingController {
+
+    @Autowired
+    private TimeTrackingService timeTrackingService;
+    @Autowired
+    private SlackService slackService;
+
+    @PostMapping("/stamp")
+    public ResponseEntity<?> stamp(@RequestParam String username, @RequestParam String type) {
+        try {
+            timeTrackingService.handlePunch(username, com.chrono.chrono.entities.TimeTrackingEntry.PunchSource.CHATBOT);
+            slackService.sendMessage("User " + username + " hat gestempelt: " + type);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Error: " + e.getMessage());
+        }
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/DashboardAnalyticsController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/DashboardAnalyticsController.java
@@ -1,0 +1,33 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.services.DashboardAnalyticsService;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/dashboard/analytics")
+public class DashboardAnalyticsController {
+
+    @Autowired
+    private DashboardAnalyticsService analyticsService;
+    @Autowired
+    private UserRepository userRepository;
+
+    @GetMapping("/overtimes")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+    public ResponseEntity<?> getOvertimes(Principal principal) {
+        User admin = userRepository.findByUsername(principal.getName()).orElse(null);
+        if (admin == null || admin.getCompany() == null) {
+            return ResponseEntity.badRequest().body("Admin ohne Firma");
+        }
+        return ResponseEntity.ok(analyticsService.getCompanyOvertimes(admin.getCompany().getId()));
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/DashboardAnalyticsDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/DashboardAnalyticsDTO.java
@@ -1,0 +1,29 @@
+package com.chrono.chrono.dto;
+
+public class DashboardAnalyticsDTO {
+    private String username;
+    private int overtimeMinutes;
+
+    public DashboardAnalyticsDTO() {}
+
+    public DashboardAnalyticsDTO(String username, int overtimeMinutes) {
+        this.username = username;
+        this.overtimeMinutes = overtimeMinutes;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public int getOvertimeMinutes() {
+        return overtimeMinutes;
+    }
+
+    public void setOvertimeMinutes(int overtimeMinutes) {
+        this.overtimeMinutes = overtimeMinutes;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ImportStatusDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ImportStatusDTO.java
@@ -1,0 +1,61 @@
+package com.chrono.chrono.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImportStatusDTO {
+    private int totalRows;
+    private int processedRows;
+    private List<String> successMessages = new ArrayList<>();
+    private List<String> errorMessages = new ArrayList<>();
+    private boolean completed;
+    private String message;
+
+    public int getTotalRows() {
+        return totalRows;
+    }
+
+    public void setTotalRows(int totalRows) {
+        this.totalRows = totalRows;
+    }
+
+    public int getProcessedRows() {
+        return processedRows;
+    }
+
+    public void setProcessedRows(int processedRows) {
+        this.processedRows = processedRows;
+    }
+
+    public List<String> getSuccessMessages() {
+        return successMessages;
+    }
+
+    public void setSuccessMessages(List<String> successMessages) {
+        this.successMessages = successMessages;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public void setErrorMessages(List<String> errorMessages) {
+        this.errorMessages = errorMessages;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/DashboardAnalyticsService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/DashboardAnalyticsService.java
@@ -1,0 +1,23 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.DashboardAnalyticsDTO;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DashboardAnalyticsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public List<DashboardAnalyticsDTO> getCompanyOvertimes(Long companyId) {
+        return userRepository.findByCompany_Id(companyId).stream()
+                .map(u -> new DashboardAnalyticsDTO(u.getUsername(), u.getTrackingBalanceInMinutes()))
+                .collect(Collectors.toList());
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ExcelImportProgressService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ExcelImportProgressService.java
@@ -1,0 +1,51 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.ImportStatusDTO;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+public class ExcelImportProgressService {
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final ConcurrentHashMap<String, ImportStatusDTO> statusMap = new ConcurrentHashMap<>();
+
+    @Autowired
+    private TimeTrackingService timeTrackingService;
+
+    public String startImport(MultipartFile file, Long adminCompanyId) {
+        String id = UUID.randomUUID().toString();
+        ImportStatusDTO status = new ImportStatusDTO();
+        statusMap.put(id, status);
+        executor.submit(() -> {
+            try (InputStream is = file.getInputStream(); Workbook workbook = WorkbookFactory.create(is)) {
+                Sheet sheet = workbook.getSheetAt(0);
+                int totalRows = sheet.getPhysicalNumberOfRows() - 1; // Header ignorieren
+                status.setTotalRows(Math.max(totalRows, 0));
+                timeTrackingService.importTimeTrackingFromExcelWithProgress(workbook, adminCompanyId, status);
+                status.setCompleted(true);
+                status.setMessage(status.getErrorMessages().isEmpty() ?
+                        "Import erfolgreich" : "Import mit Fehlern abgeschlossen");
+            } catch (Exception e) {
+                status.getErrorMessages().add(e.getMessage());
+                status.setCompleted(true);
+                status.setMessage("Import fehlgeschlagen");
+            }
+        });
+        return id;
+    }
+
+    public ImportStatusDTO getStatus(String id) {
+        return statusMap.get(id);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/SlackService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/SlackService.java
@@ -1,0 +1,33 @@
+package com.chrono.chrono.services;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Service
+public class SlackService {
+
+    @Value("${slack.webhook.url:}")
+    private String webhookUrl;
+
+    public void sendMessage(String text) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            return;
+        }
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String payload = "{\"text\":\"" + text.replace("\"", "\\\"") + "\"}";
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload))
+                    .build();
+            client.sendAsync(request, HttpResponse.BodyHandlers.discarding());
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/TimeTrackingService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/TimeTrackingService.java
@@ -3,6 +3,7 @@ package com.chrono.chrono.services;
 import com.chrono.chrono.dto.DailyTimeSummaryDTO;
 import com.chrono.chrono.dto.TimeReportDTO;
 import com.chrono.chrono.dto.TimeTrackingEntryDTO;
+import com.chrono.chrono.dto.ImportStatusDTO;
 import com.chrono.chrono.entities.TimeTrackingEntry;
 import com.chrono.chrono.entities.User;
 import com.chrono.chrono.entities.VacationRequest;
@@ -642,5 +643,126 @@ public class TimeTrackingService {
         result.put("successMessages", successes);
         result.put("errorMessages", errors);
         return result;
+    }
+
+    public void importTimeTrackingFromExcelWithProgress(Workbook workbook, Long adminCompanyId, ImportStatusDTO status) {
+        List<String> errors = status.getErrorMessages();
+        List<String> successes = status.getSuccessMessages();
+        int importedCount = 0;
+        Set<User> affectedUsers = new HashSet<>();
+
+        Sheet sheet = workbook.getSheetAt(0);
+        Iterator<Row> rowIterator = sheet.iterator();
+        if (rowIterator.hasNext()) {
+            rowIterator.next();
+        }
+        int rowNum = 1;
+        while (rowIterator.hasNext()) {
+            Row row = rowIterator.next();
+            rowNum++;
+            try {
+                String username = getCellValueAsString(row.getCell(0));
+                String timestampStr = getCellValueAsString(row.getCell(1));
+                String punchTypeStr = getCellValueAsString(row.getCell(2));
+                String sourceStr = getCellValueAsString(row.getCell(3));
+                String note = getCellValueAsString(row.getCell(4));
+
+                if (username == null || username.trim().isEmpty()) {
+                    errors.add("Zeile " + rowNum + ": Username fehlt.");
+                    continue;
+                }
+                Optional<User> userOpt = userRepository.findByUsername(username);
+                if (userOpt.isEmpty()) {
+                    errors.add("Zeile " + rowNum + ": User '" + username + "' nicht gefunden.");
+                    continue;
+                }
+                User user = userOpt.get();
+                if (adminCompanyId != null) {
+                    User importingAdmin = userRepository.findAll().stream()
+                            .filter(u -> u.getCompany() != null && u.getCompany().getId().equals(adminCompanyId)
+                                    && u.getRoles().stream().anyMatch(r -> r.getRoleName().equals("ROLE_ADMIN") || r.getRoleName().equals("ROLE_SUPERADMIN")))
+                            .findFirst().orElse(null);
+                    boolean isSuperAdmin = importingAdmin != null && importingAdmin.getRoles().stream().anyMatch(r -> r.getRoleName().equals("ROLE_SUPERADMIN"));
+                    if (!isSuperAdmin && (user.getCompany() == null || !user.getCompany().getId().equals(adminCompanyId))) {
+                        errors.add("Zeile " + rowNum + ": User '" + username + "' gehört nicht zur Firma des importierenden Admins oder Admin ist keiner Firma zugeordnet.");
+                        continue;
+                    }
+                }
+
+                LocalDateTime entryTimestamp = parseTimestampSafe(timestampStr, rowNum, username, errors);
+                if (entryTimestamp == null) {
+                    continue;
+                }
+
+                if (punchTypeStr == null || punchTypeStr.trim().isEmpty()) {
+                    errors.add("Zeile " + rowNum + " (User: " + username + "): PunchType fehlt.");
+                    continue;
+                }
+                TimeTrackingEntry.PunchType punchType;
+                try {
+                    punchType = TimeTrackingEntry.PunchType.valueOf(punchTypeStr.trim().toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    errors.add("Zeile " + rowNum + " (User: " + username + "): Ungültiger PunchType '" + punchTypeStr + "'. Erwartet: START oder ENDE.");
+                    continue;
+                }
+
+                TimeTrackingEntry.PunchSource source = TimeTrackingEntry.PunchSource.MANUAL_IMPORT;
+                if (sourceStr != null && !sourceStr.trim().isEmpty()) {
+                    try {
+                        source = TimeTrackingEntry.PunchSource.valueOf(sourceStr.trim().toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        errors.add("Zeile " + rowNum + " (User: " + username + "): Ungültige Source '" + sourceStr + "'. Wird auf MANUAL_IMPORT gesetzt.");
+                    }
+                }
+
+                TimeTrackingEntry newEntry = new TimeTrackingEntry(user, entryTimestamp, punchType, source);
+                if (note != null && !note.trim().isEmpty()) {
+                    newEntry.setSystemGeneratedNote(note);
+                }
+                newEntry.setCorrectedByUser(true);
+                timeTrackingEntryRepository.save(newEntry);
+                affectedUsers.add(user);
+                successes.add("Zeile " + rowNum + ": Eintrag für User '" + username + "' am " + entryTimestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + " (" + punchType + ") importiert.");
+                importedCount++;
+            } catch (Exception e) {
+                logger.error("Fehler beim Verarbeiten der Excel-Zeile {}: {}", rowNum, e.getMessage(), e);
+                errors.add("Zeile " + rowNum + ": Unerwarteter Fehler - " + e.getMessage());
+            } finally {
+                status.setProcessedRows(rowNum - 1);
+            }
+        }
+
+        for (User user : affectedUsers) {
+            rebuildUserBalance(user);
+        }
+
+        status.setMessage("Import beendet");
+    }
+
+    public String generateIcs(String username, LocalDate start, LocalDate end) {
+        List<DailyTimeSummaryDTO> summaries = getUserHistory(username).stream()
+                .filter(s -> !s.getDate().isBefore(start) && !s.getDate().isAfter(end))
+                .collect(Collectors.toList());
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+        StringBuilder sb = new StringBuilder();
+        sb.append("BEGIN:VCALENDAR\n");
+        sb.append("VERSION:2.0\n");
+        sb.append("PRODID:-//Chrono//EN\n");
+        for (DailyTimeSummaryDTO summary : summaries) {
+            if (summary.getEntries() == null) continue;
+            for (TimeTrackingEntryDTO entry : summary.getEntries()) {
+                String ts = entry.getEntryTimestamp().format(dtf);
+                sb.append("BEGIN:VEVENT\n");
+                sb.append("UID:" + UUID.randomUUID() + "\n");
+                sb.append("DTSTAMP:" + ts + "Z\n");
+                sb.append("SUMMARY:" + entry.getPunchType() + "\n");
+                sb.append("DESCRIPTION:" + entry.getPunchType() + "\n");
+                sb.append("DTSTART:" + ts + "Z\n");
+                sb.append("DTEND:" + ts + "Z\n");
+                sb.append("END:VEVENT\n");
+            }
+        }
+        sb.append("END:VCALENDAR\n");
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## Summary
- track Excel import progress with `ImportStatusDTO`
- expose async Excel import endpoints in admin controller
- add service for import progress
- allow ICS export via new calendar endpoint
- add simple Slack integration and chatbot controller
- provide overtime analytics endpoint
- show progress bar during Excel uploads

## Testing
- `./mvnw -q test` *(fails: failed to fetch dependencies)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e847785c8325b45124ea7113c4eb