### PR TITLE
Add scoped CSS for admin dashboard

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.css
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.css
@@ -1,0 +1,112 @@
+.admin-dashboard {
+  padding: 1rem;
+  background-color: #f9fafb; /* gray-50 */
+  min-height: 100vh;
+}
+
+.admin-dashboard .dashboard-header {
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.admin-dashboard .dashboard-header h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.admin-dashboard .admin-action-buttons-container {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.admin-dashboard .admin-action-button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+}
+
+.admin-dashboard .content-section {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  margin-bottom: 1rem;
+}
+
+.admin-dashboard .section-header {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.admin-dashboard .section-title {
+  font-weight: 600;
+}
+
+.admin-dashboard .section-content {
+  padding: 1rem;
+}
+
+.admin-dashboard .list-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.admin-dashboard .search-input,
+.admin-dashboard .date-input {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+}
+
+.admin-dashboard .button-reset-filter,
+.admin-dashboard .button-confirm-small,
+.admin-dashboard .button-deny-small,
+.admin-dashboard .button-delete-small,
+.admin-dashboard .button-approve,
+.admin-dashboard .button-deny {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.admin-dashboard .corrections-table,
+.admin-dashboard .admin-week-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-dashboard .corrections-table th,
+.admin-dashboard .corrections-table td,
+.admin-dashboard .admin-week-table th,
+.admin-dashboard .admin-week-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.admin-dashboard .status-badge {
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.admin-dashboard .status-approved {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.admin-dashboard .status-denied {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.admin-dashboard .status-pending {
+  background-color: #fef9c3;
+  color: #92400e;
+}

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -14,6 +14,7 @@ import AdminCorrectionsList from './AdminCorrectionsList';
 import EditTimeModal from './EditTimeModal';
 import PrintUserTimesModal from './PrintUserTimesModal';
 import VacationCalendarAdmin from '../../components/VacationCalendarAdmin';
+import './AdminDashboard.css';
 
 import {
     getMondayOfWeek,


### PR DESCRIPTION
## Summary
- style admin dashboard separately via new `AdminDashboard.css`
- load the stylesheet in `AdminDashboard.jsx`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9d0cbd3c8325909172256c383228