### PR TITLE
Improve modal overlay styles

### DIFF
--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -1073,18 +1073,13 @@
 .modal-overlay {
   position: fixed;
   inset: 0; /* zentriert unabhängig von der Scrollposition */
-  background: rgba(
-    0,
-    0,
-    0,
-    0.75
-  ); /* Etwas dunkleres Overlay für besseren Fokus */
   z-index: 10000;
   display: flex;
   align-items: center;
   justify-content: center;
   backdrop-filter: blur(4px); /* Etwas stärkerer Blur */
   padding: var(--u-gap-sm);
+  background-color: var(--modal-backdrop-color);
 }
 .modal-content {
   background: var(--c-card);

--- a/Chrono-frontend/src/styles/AdminUserManagementPageScoped.css
+++ b/Chrono-frontend/src/styles/AdminUserManagementPageScoped.css
@@ -757,20 +757,12 @@
 .modal-overlay {
   position: fixed; /* Wichtig: positioniert relativ zum Viewport */
   inset: 0; /* sorgt für zentrierte Platzierung im sichtbaren Bereich */
-  background: rgba(
-    0,
-    0,
-    0,
-    0.65
-  ); /* Oder eine CSS-Variable wie var(--c-overlay-bg) */
   z-index: 10000; /* Oder eine passende z-index Variable */
   display: flex;
   align-items: center; /* Vertikale Zentrierung */
   justify-content: center; /* Horizontale Zentrierung */
+  background-color: var(--modal-backdrop-color);
   /* Optional: backdrop-filter für Glassmorphism-Effekt */
-}
-[data-theme="dark"] .modal-overlay {
-  background: rgba(15, 17, 22, 0.85);
 }
 
 .modal-content {

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -693,7 +693,6 @@
 .hourly-dashboard.scoped-dashboard .modal-overlay {
   position: fixed;
   inset: 0; /* Fixierte Platzierung im gesamten Viewport */
-  background: rgba(var(--ud-c-bg-rgb, 14, 16, 28), 0.75);
   backdrop-filter: blur(10px) saturate(150%);
   -webkit-backdrop-filter: blur(10px) saturate(150%);
   display: flex;
@@ -702,6 +701,7 @@
   z-index: 10000;
   padding: var(--ud-gap-md);
   animation: modalFadeIn 0.3s ease-out;
+  background-color: var(--modal-backdrop-color);
 }
 .hourly-dashboard.scoped-dashboard .modal-content {
   position: relative;

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -539,10 +539,6 @@
 .percentage-dashboard.scoped-dashboard .modal-overlay {
   position: fixed;
   inset: 0; /* Vollständige Überdeckung des Viewports */
-  background: rgba(
-    var(--ud-c-bg-rgb, 20, 20, 25),
-    0.65
-  ); /* Verwendet --ud-c-bg-rgb falls definiert, sonst Fallback */
   backdrop-filter: blur(8px);
   display: flex;
   align-items: center;
@@ -550,12 +546,7 @@
   z-index: 10000;
   padding: var(--ud-gap-lg, 2rem);
   animation: modalFadeIn var(--u-dur, 0.25s) var(--u-ease, ease);
-}
-[data-theme="dark"] .percentage-dashboard.scoped-dashboard .modal-overlay {
-  background: rgba(
-    var(--ud-c-bg-rgb, 17, 24, 39),
-    0.75
-  ); /* Angepasstes RGB für Dark Mode BG */
+  background-color: var(--modal-backdrop-color);
 }
 
 .percentage-dashboard.scoped-dashboard .modal-content {

--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -741,7 +741,6 @@
 .user-dashboard.scoped-dashboard .modal-backdrop {
   position: fixed;
   inset: 0; /* Overlay über den gesamten Viewport */
-  background: rgba(var(--c-bg-rgb, 20, 20, 25), 0.65);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   display: flex;
@@ -750,9 +749,7 @@
   z-index: 10000;
   padding: var(--ud-gap-lg, 2rem);
   animation: modalFadeIn 0.4s var(--u-ease, ease);
-}
-[data-theme="dark"] .user-dashboard.scoped-dashboard .modal-backdrop {
-  background: rgba(var(--ud-c-bg-rgb, 17, 24, 39), 0.75);
+  background-color: var(--modal-backdrop-color);
 }
 @keyframes modalFadeIn {
   from {

--- a/Chrono-frontend/src/styles/VacationCalendar.css
+++ b/Chrono-frontend/src/styles/VacationCalendar.css
@@ -258,10 +258,6 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(
-    var(--ud-c-bg-rgb, 14, 16, 28),
-    0.75
-  ); /* Konsistenter Overlay-Effekt */
   backdrop-filter: blur(10px) saturate(150%);
   -webkit-backdrop-filter: blur(10px) saturate(150%);
   display: flex;
@@ -270,6 +266,7 @@
   z-index: 10000;
   padding: var(--ud-gap-md, 1rem);
   animation: modalFadeIn 0.3s ease-out;
+  background-color: var(--modal-backdrop-color);
 }
 .scoped-vacation .vacation-modal-content,
 .scoped-vacation .sick-leave-modal-content {

--- a/Chrono-frontend/src/styles/VacationCalendarAdminScoped.css
+++ b/Chrono-frontend/src/styles/VacationCalendarAdminScoped.css
@@ -229,12 +229,12 @@
 .vacation-calendar-admin.scoped-vacation .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65); /* Etwas dunkler für besseren Fokus */
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 4000;
   padding: 1rem; /* Abstand für kleine Bildschirme */
+  background-color: var(--modal-backdrop-color);
 }
 
 .vacation-calendar-admin.scoped-vacation .modal-content {

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -25,6 +25,8 @@
   --u-ease: cubic-bezier(0.4, 0.2, 0.2, 1);
 
   --app-brightness: 1;
+  /* Default backdrop color for modal overlays (light mode) */
+  --modal-backdrop-color: rgba(30, 30, 30, 0.6);
 }
 
 [data-theme="dark"] {
@@ -38,10 +40,13 @@
 
   --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
   --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+
+  /* Dark mode backdrop color for modal overlays */
+  --modal-backdrop-color: rgba(0, 0, 0, 0.8);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
     --c-text: #e4e6eb;
     --c-muted: #9ea3b0;
     --c-bg: #18191a;
@@ -50,7 +55,8 @@
     --c-card: #1e1f23;
     --c-border: #3d4048;
 
-    --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
-    --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+      --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
+      --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+      --modal-backdrop-color: rgba(0, 0, 0, 0.8);
+    }
   }
-}


### PR DESCRIPTION
## Summary
- define `--modal-backdrop-color` design token
- use the new variable across all page specific modal overlays

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `./mvnw -q test` *(fails: could not fetch Maven deps)*

------
https://chatgpt.com/codex/tasks/task_e_6869c983e4208325ada41b2d3c3b13ad