### PR TITLE
Enhance global styles with modern theme

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -37,7 +37,11 @@ const Navbar = () => {
     }, [brightness]);
 
     // Theme-Logik (Light / Dark)
-    const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+    const [theme, setTheme] = useState(() => {
+        const saved = localStorage.getItem('theme');
+        if (saved) return saved;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    });
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
         localStorage.setItem('theme', theme);

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -11,12 +11,13 @@
 
 html {
   scroll-behavior: smooth;
-  font-family: system-ui, sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
 }
 
 body {
   background: var(--color-bg);
   color: var(--color-text);
+  font-family: 'Inter', system-ui, sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   transition:
@@ -33,6 +34,19 @@ a {
 a:hover {
   color: var(--color-primary-hover);
 }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Orbitron', sans-serif;
+  margin-block: 1rem 0.5rem;
+  line-height: 1.2;
+}
+h1 { font-size: 2.25rem; }
+h2 { font-size: 1.75rem; }
+h3 { font-size: 1.5rem; }
+h4 { font-size: 1.25rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; }
+
 
 /* Layout helpers */
 .container {
@@ -55,7 +69,8 @@ a:hover {
 
 /* Buttons */
 button,
-.button {
+.button,
+.btn {
   cursor: pointer;
   border: none;
   border-radius: var(--radius);
@@ -68,12 +83,14 @@ button,
     transform var(--transition-fast);
 }
 button:hover,
-.button:hover {
+.button:hover,
+.btn:hover {
   background: var(--color-primary-hover);
   transform: translateY(-2px);
 }
 button:disabled,
-.button:disabled {
+.button:disabled,
+.btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
@@ -155,6 +172,66 @@ select:focus {
     animation: none !important;
     transition: none !important;
   }
+}
+
+/* Page sections */
+.site-section {
+  padding-block: 4rem;
+}
+.site-section.lg {
+  padding-block: 6rem;
+}
+.section-inner {
+  max-width: 960px;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+/* Landing page elements */
+.feature-card,
+.info-box,
+.step-item {
+  background: var(--color-bg-alt);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 1rem;
+  text-align: center;
+}
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+.steps-grid,
+.features-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+.features-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.steps-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.step-number {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.newsletter-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.newsletter-form input {
+  flex: 1;
+}
+
+.btnRow {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
 @media (max-width: 600px) {

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -6,6 +6,8 @@
   --color-surface: #ffffff;
   --color-border: #d1d5db;
 
+  --color-bg-alt: #e5e7eb;
+
   --color-primary: #3b82f6;
   --color-primary-hover: #2563eb;
   --color-primary-rgb: 59, 130, 246;
@@ -35,6 +37,8 @@
   --color-bg: #1e293b;
   --color-surface: #273447;
   --color-border: #334155;
+
+  --color-bg-alt: #334155;
 
   --color-primary: #60a5fa;
   --color-primary-hover: #3b82f6;


### PR DESCRIPTION
## Summary
- add alt background color token
- tune default theme to match system preference in Navbar
- modernize global CSS with Inter/Orbitron fonts and layout classes
- style landing page components and shared button classes

## Testing
- `npm --prefix Chrono-frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eec94e99c8325a9b2ba752b79b6a3