### PR TITLE
Add async Excel import progress and calendar export

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/TaskExecutorConfig.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/TaskExecutorConfig.java
@@ -1,0 +1,19 @@
+package com.chrono.chrono.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class TaskExecutorConfig {
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("import-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/CalendarController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/CalendarController.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.services.ReportService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarController {
+
+    @Autowired
+    private ReportService reportService;
+
+    @GetMapping("/ics")
+    public ResponseEntity<String> getIcs(@RequestParam String username,
+                                         @RequestParam String startDate,
+                                         @RequestParam String endDate) {
+        String ics = reportService.generateIcs(username, LocalDate.parse(startDate), LocalDate.parse(endDate));
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("text/calendar"));
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=chrono.ics");
+        return ResponseEntity.ok().headers(headers).body(ics);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
@@ -54,4 +54,15 @@ public class ReportController {
 
         return new ResponseEntity<>(csv, headers, HttpStatus.OK);
     }
+
+    @GetMapping("/worktrend")
+    public ResponseEntity<?> getWorkTrend(
+            @RequestParam String username,
+            @RequestParam String startDate,
+            @RequestParam String endDate) {
+        return ResponseEntity.ok(
+                reportService.getWorkTrend(username,
+                        LocalDate.parse(startDate),
+                        LocalDate.parse(endDate)));
+    }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ImportStatus.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ImportStatus.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImportStatus {
+    private int totalRows;
+    private int processedRows;
+    private boolean completed;
+    private int importedCount;
+    private List<String> successMessages = new ArrayList<>();
+    private List<String> errorMessages = new ArrayList<>();
+
+    public int getTotalRows() {
+        return totalRows;
+    }
+    public void setTotalRows(int totalRows) {
+        this.totalRows = totalRows;
+    }
+    public int getProcessedRows() {
+        return processedRows;
+    }
+    public void setProcessedRows(int processedRows) {
+        this.processedRows = processedRows;
+    }
+    public boolean isCompleted() {
+        return completed;
+    }
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+    public int getImportedCount() { return importedCount; }
+    public void setImportedCount(int importedCount) { this.importedCount = importedCount; }
+    public List<String> getSuccessMessages() {
+        return successMessages;
+    }
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ImportProgressService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ImportProgressService.java
@@ -1,0 +1,53 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.ImportStatus;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.security.Principal;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class ImportProgressService {
+
+    private final Map<String, ImportStatus> statusMap = new ConcurrentHashMap<>();
+
+    @Autowired
+    private TimeTrackingService timeTrackingService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ThreadPoolTaskExecutor taskExecutor;
+
+    public String startImport(MultipartFile file, Principal principal) throws Exception {
+        String importId = UUID.randomUUID().toString();
+        ImportStatus status = new ImportStatus();
+        statusMap.put(importId, status);
+
+        User currentUser = userRepository.findByUsername(principal.getName())
+                .orElseThrow();
+        Long companyId = currentUser.getCompany() != null ? currentUser.getCompany().getId() : null;
+
+        taskExecutor.execute(() -> {
+            try (InputStream is = file.getInputStream()) {
+                timeTrackingService.importTimeTrackingFromExcelWithProgress(is, companyId, status);
+            } catch (Exception e) {
+                status.getErrorMessages().add("Fehler: " + e.getMessage());
+            } finally {
+                status.setCompleted(true);
+            }
+        });
+        return importId;
+    }
+
+    public ImportStatus getStatus(String importId) {
+        return statusMap.get(importId);
+    }
+}

--- a/Chrono-frontend/src/styles/ImportProgress.css
+++ b/Chrono-frontend/src/styles/ImportProgress.css
@@ -1,0 +1,3 @@
+.progress-container { margin-top: 10px; }
+.progress-bar { height: 10px; background: #eee; border-radius: 4px; }
+.progress-bar-inner { height: 100%; background: #007bff; border-radius: 4px; }


### PR DESCRIPTION
## Summary
- implement async Excel import progress using ImportProgressService and ImportStatus DTO
- expose progress endpoints and add task executor configuration
- add calendar ICS export and work trend API
- show upload progress bar in frontend import component

## Testing
- `mvnw test -DskipTests=true` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867e89852c08325913b8438587429c5