### PR TITLE
Add futuristic design tokens

### DIFF
--- a/Chrono-frontend/index.html
+++ b/Chrono-frontend/index.html
@@ -9,6 +9,9 @@
   <!--  Favicon -->
   <link rel="icon" href="/img/favicon_transparent.png" type="image/png" />
   <link rel="apple-touch-icon" href="/img/favicon_transparent.png" /> <!-- iOS Home-Screen -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Orbitron:wght@600&display=swap" rel="stylesheet" />
   <!-- Tailwind via CDN for modern styling -->
   <script src="https://cdn.tailwindcss.com"></script>
 

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -49,7 +49,7 @@ a:focus-visible {
 
 /* ---------- 2)  Basis-Typografie -------------------------------------- */
 html {
-  font-family: "Poppins", system-ui, sans-serif;
+  font-family: "Inter", system-ui, sans-serif;
   font-size: 16px;
   line-height: 1.45;
   scroll-behavior: smooth; /* sanftes Scrollen auf der gesamten Seite */
@@ -62,6 +62,11 @@ body {
   transition:
     background var(--u-dur) var(--u-ease),
     color var(--u-dur) var(--u-ease);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: "Orbitron", "Inter", sans-serif;
+  font-weight: 600;
 }
 
 /* Links */

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -1,19 +1,19 @@
 /* Central design tokens for colors, typography and spacing */
 :root {
   /* Primary colors */
-  --c-pri: #475bff;
-  --c-pri-dim: #6b7cff;
-  --c-pri-rgb: 71, 91, 255;
-  --c-danger: #ed5757;
+  --c-pri: #00e5ff;
+  --c-pri-dim: #66f7ff;
+  --c-pri-rgb: 0, 229, 255;
+  --c-danger: #ff007a;
 
   /* Base colors (light) */
-  --c-text: #1f1f1f;
-  --c-muted: #60646c;
-  --c-bg: #ffffff;
-  --c-bg-rgb: 255, 255, 255;
-  --c-surface: #f4f6ff;
+  --c-text: #202225;
+  --c-muted: #6b7280;
+  --c-bg: #f3f4f6;
+  --c-bg-rgb: 243, 244, 246;
+  --c-surface: #ffffff;
   --c-card: #ffffff;
-  --c-border: #d0d3e2;
+  --c-border: #e5e7eb;
 
   /* Radius & shadow */
   --u-radius: 12px;
@@ -30,16 +30,16 @@
 }
 
 [data-theme="dark"] {
-  --c-text: #e4e6eb;
-  --c-muted: #9ea3b0;
-  --c-bg: #18191a;
-  --c-bg-rgb: 24, 25, 26;
-  --c-surface: #202328;
-  --c-card: #1e1f23;
-  --c-border: #3d4048;
+  --c-text: #e5e7eb;
+  --c-muted: #9ca3af;
+  --c-bg: #0f172a;
+  --c-bg-rgb: 15, 23, 42;
+  --c-surface: #1e293b;
+  --c-card: #1a2234;
+  --c-border: #334155;
 
-  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
-  --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+  --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.6);
+  --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.8);
 
   /* Dark mode backdrop color for modal overlays */
   --modal-backdrop-color: rgba(0, 0, 0, 0.8);
@@ -47,16 +47,16 @@
 
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
-    --c-text: #e4e6eb;
-    --c-muted: #9ea3b0;
-    --c-bg: #18191a;
-    --c-bg-rgb: 24, 25, 26;
-    --c-surface: #202328;
-    --c-card: #1e1f23;
-    --c-border: #3d4048;
+    --c-text: #e5e7eb;
+    --c-muted: #9ca3af;
+    --c-bg: #0f172a;
+    --c-bg-rgb: 15, 23, 42;
+    --c-surface: #1e293b;
+    --c-card: #1a2234;
+    --c-border: #334155;
 
-      --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4);
-      --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.65);
+      --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.6);
+      --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.8);
       --modal-backdrop-color: rgba(0, 0, 0, 0.8);
     }
   }


### PR DESCRIPTION
## Summary
- refresh design tokens with neon-inspired palette
- use Inter and Orbitron fonts for a futuristic style
- load fonts via Google Fonts

## Testing
- `mvn test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed71b94488325b265ba0a5a1dd3dd