### PR TITLE
Enhance base design tokens and utilities

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -37,7 +37,11 @@ const Navbar = () => {
     }, [brightness]);
 
     // Theme-Logik (Light / Dark)
-    const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'light');
+    const [theme, setTheme] = useState(() => {
+        const saved = localStorage.getItem('theme');
+        if (saved) return saved;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    });
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
         localStorage.setItem('theme', theme);

--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -11,12 +11,14 @@
 
 html {
   scroll-behavior: smooth;
-  font-family: system-ui, sans-serif;
+  font-family: var(--font-base);
+  color-scheme: light dark;
 }
 
 body {
   background: var(--color-bg);
   color: var(--color-text);
+  font-family: var(--font-base);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   transition:
@@ -33,6 +35,19 @@ a {
 a:hover {
   color: var(--color-primary-hover);
 }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  margin-block: 1rem 0.5rem;
+  line-height: 1.2;
+}
+h1 { font-size: 2.25rem; }
+h2 { font-size: 1.75rem; }
+h3 { font-size: 1.5rem; }
+h4 { font-size: 1.25rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; }
+
 
 /* Layout helpers */
 .container {
@@ -55,7 +70,8 @@ a:hover {
 
 /* Buttons */
 button,
-.button {
+.button,
+.btn {
   cursor: pointer;
   border: none;
   border-radius: var(--radius);
@@ -68,12 +84,14 @@ button,
     transform var(--transition-fast);
 }
 button:hover,
-.button:hover {
+.button:hover,
+.btn:hover {
   background: var(--color-primary-hover);
   transform: translateY(-2px);
 }
 button:disabled,
-.button:disabled {
+.button:disabled,
+.btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
@@ -155,6 +173,95 @@ select:focus {
     animation: none !important;
     transition: none !important;
   }
+}
+
+/* Page sections */
+.site-section {
+  padding-block: 4rem;
+}
+.site-section.lg {
+  padding-block: 6rem;
+}
+.section-inner {
+  max-width: 960px;
+  margin-inline: auto;
+  padding-inline: 1rem;
+}
+
+/* Landing page elements */
+.feature-card,
+.info-box,
+.step-item {
+  background: var(--color-bg-alt);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 1rem;
+  text-align: center;
+}
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+.steps-grid,
+.features-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+.features-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.steps-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+.step-number {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.newsletter-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+.newsletter-form input {
+  flex: 1;
+}
+
+.btnRow {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+/* Generic forms */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+}
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+.page-header {
+  margin-block: 2rem 1rem;
+  text-align: center;
+}
+
+.error-message {
+  color: var(--color-danger);
+  margin-top: 0.25rem;
+}
+
+.success-message-box {
+  background: var(--color-success);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  margin-top: 1rem;
 }
 
 @media (max-width: 600px) {

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -6,10 +6,18 @@
   --color-surface: #ffffff;
   --color-border: #d1d5db;
 
+  --color-bg-alt: #e5e7eb;
+
   --color-primary: #3b82f6;
   --color-primary-hover: #2563eb;
   --color-primary-rgb: 59, 130, 246;
   --color-danger: #dc2626;
+
+  --color-success: #10b981;
+  --color-warn: #d97706;
+
+  --font-base: 'Inter', system-ui, sans-serif;
+  --font-heading: 'Orbitron', sans-serif;
 
   --radius: 8px;
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.05);
@@ -36,10 +44,17 @@
   --color-surface: #273447;
   --color-border: #334155;
 
+  --color-bg-alt: #334155;
+
   --color-primary: #60a5fa;
   --color-primary-hover: #3b82f6;
   --color-primary-rgb: 96, 165, 250;
   --color-danger: #f87171;
+  --color-success: #34d399;
+  --color-warn: #fbbf24;
+
+  --font-base: 'Inter', system-ui, sans-serif;
+  --font-heading: 'Orbitron', sans-serif;
 
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- add success/warn and font tokens
- use tokenized fonts and color-scheme in global styles
- include generic page, form and message helpers

## Testing
- `npm --prefix Chrono-frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eec94e99c8325a9b2ba752b79b6a3