### PR TITLE
Refactor styles into centralized tokens

### DIFF
--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 
 /* ---------- globale Styles -------------------------------------------- */
 import "./styles/global.css";
+import "./styles/Button.css";
 import "./styles/Login.css";
 import "./styles/Navbar.css";
 import "./styles/PercentageDashboardScoped.css";

--- a/Chrono-frontend/src/pages/CompanyManagementPage.jsx
+++ b/Chrono-frontend/src/pages/CompanyManagementPage.jsx
@@ -257,7 +257,7 @@ const CompanyManagementPage = () => {
                                 value={newCompanyCanton}
                                 onChange={(e) => setNewCompanyCanton(e.target.value)}
                                 maxLength="2"
-                                style={{ textTransform: 'uppercase' }}
+                                className="text-uppercase"
                             />
                             <button type="submit">Erstellen</button>
                         </form>
@@ -284,7 +284,7 @@ const CompanyManagementPage = () => {
                                     setCreateWithAdmin({ ...createWithAdmin, companyCanton: e.target.value })
                                 }
                                 maxLength="2"
-                                style={{ textTransform: 'uppercase' }}
+                                className="text-uppercase"
                             />
                             <input
                                 type="text"
@@ -356,7 +356,8 @@ const CompanyManagementPage = () => {
                                                     setEditingCompany({ ...editingCompany, cantonAbbreviation: e.target.value })
                                                 }
                                                 maxLength="2"
-                                                style={{ textTransform: 'uppercase', width: '80px' }}
+                                                className="text-uppercase"
+                                                style={{ width: '80px' }}
                                             />
                                             <label style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                                                 <input

--- a/Chrono-frontend/src/styles/Button.css
+++ b/Chrono-frontend/src/styles/Button.css
@@ -1,0 +1,54 @@
+.button-primary {
+  border: none;
+  border-radius: var(--u-radius);
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color var(--u-dur),
+    transform var(--u-dur),
+    box-shadow var(--u-dur);
+  font-size: 1rem;
+  padding: 0.5rem 1.25rem;
+  background: var(--c-pri);
+  color: #fff;
+  text-align: center;
+  box-shadow: var(--u-shadow-sm);
+  line-height: 1.5;
+}
+
+.button-primary:hover {
+  background: var(--c-pri-dim);
+  transform: translateY(-2px);
+  box-shadow: var(--u-shadow-lg);
+}
+
+.button-secondary {
+  border-radius: var(--u-radius);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-text);
+  padding: 0.5rem 1.25rem;
+  font-weight: 500;
+  transition: background-color var(--u-dur),
+    border-color var(--u-dur),
+    transform var(--u-dur);
+}
+
+.button-secondary:hover {
+  background: var(--c-border);
+  border-color: var(--c-muted);
+  transform: translateY(-1px);
+}
+
+.button-danger {
+  border: none;
+  border-radius: var(--u-radius);
+  background: var(--c-danger);
+  color: #fff;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  transition: background-color var(--u-dur), transform var(--u-dur);
+}
+
+.button-danger:hover {
+  background: color-mix(in srgb, var(--c-danger) 85%, black);
+}

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -228,65 +228,7 @@
 /* =========================================================================
    Globale Button Styles - Übernahme von UserDashboard
    ========================================================================= */
-.hourly-dashboard.scoped-dashboard button,
-.hourly-dashboard.scoped-dashboard .button-primary {
-  border: none;
-  border-radius: var(--ud-radius-md);
-  cursor: pointer;
-  font-weight: 600;
-  transition:
-    background-color 0.2s,
-    transform 0.15s,
-    box-shadow 0.2s;
-  font-size: var(--ud-fz-md);
-  padding: var(--ud-gap-sm) var(--ud-gap-lg);
-  background: var(--ud-c-primary);
-  color: #fff;
-  text-align: center;
-  box-shadow: var(--ud-shadow-interactive);
-  line-height: 1.5;
-}
-.hourly-dashboard.scoped-dashboard button:hover,
-.hourly-dashboard.scoped-dashboard .button-primary:hover {
-  background: var(--ud-c-primary-dim);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(var(--ud-c-primary-rgb), 0.2);
-}
-.hourly-dashboard.scoped-dashboard button:active,
-.hourly-dashboard.scoped-dashboard .button-primary:active {
-  transform: translateY(-1px);
-  box-shadow: var(--ud-shadow-interactive);
-}
-.hourly-dashboard.scoped-dashboard button:focus-visible,
-.hourly-dashboard.scoped-dashboard .button-primary:focus-visible {
-  outline: 3px solid var(--ud-c-primary-light-bg);
-  outline-offset: 2px;
-}
 
-.hourly-dashboard.scoped-dashboard button.button-secondary {
-  background: var(--ud-c-surface);
-  color: var(--ud-c-primary-text);
-  border: 1px solid var(--ud-c-primary);
-  box-shadow: none;
-}
-.hourly-dashboard.scoped-dashboard button.button-secondary:hover {
-  background: var(--ud-c-primary-light-bg);
-  border-color: var(--ud-c-primary-dim);
-  color: var(--ud-c-primary-dim);
-  transform: translateY(-1px);
-}
-[data-theme="dark"] .hourly-dashboard.scoped-dashboard button.button-secondary {
-  background: var(--ud-c-surface);
-  color: var(--ud-c-primary);
-  border-color: var(--ud-c-primary);
-}
-[data-theme="dark"]
-  .hourly-dashboard.scoped-dashboard
-  button.button-secondary:hover {
-  background: var(--ud-c-primary-light-bg);
-  color: var(--ud-c-primary-dim);
-  border-color: var(--ud-c-primary-dim);
-}
 
 /* =========================================================================
    Punch-Message (Popup) - Übernahme von UserDashboard

--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -217,68 +217,7 @@
   border-color: rgba(255, 255, 255, 0.1);
 }
 
-/* =========================================================================
-   2) Global Button Styles
-   ========================================================================= */
-.user-dashboard.scoped-dashboard button,
-.user-dashboard.scoped-dashboard .button-primary {
-  border: none;
-  border-radius: var(--ud-radius-md);
-  cursor: pointer;
-  font-weight: 600;
-  transition:
-    background-color var(--u-dur),
-    transform var(--u-dur),
-    box-shadow var(--u-dur);
-  font-size: var(--ud-fz-md);
-  padding: var(--ud-gap-sm) var(--ud-gap-lg);
-  background: var(--ud-c-primary);
-  color: #fff;
-  text-align: center;
-  box-shadow: var(--ud-shadow-interactive);
-  line-height: 1.5;
-}
-.user-dashboard.scoped-dashboard button:hover,
-.user-dashboard.scoped-dashboard .button-primary:hover {
-  background: var(--ud-c-primary-dim);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(var(--ud-c-primary-rgb), 0.2);
-}
-.user-dashboard.scoped-dashboard button:active,
-.user-dashboard.scoped-dashboard .button-primary:active {
-  transform: translateY(-1px);
-  box-shadow: var(--ud-shadow-interactive);
-}
-.user-dashboard.scoped-dashboard button:focus-visible,
-.user-dashboard.scoped-dashboard .button-primary:focus-visible {
-  outline: 3px solid var(--ud-c-primary-light-bg);
-  outline-offset: 2px;
-}
 
-.user-dashboard.scoped-dashboard button.button-secondary {
-  background: var(--ud-c-surface);
-  color: var(--ud-c-primary-text);
-  border: 1px solid var(--ud-c-primary);
-  box-shadow: none;
-}
-.user-dashboard.scoped-dashboard button.button-secondary:hover {
-  background: var(--ud-c-primary-light-bg);
-  border-color: var(--ud-c-primary-dim);
-  color: var(--ud-c-primary-dim);
-  transform: translateY(-1px);
-}
-[data-theme="dark"] .user-dashboard.scoped-dashboard button.button-secondary {
-  background: var(--ud-c-surface);
-  color: var(--ud-c-primary);
-  border-color: var(--ud-c-primary);
-}
-[data-theme="dark"]
-  .user-dashboard.scoped-dashboard
-  button.button-secondary:hover {
-  background: var(--ud-c-primary-light-bg);
-  color: var(--ud-c-primary-dim);
-  border-color: var(--ud-c-primary-dim);
-}
 
 /* =========================================================================
    3) Punch-Message (Popup)

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -44,35 +44,8 @@ a:focus-visible {
   outline-offset: 2px;
 }
 
-/* ---------- 1)  Grundtokens (Light-Default) --------------------------- */
-:root {
-  /* Primärfarben + optionales RGB für semitransparente Hintergründe */
-  --c-pri: #475bff;
-  --c-pri-dim: #6b7cff;
-  --c-pri-rgb: 71, 91, 255;
-
-  --c-danger: #ed5757;
-
-  /* Grundfarben (Light) */
-  --c-text: #1f1f1f;
-  --c-muted: #60646c;
-  --c-bg: #ffffff;
-  --c-surface: #f4f6ff;
-  --c-card: #ffffff;
-  --c-border: #d0d3e2;
-
-  /* Radius + Schatten */
-  --u-radius: 12px;
-  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.05);
-  --u-shadow-lg: 0 20px 34px rgba(0, 0, 0, 0.12);
-
-  /* Motion */
-  --u-dur: 0.25s;
-  --u-ease: cubic-bezier(0.4, 0.2, 0.2, 1);
-
-  /* Globale Brightness-Skala (z. B. via Navbar-Slider) */
-  --app-brightness: 1;
-}
+/* ---------- 1)  Design Tokens --------------------------------------- */
+@import "./tokens/design-tokens.css";
 
 /* ---------- 2)  Basis-Typografie -------------------------------------- */
 html {
@@ -101,33 +74,7 @@ a:hover {
 }
 
 /* ---------- 3)  Dark-Mode-Overrides ----------------------------------- */
-[data-theme="dark"] {
-  --c-text: #e4e6eb;
-  --c-muted: #9ea3b0;
-  --c-bg: #18191a;
-  --c-surface: #202328;
-  --c-card: #1e1f23;
-  --c-border: #3d4048;
-
-  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
-  --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
-}
-
-/* Fallback für Nutzer mit prefers-color-scheme: dark,
-   wenn noch kein data-theme="light" oder data-theme="dark" gesetzt ist: */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --c-text: #e4e6eb;
-    --c-muted: #9ea3b0;
-    --c-bg: #18191a;
-    --c-surface: #202328;
-    --c-card: #1e1f23;
-    --c-border: #3d4048;
-
-    --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
-    --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
-  }
-}
+/* tokens for dark mode are defined in design-tokens.css */
 
 /* ---------- 4)  Accessibility / Helpers ------------------------------- */
 /* Screenreader-only content */
@@ -189,6 +136,11 @@ html[data-theme="dark"] {
   --shadow-color: rgba(0, 0, 0, 0.5);
   --text-color-secondary: #aaa;
   --subtle-bg-color: #2c2c34; /* Ein dunkles Grau, das sich vom Hintergrund abhebt */
+}
+
+/* Utility classes */
+.text-uppercase {
+  text-transform: uppercase;
 }
 /* ---------- 5)  Reduced-Motion ---------------------------------------- */
 @media (prefers-reduced-motion: reduce) {

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -1,0 +1,56 @@
+/* Central design tokens for colors, typography and spacing */
+:root {
+  /* Primary colors */
+  --c-pri: #475bff;
+  --c-pri-dim: #6b7cff;
+  --c-pri-rgb: 71, 91, 255;
+  --c-danger: #ed5757;
+
+  /* Base colors (light) */
+  --c-text: #1f1f1f;
+  --c-muted: #60646c;
+  --c-bg: #ffffff;
+  --c-bg-rgb: 255, 255, 255;
+  --c-surface: #f4f6ff;
+  --c-card: #ffffff;
+  --c-border: #d0d3e2;
+
+  /* Radius & shadow */
+  --u-radius: 12px;
+  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.05);
+  --u-shadow-lg: 0 20px 34px rgba(0, 0, 0, 0.12);
+
+  /* Motion */
+  --u-dur: 0.25s;
+  --u-ease: cubic-bezier(0.4, 0.2, 0.2, 1);
+
+  --app-brightness: 1;
+}
+
+[data-theme="dark"] {
+  --c-text: #e4e6eb;
+  --c-muted: #9ea3b0;
+  --c-bg: #18191a;
+  --c-bg-rgb: 24, 25, 26;
+  --c-surface: #202328;
+  --c-card: #1e1f23;
+  --c-border: #3d4048;
+
+  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
+  --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --c-text: #e4e6eb;
+    --c-muted: #9ea3b0;
+    --c-bg: #18191a;
+    --c-bg-rgb: 24, 25, 26;
+    --c-surface: #202328;
+    --c-card: #1e1f23;
+    --c-border: #3d4048;
+
+    --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
+    --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+  }
+}


### PR DESCRIPTION
## Summary
- add `design-tokens.css` and import in global styles
- move shared button styles to new `Button.css`
- remove inline text-transform styling in CompanyManagementPage
- streamline dashboard scoped styles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c39b4f808325912fbaaaaf3838a7