### PR TITLE
Add advanced import and calendar export

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
@@ -54,4 +54,22 @@ public class ReportController {
 
         return new ResponseEntity<>(csv, headers, HttpStatus.OK);
     }
+
+    @GetMapping("/timesheet/ics")
+    public ResponseEntity<byte[]> downloadIcs(
+            @RequestParam String username,
+            @RequestParam String startDate,
+            @RequestParam String endDate
+    ) {
+        byte[] ics = reportService.generateIcs(
+                username,
+                LocalDate.parse(startDate),
+                LocalDate.parse(endDate));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("text/calendar"));
+        headers.setContentDisposition(ContentDisposition.attachment().filename("timesheet.ics").build());
+
+        return new ResponseEntity<>(ics, headers, HttpStatus.OK);
+    }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/TimeTrackingImportRowDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/TimeTrackingImportRowDTO.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.dto;
+
+public class TimeTrackingImportRowDTO {
+    private String username;
+    private String timestamp;
+    private String punchType;
+    private String source;
+    private String note;
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getTimestamp() {
+        return timestamp;
+    }
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+    public String getPunchType() {
+        return punchType;
+    }
+    public void setPunchType(String punchType) {
+        this.punchType = punchType;
+    }
+    public String getSource() {
+        return source;
+    }
+    public void setSource(String source) {
+        this.source = source;
+    }
+    public String getNote() {
+        return note;
+    }
+    public void setNote(String note) {
+        this.note = note;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/TimeTrackingService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/TimeTrackingService.java
@@ -3,6 +3,7 @@ package com.chrono.chrono.services;
 import com.chrono.chrono.dto.DailyTimeSummaryDTO;
 import com.chrono.chrono.dto.TimeReportDTO;
 import com.chrono.chrono.dto.TimeTrackingEntryDTO;
+import com.chrono.chrono.dto.TimeTrackingImportRowDTO;
 import com.chrono.chrono.entities.TimeTrackingEntry;
 import com.chrono.chrono.entities.User;
 import com.chrono.chrono.entities.VacationRequest;
@@ -28,6 +29,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Objects;
 
 
 @Service
@@ -363,6 +365,10 @@ public class TimeTrackingService {
         logger.info("✅ Saldo-Neuberechnung für alle User abgeschlossen.");
     }
 
+    public List<TimeTrackingEntry> getEntriesForUser(User user, LocalDateTime start, LocalDateTime end) {
+        return timeTrackingEntryRepository.findByUserAndEntryTimestampBetweenOrderByEntryTimestampAsc(user, start, end);
+    }
+
     public int getWeeklyBalance(User user, LocalDate monday) {
         User freshUser = userRepository.findById(user.getId()).orElseThrow(() -> new UserNotFoundException("User not found: " + user.getUsername()));
         List<VacationRequest> approvedVacations = vacationRequestRepository.findByUserAndApprovedTrue(freshUser);
@@ -539,6 +545,7 @@ public class TimeTrackingService {
         Map<String, Object> result = new HashMap<>();
         List<String> errors = new ArrayList<>();
         List<String> successes = new ArrayList<>();
+        List<Map<String, String>> invalidRows = new ArrayList<>();
         int importedCount = 0;
         Set<User> affectedUsers = new HashSet<>();
 
@@ -555,6 +562,8 @@ public class TimeTrackingService {
                 Row row = rowIterator.next();
                 rowNum++;
 
+                Map<String, String> rowData = new LinkedHashMap<>();
+
                 try {
                     String username = getCellValueAsString(row.getCell(0));
                     String timestampStr = getCellValueAsString(row.getCell(1));
@@ -562,13 +571,26 @@ public class TimeTrackingService {
                     String sourceStr = getCellValueAsString(row.getCell(3));
                     String note = getCellValueAsString(row.getCell(4));
 
+                    rowData.put("rowNumber", String.valueOf(rowNum));
+                    rowData.put("username", username);
+                    rowData.put("timestamp", timestampStr);
+                    rowData.put("punchType", punchTypeStr);
+                    rowData.put("source", sourceStr);
+                    rowData.put("note", note);
+
                     if (username == null || username.trim().isEmpty()) {
-                        errors.add("Zeile " + rowNum + ": Username fehlt.");
+                        String msg = "Zeile " + rowNum + ": Username fehlt.";
+                        errors.add(msg);
+                        rowData.put("error", msg);
+                        invalidRows.add(rowData);
                         continue;
                     }
                     Optional<User> userOpt = userRepository.findByUsername(username);
                     if (userOpt.isEmpty()) {
-                        errors.add("Zeile " + rowNum + ": User '" + username + "' nicht gefunden.");
+                        String msg = "Zeile " + rowNum + ": User '" + username + "' nicht gefunden.";
+                        errors.add(msg);
+                        rowData.put("error", msg);
+                        invalidRows.add(rowData);
                         continue;
                     }
                     User user = userOpt.get();
@@ -580,7 +602,10 @@ public class TimeTrackingService {
                         boolean isSuperAdmin = importingAdmin != null && importingAdmin.getRoles().stream().anyMatch(r -> r.getRoleName().equals("ROLE_SUPERADMIN"));
 
                         if (!isSuperAdmin && (user.getCompany() == null || !user.getCompany().getId().equals(adminCompanyId))) {
-                            errors.add("Zeile " + rowNum + ": User '" + username + "' gehört nicht zur Firma des importierenden Admins oder Admin ist keiner Firma zugeordnet.");
+                            String msg = "Zeile " + rowNum + ": User '" + username + "' gehört nicht zur Firma des importierenden Admins oder Admin ist keiner Firma zugeordnet.";
+                            errors.add(msg);
+                            rowData.put("error", msg);
+                            invalidRows.add(rowData);
                             continue;
                         }
                     }
@@ -588,18 +613,26 @@ public class TimeTrackingService {
 
                     LocalDateTime entryTimestamp = parseTimestampSafe(timestampStr, rowNum, username, errors);
                     if (entryTimestamp == null) {
+                        rowData.putIfAbsent("error", errors.get(errors.size() - 1));
+                        invalidRows.add(rowData);
                         continue;
                     }
 
                     if (punchTypeStr == null || punchTypeStr.trim().isEmpty()) {
-                        errors.add("Zeile " + rowNum + " (User: " + username + "): PunchType fehlt.");
+                        String msg = "Zeile " + rowNum + " (User: " + username + "): PunchType fehlt.";
+                        errors.add(msg);
+                        rowData.put("error", msg);
+                        invalidRows.add(rowData);
                         continue;
                     }
                     TimeTrackingEntry.PunchType punchType;
                     try {
                         punchType = TimeTrackingEntry.PunchType.valueOf(punchTypeStr.trim().toUpperCase());
                     } catch (IllegalArgumentException e) {
-                        errors.add("Zeile " + rowNum + " (User: " + username + "): Ungültiger PunchType '" + punchTypeStr + "'. Erwartet: START oder ENDE.");
+                        String msg = "Zeile " + rowNum + " (User: " + username + "): Ungültiger PunchType '" + punchTypeStr + "'. Erwartet: START oder ENDE.";
+                        errors.add(msg);
+                        rowData.put("error", msg);
+                        invalidRows.add(rowData);
                         continue;
                     }
 
@@ -608,8 +641,11 @@ public class TimeTrackingService {
                         try {
                             source = TimeTrackingEntry.PunchSource.valueOf(sourceStr.trim().toUpperCase());
                         } catch (IllegalArgumentException e) {
-                            errors.add("Zeile " + rowNum + " (User: " + username + "): Ungültige Source '" + sourceStr + "'. Wird auf MANUAL_IMPORT gesetzt.");
-                        }
+                            String msg = "Zeile " + rowNum + " (User: " + username + "): Ungültige Source '" + sourceStr + "'. Wird auf MANUAL_IMPORT gesetzt.";
+                            errors.add(msg);
+                            rowData.put("error", msg);
+                            invalidRows.add(rowData);
+                            }
                     }
 
                     TimeTrackingEntry newEntry = new TimeTrackingEntry(user, entryTimestamp, punchType, source);
@@ -625,7 +661,10 @@ public class TimeTrackingService {
 
                 } catch (Exception e) {
                     logger.error("Fehler beim Verarbeiten der Excel-Zeile {}: {}", rowNum, e.getMessage(), e);
-                    errors.add("Zeile " + rowNum + ": Unerwarteter Fehler - " + e.getMessage());
+                    String msg = "Zeile " + rowNum + ": Unerwarteter Fehler - " + e.getMessage();
+                    errors.add(msg);
+                    rowData.put("error", msg);
+                    invalidRows.add(rowData);
                 }
             }
 
@@ -641,6 +680,141 @@ public class TimeTrackingService {
         result.put("importedCount", importedCount);
         result.put("successMessages", successes);
         result.put("errorMessages", errors);
+        result.put("invalidRows", invalidRows);
+        return result;
+    }
+
+    @Transactional
+    public Map<String, Object> importTimeTrackingFromRows(List<TimeTrackingImportRowDTO> rows, Long adminCompanyId) {
+        Map<String, Object> result = new HashMap<>();
+        List<String> errors = new ArrayList<>();
+        List<String> successes = new ArrayList<>();
+        List<Map<String, String>> invalidRows = new ArrayList<>();
+        int importedCount = 0;
+        Set<User> affectedUsers = new HashSet<>();
+
+        int rowNum = 1;
+        for (TimeTrackingImportRowDTO row : rows) {
+            Map<String, String> rowData = new LinkedHashMap<>();
+            String username = row.getUsername();
+            String timestampStr = row.getTimestamp();
+            String punchTypeStr = row.getPunchType();
+            String sourceStr = row.getSource();
+            String note = row.getNote();
+
+            rowData.put("rowNumber", String.valueOf(rowNum));
+            rowData.put("username", username);
+            rowData.put("timestamp", timestampStr);
+            rowData.put("punchType", punchTypeStr);
+            rowData.put("source", sourceStr);
+            rowData.put("note", note);
+
+            if (username == null || username.trim().isEmpty()) {
+                String msg = "Zeile " + rowNum + ": Username fehlt.";
+                errors.add(msg);
+                rowData.put("error", msg);
+                invalidRows.add(rowData);
+                rowNum++;
+                continue;
+            }
+
+            Optional<User> userOpt = userRepository.findByUsername(username);
+            if (userOpt.isEmpty()) {
+                String msg = "Zeile " + rowNum + ": User '" + username + "' nicht gefunden.";
+                errors.add(msg);
+                rowData.put("error", msg);
+                invalidRows.add(rowData);
+                rowNum++;
+                continue;
+            }
+            User user = userOpt.get();
+
+            if (adminCompanyId != null) {
+                User importingAdmin = userRepository.findAll().stream()
+                        .filter(u -> u.getCompany() != null && u.getCompany().getId().equals(adminCompanyId)
+                                && u.getRoles().stream().anyMatch(r -> r.getRoleName().equals("ROLE_ADMIN") || r.getRoleName().equals("ROLE_SUPERADMIN")))
+                        .findFirst().orElse(null);
+                boolean isSuperAdmin = importingAdmin != null && importingAdmin.getRoles().stream().anyMatch(r -> r.getRoleName().equals("ROLE_SUPERADMIN"));
+
+                if (!isSuperAdmin && (user.getCompany() == null || !user.getCompany().getId().equals(adminCompanyId))) {
+                    String msg = "Zeile " + rowNum + ": User '" + username + "' gehört nicht zur Firma des importierenden Admins oder Admin ist keiner Firma zugeordnet.";
+                    errors.add(msg);
+                    rowData.put("error", msg);
+                    invalidRows.add(rowData);
+                    rowNum++;
+                    continue;
+                }
+            }
+
+            LocalDateTime entryTimestamp = parseTimestampSafe(timestampStr, rowNum, username, errors);
+            if (entryTimestamp == null) {
+                rowData.putIfAbsent("error", errors.get(errors.size() - 1));
+                invalidRows.add(rowData);
+                rowNum++;
+                continue;
+            }
+
+            if (punchTypeStr == null || punchTypeStr.trim().isEmpty()) {
+                String msg = "Zeile " + rowNum + " (User: " + username + "): PunchType fehlt.";
+                errors.add(msg);
+                rowData.put("error", msg);
+                invalidRows.add(rowData);
+                rowNum++;
+                continue;
+            }
+
+            TimeTrackingEntry.PunchType punchType;
+            try {
+                punchType = TimeTrackingEntry.PunchType.valueOf(punchTypeStr.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                String msg = "Zeile " + rowNum + " (User: " + username + "): Ungültiger PunchType '" + punchTypeStr + "'. Erwartet: START oder ENDE.";
+                errors.add(msg);
+                rowData.put("error", msg);
+                invalidRows.add(rowData);
+                rowNum++;
+                continue;
+            }
+
+            TimeTrackingEntry.PunchSource source = TimeTrackingEntry.PunchSource.MANUAL_IMPORT;
+            if (sourceStr != null && !sourceStr.trim().isEmpty()) {
+                try {
+                    source = TimeTrackingEntry.PunchSource.valueOf(sourceStr.trim().toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    String msg = "Zeile " + rowNum + " (User: " + username + "): Ungültige Source '" + sourceStr + "'. Wird auf MANUAL_IMPORT gesetzt.";
+                    errors.add(msg);
+                    rowData.put("error", msg);
+                    invalidRows.add(rowData);
+                }
+            }
+
+            try {
+                TimeTrackingEntry newEntry = new TimeTrackingEntry(user, entryTimestamp, punchType, source);
+                if (note != null && !note.trim().isEmpty()) {
+                    newEntry.setSystemGeneratedNote(note);
+                }
+                newEntry.setCorrectedByUser(true);
+                timeTrackingEntryRepository.save(newEntry);
+                affectedUsers.add(user);
+                successes.add("Zeile " + rowNum + ": Eintrag für User '" + username + "' am " + entryTimestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + " (" + punchType + ") importiert.");
+                importedCount++;
+            } catch (Exception e) {
+                String msg = "Zeile " + rowNum + ": Unerwarteter Fehler - " + e.getMessage();
+                errors.add(msg);
+                rowData.put("error", msg);
+                invalidRows.add(rowData);
+            }
+
+            rowNum++;
+        }
+
+        for (User user : affectedUsers) {
+            rebuildUserBalance(user);
+        }
+
+        result.put("importedCount", importedCount);
+        result.put("successMessages", successes);
+        result.put("errorMessages", errors);
+        result.put("invalidRows", invalidRows);
         return result;
     }
 }

--- a/Chrono-frontend/src/TimeTrackingImport.jsx
+++ b/Chrono-frontend/src/TimeTrackingImport.jsx
@@ -11,19 +11,26 @@ import api from './utils/api'; // Geändert: Importiere die globale api-Instanz
 // entweder die VITE_API_BASE_URL ist (z.B. http://localhost:8080)
 // oder "/api". In beiden Fällen ist der folgende Pfad korrekt, um
 // auf /api/admin/timetracking/import zu zielen.
+import './styles/TimeTrackingImport.css';
 const API_ENDPOINT_PATH = '/api/admin/timetracking/import';
 
 function TimeTrackingImport() {
     const [selectedFile, setSelectedFile] = useState(null);
     const [isUploading, setIsUploading] = useState(false);
+    const [progress, setProgress] = useState(0);
     const [uploadResponse, setUploadResponse] = useState(null);
     const [error, setError] = useState('');
+    const [invalidRows, setInvalidRows] = useState([]);
+    const [isReimporting, setIsReimporting] = useState(false);
+    const [reimportProgress, setReimportProgress] = useState(0);
     // const fileInputRef = useRef(null); // EINKOMMENTIEREN, falls benötigt
 
     const handleFileChange = (event) => {
         setSelectedFile(event.target.files[0]);
         setUploadResponse(null); // Reset previous response
         setError('');
+        setProgress(0);
+        setInvalidRows([]);
     };
 
     const handleSubmit = async (event) => {
@@ -36,6 +43,7 @@ function TimeTrackingImport() {
         setIsUploading(true);
         setError('');
         setUploadResponse(null);
+        setProgress(0);
 
         const formData = new FormData();
         formData.append('file', selectedFile);
@@ -48,8 +56,12 @@ function TimeTrackingImport() {
             const response = await api.post(API_ENDPOINT_PATH, formData, {
                 headers: {
                     'Content-Type': 'multipart/form-data',
-                    // 'Authorization'-Header wird von der api-Instanz gehandhabt
                 },
+                onUploadProgress: (e) => {
+                    if (e.total) {
+                        setProgress(Math.round((e.loaded * 100) / e.total));
+                    }
+                }
             });
 
             setUploadResponse(response.data);
@@ -71,6 +83,7 @@ function TimeTrackingImport() {
                 } else {
                     setUploadResponse({ errors: [backendError], importedCount: 0, successMessages: []});
                 }
+                setInvalidRows(err.response.data?.invalidRows || []);
             } else if (err.request) {
                 setError('Keine Antwort vom Server erhalten. Bitte Netzwerk überprüfen.');
             } else {
@@ -78,6 +91,36 @@ function TimeTrackingImport() {
             }
         } finally {
             setIsUploading(false);
+            setProgress(0);
+        }
+    };
+
+    const handleRowChange = (index, field, value) => {
+        const rows = [...invalidRows];
+        rows[index][field] = value;
+        setInvalidRows(rows);
+    };
+
+    const handleReimport = async () => {
+        if (invalidRows.length === 0) return;
+        setIsReimporting(true);
+        setReimportProgress(0);
+        try {
+            const res = await api.post('/api/admin/timetracking/import/json', invalidRows, {
+                onUploadProgress: (e) => {
+                    if (e.total) {
+                        setReimportProgress(Math.round((e.loaded * 100) / e.total));
+                    }
+                }
+            });
+            setUploadResponse(res.data);
+            setInvalidRows(res.data.invalidRows || []);
+        } catch (err) {
+            console.error('Reimport error', err);
+            setError(err.response?.data?.error || 'Fehler beim Reimport');
+        } finally {
+            setIsReimporting(false);
+            setReimportProgress(0);
         }
     };
 
@@ -113,6 +156,41 @@ function TimeTrackingImport() {
                         </ul>
                     </div>
                 )}
+                {invalidRows.length > 0 && (
+                    <div style={{ marginTop: '10px' }}>
+                        <h5>Korrigierbare Zeilen:</h5>
+                        <table className="invalid-table">
+                            <thead>
+                                <tr>
+                                    <th>Nr</th>
+                                    <th>User</th>
+                                    <th>Timestamp</th>
+                                    <th>Type</th>
+                                    <th>Source</th>
+                                    <th>Note</th>
+                                    <th>Fehler</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {invalidRows.map((row, idx) => (
+                                    <tr key={idx}>
+                                        <td>{row.rowNumber}</td>
+                                        <td><input value={row.username || ''} onChange={e => handleRowChange(idx, 'username', e.target.value)} /></td>
+                                        <td><input value={row.timestamp || ''} onChange={e => handleRowChange(idx, 'timestamp', e.target.value)} /></td>
+                                        <td><input value={row.punchType || ''} onChange={e => handleRowChange(idx, 'punchType', e.target.value)} /></td>
+                                        <td><input value={row.source || ''} onChange={e => handleRowChange(idx, 'source', e.target.value)} /></td>
+                                        <td><input value={row.note || ''} onChange={e => handleRowChange(idx, 'note', e.target.value)} /></td>
+                                        <td style={{color:'red'}}>{row.error}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                        <button onClick={handleReimport} disabled={isReimporting} style={{marginTop:'10px'}}>
+                            {isReimporting ? 'Importiere...' : 'Korrigierte Zeilen importieren'}
+                        </button>
+                        {isReimporting && <div className="import-progress"><div className="import-progress-bar" style={{width: `${reimportProgress}%`}}/></div>}
+                    </div>
+                )}
             </div>
         );
     };
@@ -145,6 +223,7 @@ function TimeTrackingImport() {
                 >
                     {isUploading ? 'Wird hochgeladen...' : 'Importieren'}
                 </button>
+                {isUploading && <div className="import-progress" style={{marginTop:'8px'}}><div className="import-progress-bar" style={{width:`${progress}%`}} /></div>}
             </form>
             {error && <p style={{ color: 'red', marginTop: '10px' }}>{error}</p>}
             {renderFeedback()}

--- a/Chrono-frontend/src/components/TrendChart.jsx
+++ b/Chrono-frontend/src/components/TrendChart.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import '../styles/TrendChart.css';
+
+function TrendChart({ data }) {
+  const max = Math.max(...data.map(d => d.workedMinutes), 1);
+  return (
+    <div className="trend-chart">
+      {data.map(d => (
+        <div key={d.date} className="trend-bar-wrapper">
+          <div className="trend-bar" style={{height: `${(d.workedMinutes / max) * 100}%`}} />
+          <span className="trend-label">{new Date(d.date).toLocaleDateString()}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+TrendChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      workedMinutes: PropTypes.number.isRequired
+    })
+  ).isRequired
+};
+
+export default TrendChart;

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -13,6 +13,7 @@ import {
 } from './hourDashUtils';
 import '../../styles/HourlyDashboardScoped.css';
 import api from "../../utils/api.js";
+import TrendChart from '../../components/TrendChart';
 
 const HourlyWeekOverview = ({
                                 t,
@@ -36,6 +37,12 @@ const HourlyWeekOverview = ({
     const weekDates = selectedMonday
         ? Array.from({ length: 7 }, (_, i) => addDays(selectedMonday, i))
         : [];
+
+    const chartData = weekDates.map(d => {
+        const iso = formatLocalDate(d);
+        const summary = dailySummaries.find(s => s.date === iso);
+        return { date: iso, workedMinutes: summary ? summary.workedMinutes : 0 };
+    });
 
     function handlePrevWeek() {
         setSelectedMonday(prev => addDays(prev, -7));
@@ -99,6 +106,7 @@ const HourlyWeekOverview = ({
                 <p><strong>{t("weeklyHours", "Ges. Std. (Woche)")}:</strong> {minutesToHHMM(weeklyTotalMins)}</p>
                 <p><strong>{t("monthlyHours", "Ges. Std. (Monat)")}:</strong> {minutesToHHMM(monthlyTotalMins)}</p>
             </div>
+            <TrendChart data={chartData} />
 
             {/* Deine bestehende Wochenanzeige bleibt unverändert */}
             <div className="week-display">

--- a/Chrono-frontend/src/styles/TimeTrackingImport.css
+++ b/Chrono-frontend/src/styles/TimeTrackingImport.css
@@ -1,0 +1,25 @@
+.import-progress {
+  width: 100%;
+  height: 8px;
+  background: #eee;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.import-progress-bar {
+  height: 100%;
+  background: #007bff;
+  width: 0;
+  transition: width 0.3s;
+}
+.invalid-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.invalid-table th, .invalid-table td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  font-size: 0.8rem;
+}
+.invalid-table input {
+  width: 100%;
+}

--- a/Chrono-frontend/src/styles/TrendChart.css
+++ b/Chrono-frontend/src/styles/TrendChart.css
@@ -1,0 +1,19 @@
+.trend-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 150px;
+  margin: 20px 0;
+}
+.trend-bar-wrapper {
+  flex: 1;
+  text-align: center;
+}
+.trend-bar {
+  width: 100%;
+  background: #4caf50;
+  border-radius: 4px 4px 0 0;
+}
+.trend-label {
+  font-size: 0.7rem;
+}


### PR DESCRIPTION
## Summary
- improve AdminTimeTrackingController to support JSON import
- extend TimeTrackingService to return invalid rows and allow JSON data
- add ICS export via ReportService and controller endpoint
- provide progress and correction UI for Excel import
- visualize weekly hours with new TrendChart component
- fix affected user balance rebuild in JSON import

## Testing
- `npm test` *(fails: vitest not installed)*
- `./mvnw -q -DskipTests package` *(fails: unable to download Maven due to network)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6867ee011d58832594b37cf14910ed36