### PR TITLE
Fix missing formatDate import

### DIFF
--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionsPanel.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageCorrectionsPanel.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import ModalOverlay from '../../components/ModalOverlay';
 import PropTypes from 'prop-types';
-import { formatLocalDate, formatTime } from './percentageDashUtils'; // Eigene Utils verwenden
+import { formatLocalDate, formatTime, formatDate } from './percentageDashUtils'; // Eigene Utils verwenden
 
 const PercentageCorrectionModal = ({
                                        visible,


### PR DESCRIPTION
## Summary
- fix PercentageCorrectionsPanel import to include `formatDate`

## Testing
- `npx eslint src/pages/PercentageDashboard/PercentageCorrectionsPanel.jsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68718b20a2848325918c4deaa4899918