### PR TITLE
Fix CSS variable syntax

### DIFF
--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -1499,9 +1499,7 @@
   .admin-dashboard.scoped-dashboard
   .correction-list
   li.status-is-pending {
-  color: var(
-    --c-text
-  ); /* Haupttextfarbe für bessere Lesbarkeit auf dunkleren Status-BGs */
+  color: var(--c-text); /* Haupttextfarbe für bessere Lesbarkeit auf dunkleren Status-BGs */
 }
 /* Optionale Ränder für Status-Items im Dark Mode, falls gewünscht (aktuell nicht aktiv) */
 /*
@@ -1724,13 +1722,9 @@
   .modal-content
   .time-entry-edit-row
   .note-input {
-  background-color: var(
-    --c-surface
-  ); /* Sollte ein dunklerer Ton sein, z.B. #252830 */
+  background-color: var(--c-surface); /* Sollte ein dunklerer Ton sein, z.B. #252830 */
   color: var(--c-text); /* Sollte eine helle Textfarbe sein, z.B. #e5e7ec */
-  border-color: var(
-    --c-border
-  ); /* Sollte ein passender Rand für Darkmode sein, z.B. #373b46 */
+  border-color: var(--c-border); /* Sollte ein passender Rand für Darkmode sein, z.B. #373b46 */
 }
 
 /* Spezifischer Style für das datetime-local Icon im Dark Mode, falls es Probleme gibt (WebKit-Browser) */
@@ -1829,10 +1823,7 @@
 
 .corrections-table thead th {
   background-color: var(--ad-c-bg-header, #f9fafb);
-  color: var(
-    --ad-c-text-header,
-    #4b5563
-  ); /* Etwas dunklerer Text für besseren Kontrast */
+  color: var(--ad-c-text-header, #4b5563); /* Etwas dunklerer Text für besseren Kontrast */
   font-weight: 600;
   font-size: 0.75rem;
   text-transform: uppercase;

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -478,9 +478,7 @@
 }
 .hourly-dashboard.scoped-dashboard .correction-button-row button {
   width: 100%;
-  font-size: var(
-    --ud-fz-sm
-  ); /* Nutzt .button-secondary Stil über Klasse im JSX */
+  font-size: var(--ud-fz-sm); /* Nutzt .button-secondary Stil über Klasse im JSX */
 }
 
 /* Tageskarten für Urlaub, Krankheit, Feiertag (Übernahme von UserDashboard) */

--- a/Chrono-frontend/src/styles/Navbar.css
+++ b/Chrono-frontend/src/styles/Navbar.css
@@ -20,33 +20,18 @@
   --nav-button-text: #fff;
   --nav-button-hover-bg: var(--c-pri-dim, #6b7cff);
   --nav-logout-bg: var(--c-danger, #ed5757);
-  --nav-logout-hover-bg: color-mix(
-    in srgb,
-    var(--c-danger, #ed5757) 85%,
-    black
-  );
+  --nav-logout-hover-bg: color-mix(in srgb, var(--c-danger, #ed5757) 85%, black);
 
   /* UI-Elemente */
   --nav-height: 65px; /* Standardhöhe der Navbar */
   --nav-padding-x: clamp(1rem, 4vw, 2rem); /* Responsive horizontales Padding */
   --nav-padding-y: 0.75rem;
-  --nav-radius: var(
-    --u-radius-md,
-    10px
-  ); /* Konsistenter Radius mit anderen Elementen */
-  --nav-shadow: var(
-    --u-shadow-md,
-    0 5px 15px rgba(0, 0, 0, 0.08)
-  ); /* Subtiler Schatten */
+  --nav-radius: var(--u-radius-md, 10px); /* Konsistenter Radius mit anderen Elementen */
+  --nav-shadow: var(--u-shadow-md, 0 5px 15px rgba(0, 0, 0, 0.08)); /* Subtiler Schatten */
   --nav-transition: var(--u-dur, 0.25s)
     var(--u-ease, cubic-bezier(0.4, 0.2, 0.2, 1));
 
-  font-family: var(
-    --ud-font-family,
-    "Poppins",
-    system-ui,
-    sans-serif
-  ); /* Erbt von Dashboard-Font */
+  font-family: var(--ud-font-family, "Poppins", system-ui, sans-serif); /* Erbt von Dashboard-Font */
 }
 
 [data-theme="dark"] .scoped-navbar {
@@ -58,20 +43,13 @@
   --nav-text: var(--c-text, #e4e6eb);
   --nav-text-muted: var(--c-muted, #9da1b2);
   --nav-border: var(--c-border, #363a46);
-  --nav-link-hover-bg: var(
-    --c-pri,
-    #475bff
-  ); /* Kann im Dark Mode heller sein, wenn Primärfarbe dunkler ist */
+  --nav-link-hover-bg: var(--c-pri, #475bff); /* Kann im Dark Mode heller sein, wenn Primärfarbe dunkler ist */
   --nav-link-hover-text: #fff;
   --nav-button-bg: var(--c-pri, #475bff);
   --nav-button-text: #fff;
   --nav-button-hover-bg: var(--c-pri-dim, #6b7cff);
   --nav-logout-bg: var(--c-danger, #ed5757);
-  --nav-logout-hover-bg: color-mix(
-    in srgb,
-    var(--c-danger, #ed5757) 85%,
-    black
-  );
+  --nav-logout-hover-bg: color-mix(in srgb, var(--c-danger, #ed5757) 85%, black);
 }
 
 /* ----------------------------- Navbar-Grundlayout ----------------------------- */
@@ -391,9 +369,7 @@
   }
   .scoped-navbar .navbar-links a:hover,
   .scoped-navbar .navbar-links button:hover {
-    background-color: var(
-      --nav-link-hover-bg
-    ); /* Einheitlicher Hover für alle Elemente */
+    background-color: var(--nav-link-hover-bg); /* Einheitlicher Hover für alle Elemente */
     color: var(--nav-link-hover-text);
     transform: none; /* Kein Transform im Dropdown */
   }

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -60,12 +60,8 @@
   --ud-c-warn-light-bg: rgba(251, 191, 36, 0.15);
   --ud-c-warn-text: #fde68a;
 
-  --ud-c-late-time: var(
-    --ud-c-error
-  ); /* Verwendet die definierte Fehlerfarbe */
-  --ud-c-late-time-bg: var(
-    --ud-c-error-light-bg
-  ); /* Verwendet den hellen Fehlerhintergrund */
+  --ud-c-late-time: var(--ud-c-error); /* Verwendet die definierte Fehlerfarbe */
+  --ud-c-late-time-bg: var(--ud-c-error-light-bg); /* Verwendet den hellen Fehlerhintergrund */
 
   --ud-shadow-card: 0 8px 24px rgba(0, 0, 0, 0.25);
   --ud-shadow-interactive: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -208,10 +204,7 @@
 }
 /* Dark Mode für Punch-Message wird durch Neudefinition von --ud-c-success und --ud-c-text (implizit für #fff) abgedeckt */
 [data-theme="dark"] .percentage-dashboard.scoped-dashboard .punch-message {
-  background-color: var(
-    --ud-c-success-dim,
-    #10b981
-  ); /* Dunkleres Grün für Dark Mode */
+  background-color: var(--ud-c-success-dim, #10b981); /* Dunkleres Grün für Dark Mode */
   color: var(--ud-c-text, #e5e7eb); /* Heller Text auf dunklem Grün */
 }
 
@@ -272,12 +265,9 @@
 }
 [data-theme="dark"]
   .percentage-dashboard.scoped-dashboard
-  .week-navigation
-  input[type="date"] {
+  .week-navigation input[type="date"] {
   border-color: var(--ud-c-border); /* Nutzt Dark Mode Border Variable */
-  background-color: var(
-    --ud-c-surface
-  ); /* Nutzt Dark Mode Surface Variable für Inputs */
+  background-color: var(--ud-c-surface); /* Nutzt Dark Mode Surface Variable für Inputs */
   color: var(--ud-c-text); /* Nutzt Dark Mode Text Variable */
 }
 /* Dark Mode für week-navigation Hintergrund ist bereits oben in der Haupt-Dark-Mode-Regel für --ud-c-surface und --ud-c-card definiert. */
@@ -700,10 +690,7 @@
   .percentage-dashboard.scoped-dashboard .punch-message,
   .percentage-dashboard.scoped-dashboard .modal-content,
   .percentage-dashboard.scoped-dashboard button {
-    box-shadow: var(
-      --ud-shadow-sm,
-      0 2px 6px rgba(0, 0, 0, 0.05)
-    ) !important; /* Fallback für --ud-shadow-sm */
+    box-shadow: var(--ud-shadow-sm, 0 2px 6px rgba(0, 0, 0, 0.05)) !important; /* Fallback für --ud-shadow-sm */
   }
   [data-theme="dark"] .percentage-dashboard.scoped-dashboard .dashboard-header,
   [data-theme="dark"] .percentage-dashboard.scoped-dashboard .weekly-overview,
@@ -711,9 +698,6 @@
   [data-theme="dark"] .percentage-dashboard.scoped-dashboard .punch-message,
   [data-theme="dark"] .percentage-dashboard.scoped-dashboard .modal-content,
   [data-theme="dark"] .percentage-dashboard.scoped-dashboard button {
-    box-shadow: var(
-      --ud-shadow-sm,
-      0 2px 6px rgba(0, 0, 0, 0.25)
-    ) !important; /* Fallback für --ud-shadow-sm im Dark Mode */
+    box-shadow: var(--ud-shadow-sm, 0 2px 6px rgba(0, 0, 0, 0.25)) !important; /* Fallback für --ud-shadow-sm im Dark Mode */
   }
 }

--- a/Chrono-frontend/src/styles/VacationCalendar.css
+++ b/Chrono-frontend/src/styles/VacationCalendar.css
@@ -13,10 +13,7 @@
   color: var(--ud-c-text, #212529);
   padding: var(--ud-gap-lg, 1.5rem); /* Konsistent mit Dashboard Sektionen */
   background-color: var(--ud-c-card, #ffffff);
-  border-radius: var(
-    --ud-radius-xl,
-    24px
-  ); /* Größerer Radius für modernen Look */
+  border-radius: var(--ud-radius-xl, 24px); /* Größerer Radius für modernen Look */
   border: 1px solid var(--ud-c-border, #dee2e6);
   box-shadow: var(--ud-shadow-card, 0 10px 30px rgba(0, 0, 0, 0.07));
 }
@@ -193,10 +190,7 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background-color: var(
-    --ud-c-primary,
-    var(--c-pri)
-  ); /* Standard-Urlaubsfarbe */
+  background-color: var(--ud-c-primary, var(--c-pri)); /* Standard-Urlaubsfarbe */
   /* box-shadow: 0 0 0 1.5px var(--ud-c-card, #ffffff); Optional, wenn auf Kachelhintergrund besser aussieht */
   flex-shrink: 0;
 }
@@ -227,10 +221,7 @@
   /* Styles werden von .button-primary und .button-secondary (im JSX) übernommen */
 }
 .scoped-vacation .report-sick-leave-button {
-  background-color: var(
-    --ud-c-warn,
-    #ffc107
-  ); /* Warnfarbe für "Krank melden" */
+  background-color: var(--ud-c-warn, #ffc107); /* Warnfarbe für "Krank melden" */
   color: #212529; /* Dunkler Text für guten Kontrast auf Gelb */
   border-color: var(--ud-c-warn, #ffc107);
 }
@@ -296,10 +287,7 @@
   border-bottom: 1px solid var(--ud-c-line, #dee2e6);
 }
 .scoped-vacation .sick-leave-modal-content h3 {
-  color: var(
-    --ud-c-warn-text,
-    #856404
-  ); /* Spezifische Farbe für Krank-Modal Titel */
+  color: var(--ud-c-warn-text, #856404); /* Spezifische Farbe für Krank-Modal Titel */
 }
 [data-theme="dark"] .scoped-vacation .sick-leave-modal-content h3 {
   color: var(--ud-c-warn, #fab005);
@@ -324,10 +312,7 @@
   border: 1px solid var(--ud-c-border, #dee2e6);
   border-radius: var(--ud-radius-md, 12px); /* Konsistenter Radius */
   color: var(--ud-c-text, #212529);
-  background-color: var(
-    --ud-c-surface,
-    #e9ecef
-  ); /* Leichter Hintergrund für Inputs */
+  background-color: var(--ud-c-surface, #e9ecef); /* Leichter Hintergrund für Inputs */
   padding: var(--ud-gap-sm, 0.6rem) var(--ud-gap-md, 1rem);
   font-size: var(--ud-fz-md, 1rem);
   width: 100%;

--- a/Chrono-frontend/src/styles/VacationCalendarAdminScoped.css
+++ b/Chrono-frontend/src/styles/VacationCalendarAdminScoped.css
@@ -930,14 +930,8 @@
   /* ... (z.B. background-color, color, border-radius, transition etc. für report-sick-leave-button-admin) ... */
 }
 .vacation-calendar-admin.scoped-vacation .report-sick-leave-button-admin {
-  background-color: var(
-    --c-warn,
-    #ffc107
-  ); /* Beispiel: Warnfarbe für Krankmeldung */
-  color: var(
-    --c-warn-text-strong,
-    #5d4702
-  ); /* Stärkerer Kontrast für Lesbarkeit */
+  background-color: var(--c-warn, #ffc107); /* Beispiel: Warnfarbe für Krankmeldung */
+  color: var(--c-warn-text-strong, #5d4702); /* Stärkerer Kontrast für Lesbarkeit */
   border: 1px solid transparent;
   border-radius: var(--u-radius);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- cleanup CSS variable syntax so `var()` expressions are on a single line

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b82e253e88325810443a6260fd90b