### PR TITLE
Fix modal overlay visibility

### DIFF
--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -110,7 +110,9 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000; /* Popup immer über dem Seiteninhalt */
+  /* z-index auf 10000 angehoben, damit Modals stets 
+     oberhalb aller Inhalte (z.B. Navbar mit z-index 1000) liegen */
+  z-index: 10000;
   background-color: var(--modal-backdrop-color, rgba(0, 0, 0, 0.6));
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);


### PR DESCRIPTION
## Summary
- adjust `z-index` for modal overlays so they render above navbar and other elements

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af1aaa9a08325b04186669117b3ef