### PR TITLE
Improve theme init and modal overlay

### DIFF
--- a/Chrono-frontend/index.html
+++ b/Chrono-frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -13,6 +13,16 @@
   <script src="https://cdn.tailwindcss.com"></script>
 
   <!-- (weitere Meta-Tags, CSS etc.) -->
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+      const brightness = localStorage.getItem('appBrightness');
+      if (brightness) {
+        document.documentElement.style.setProperty('--app-brightness', brightness);
+      }
+    })();
+  </script>
 </head>
 <body>
 <div id="root"></div>

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -155,10 +155,7 @@ a:hover {
 .sick-leave-modal-overlay,
 .changelog-backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0; /* stellt top, right, bottom, left sicher */
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- initialize theme and brightness before React loads
- tweak global modal overlay CSS for consistent positioning

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fdbf9e748325a8fa35e358f90e39