### PR TITLE
Fix customer tracking option display

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -117,7 +117,7 @@ const Navbar = () => {
                                     <li><Link to="/admin">{t('navbar.adminStart', 'Admin‑Start')}</Link></li>
                                     <li><Link to="/admin/users">{t('navbar.userManagement', 'Benutzerverwaltung')}</Link></li>
 
-                                    {currentUser?.company?.customerTrackingEnabled && (
+                                    {currentUser?.customerTrackingEnabled && (
 
                                         <li><Link to="/admin/customers">{t('navbar.customerManagement', 'Kunden')}</Link></li>
                                     )}

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -151,7 +151,7 @@ const assignCustomerForDay = async (isoDate, customerId) => {
     }, [fetchCurrentUser]);
 
     useEffect(() => {
-        if (currentUser?.company?.customerTrackingEnabled) {
+        if (currentUser?.customerTrackingEnabled) {
             api.get('/api/customers')
                 .then(res => setCustomers(Array.isArray(res.data) ? res.data : []))
                 .catch(err => console.error('Error loading customers', err));

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -100,7 +100,7 @@ const HourlyWeekOverview = ({
             {punchMessage && <div className="punch-message">{punchMessage}</div>}
             <div className="punch-section">
                 <h4>{t("manualPunchTitle", "Manuelles Stempeln")}</h4>
-                {userProfile?.company?.customerTrackingEnabled && (
+                {userProfile?.customerTrackingEnabled && (
                     <>
                         <select value={selectedCustomerId} onChange={e => setSelectedCustomerId(e.target.value)}>
                             <option value="">{t('noCustomer')}</option>
@@ -155,7 +155,7 @@ const HourlyWeekOverview = ({
                         <div className="week-day-header day-card-header">
                                 <h4>{dayName}, {formattedDisplayDate}</h4>
 
-                                {userProfile?.company?.customerTrackingEnabled && (
+                                {userProfile?.customerTrackingEnabled && (
 
                                     <div className="day-customer-select">
                                         <select

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -101,7 +101,7 @@ const PercentageDashboard = () => {
     }, [loadProfileAndInitialData]);
 
     useEffect(() => {
-        if (userProfile?.company?.customerTrackingEnabled) {
+        if (userProfile?.customerTrackingEnabled) {
 
             api.get('/api/customers')
                 .then(res => setCustomers(Array.isArray(res.data) ? res.data : []))

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -72,7 +72,7 @@ const [selectedProjects, setSelectedProjects] = useState({});
 
             <div className="punch-section">
                 <h4>{t("manualPunchTitle", "Manuelles Stempeln")}</h4>
-                {userProfile?.company?.customerTrackingEnabled && (
+                {userProfile?.customerTrackingEnabled && (
                     <>
                         <select value={selectedCustomerId} onChange={e => setSelectedCustomerId(e.target.value)}>
                             <option value="">{t('noCustomer')}</option>
@@ -162,7 +162,7 @@ const [selectedProjects, setSelectedProjects] = useState({});
                                     <span className="expected-hours">({t("expectedWorkHours", "Soll")}: {minutesToHHMM(displayDailyExpectedMins)})</span>
                                     {summary && <span className={`daily-diff ${dailyDiffMinutes < 0 ? 'balance-negative' : 'balance-positive'}`}>({t("diffToday")}: {minutesToHHMM(dailyDiffMinutes)})</span>}
                                 </div>
-                                {userProfile?.company?.customerTrackingEnabled && (
+                                {userProfile?.customerTrackingEnabled && (
                                     <div className="day-customer-select">
                                         <select
                                             value={selectedCustomers[isoDate] || ''}


### PR DESCRIPTION
## Summary
- correct checks for `customerTrackingEnabled` in the front‑end

## Testing
- `npm test` *(fails: vitest not found)*
- `sh Chrono-backend/mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687156e16804832596081f7be3c064f9