### PR TITLE
Implement daily note backend

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/TimeTrackingController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/TimeTrackingController.java
@@ -227,4 +227,21 @@ public class TimeTrackingController {
             return ResponseEntity.badRequest().build();
         }
     }
+
+    @PostMapping("/daily-note")
+    public ResponseEntity<Void> saveDailyNote(
+            @RequestParam String username,
+            @RequestParam String date,
+            @RequestBody Map<String, String> body,
+            Principal principal) {
+        if (principal == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        String note = body.get("note");
+        if (note == null) note = "";
+        try {
+            timeTrackingService.saveDailyNote(username, LocalDate.parse(date), note);
+            return ResponseEntity.ok().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/DailyNote.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/DailyNote.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "daily_notes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "note_date"})
+})
+public class DailyNote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "note_date", nullable = false)
+    private LocalDate noteDate;
+
+    @Column(name = "content", length = 2000)
+    private String content;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public LocalDate getNoteDate() { return noteDate; }
+    public void setNoteDate(LocalDate noteDate) { this.noteDate = noteDate; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/DailyNoteRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/DailyNoteRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.DailyNote;
+import com.chrono.chrono.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailyNoteRepository extends JpaRepository<DailyNote, Long> {
+    Optional<DailyNote> findByUserAndNoteDate(User user, LocalDate noteDate);
+}

--- a/Chrono-backend/src/main/resources/db/schema.sql
+++ b/Chrono-backend/src/main/resources/db/schema.sql
@@ -32,3 +32,12 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS last_customer_id BIGINT;
 ALTER TABLE users ADD CONSTRAINT fk_last_customer FOREIGN KEY (last_customer_id) REFERENCES customers(id);
 ALTER TABLE time_tracking_entries ADD COLUMN IF NOT EXISTS project_id BIGINT;
 ALTER TABLE time_tracking_entries ADD CONSTRAINT fk_project FOREIGN KEY (project_id) REFERENCES projects(id);
+
+CREATE TABLE IF NOT EXISTS daily_notes (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    note_date DATE NOT NULL,
+    content VARCHAR(2000),
+    CONSTRAINT fk_daily_note_user FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT uc_daily_note UNIQUE (user_id, note_date)
+);


### PR DESCRIPTION
## Summary
- add `DailyNote` entity and repository
- support saving daily notes in `TimeTrackingService`
- expose `/api/timetracking/daily-note` endpoint in `TimeTrackingController`
- create `daily_notes` table in schema

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718e8c10488325afed90de486ebae3