### PR TITLE
Add customer context

### DIFF
--- a/Chrono-frontend/src/context/CustomerContext.jsx
+++ b/Chrono-frontend/src/context/CustomerContext.jsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import api from '../utils/api';
+import { useNotification } from './NotificationContext';
+import { useTranslation } from './LanguageContext';
+
+export const CustomerContext = createContext();
+
+export const CustomerProvider = ({ children }) => {
+    const [customers, setCustomers] = useState([]);
+    const { notify } = useNotification();
+    const { t } = useTranslation();
+
+    const fetchCustomers = async () => {
+        try {
+            const res = await api.get('/api/customers');
+            setCustomers(Array.isArray(res.data) ? res.data : []);
+        } catch (err) {
+            console.error('Error loading customers', err);
+            notify(t('customerSaveError', 'Fehler beim Laden der Kunden'), 'error');
+        }
+    };
+
+    const createCustomer = async (name) => {
+        try {
+            const res = await api.post('/api/customers', { name: name.trim() });
+            setCustomers(prev => [...prev, res.data]);
+            return res.data;
+        } catch (err) {
+            console.error('Error creating customer', err);
+            notify(t('customerSaveError', 'Fehler beim Anlegen'), 'error');
+            throw err;
+        }
+    };
+
+    const updateCustomer = async (id, name) => {
+        try {
+            const res = await api.put(`/api/customers/${id}`, { name: name.trim() });
+            setCustomers(prev => prev.map(c => c.id === id ? res.data : c));
+            return res.data;
+        } catch (err) {
+            console.error('Error updating customer', err);
+            notify(t('customerSaveError', 'Fehler beim Speichern'), 'error');
+            throw err;
+        }
+    };
+
+    const deleteCustomer = async (id) => {
+        try {
+            await api.delete(`/api/customers/${id}`);
+            setCustomers(prev => prev.filter(c => c.id !== id));
+        } catch (err) {
+            console.error('Error deleting customer', err);
+            notify(t('customerSaveError', 'Fehler beim Löschen'), 'error');
+            throw err;
+        }
+    };
+
+    useEffect(() => { fetchCustomers(); }, []);
+
+    return (
+        <CustomerContext.Provider value={{ customers, fetchCustomers, createCustomer, updateCustomer, deleteCustomer }}>
+            {children}
+        </CustomerContext.Provider>
+    );
+};
+
+export const useCustomers = () => useContext(CustomerContext);

--- a/Chrono-frontend/src/main.jsx
+++ b/Chrono-frontend/src/main.jsx
@@ -6,6 +6,7 @@ import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
 import { NotificationProvider } from "./context/NotificationContext";
 import { LanguageProvider } from "./context/LanguageContext";
+import { CustomerProvider } from "./context/CustomerContext";
 import "./styles/global.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
@@ -14,11 +15,13 @@ root.render(
         {/* LanguageProvider muss die Provider umschließen, die useTranslation() verwenden */}
         <LanguageProvider>
             <AuthProvider>
-                <NotificationProvider>
-                    <React.StrictMode>
-                        <App />
-                    </React.StrictMode>
-                </NotificationProvider>
+                <CustomerProvider>
+                    <NotificationProvider>
+                        <React.StrictMode>
+                            <App />
+                        </React.StrictMode>
+                    </NotificationProvider>
+                </CustomerProvider>
             </AuthProvider>
         </LanguageProvider>
     </HashRouter>

--- a/Chrono-frontend/src/pages/AdminCustomers/AdminCustomersPage.jsx
+++ b/Chrono-frontend/src/pages/AdminCustomers/AdminCustomersPage.jsx
@@ -1,38 +1,26 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Navbar from '../../components/Navbar';
-import api from '../../utils/api';
 import { useNotification } from '../../context/NotificationContext';
 import { useTranslation } from '../../context/LanguageContext';
+import { useCustomers } from '../../context/CustomerContext';
 import '../../styles/AdminCustomersPageScoped.css';
 
 const AdminCustomersPage = () => {
     const { notify } = useNotification();
     const { t } = useTranslation();
 
-    const [customers, setCustomers] = useState([]);
+    const { customers, createCustomer, updateCustomer, deleteCustomer } = useCustomers();
     const [newName, setNewName] = useState('');
     // State for editing
     const [editingId, setEditingId] = useState(null);
     const [editingName, setEditingName] = useState('');
 
-    const fetchCustomers = async () => {
-        try {
-            const res = await api.get('/api/customers');
-            setCustomers(Array.isArray(res.data) ? res.data : []);
-        } catch (err) {
-            console.error('Error loading customers', err);
-            notify('Fehler beim Laden der Kunden', 'error');
-        }
-    };
-
-    useEffect(() => { fetchCustomers(); }, []);
 
     const handleCreate = async (e) => {
         e.preventDefault();
         if (!newName.trim()) return;
         try {
-            const res = await api.post('/api/customers', { name: newName.trim() });
-            setCustomers(prev => [...prev, res.data]);
+            await createCustomer(newName);
             setNewName('');
         } catch (err) {
             console.error('Error creating customer', err);
@@ -43,8 +31,7 @@ const AdminCustomersPage = () => {
     const handleUpdate = async (e) => {
         e.preventDefault();
         try {
-            const res = await api.put(`/api/customers/${editingId}`, { name: editingName.trim() });
-            setCustomers(prev => prev.map(c => c.id === editingId ? res.data : c));
+            await updateCustomer(editingId, editingName);
             setEditingId(null);
             setEditingName('');
         } catch (err) {
@@ -56,8 +43,7 @@ const AdminCustomersPage = () => {
     const handleDelete = async (id) => {
         if (!window.confirm('Löschen?')) return;
         try {
-            await api.delete(`/api/customers/${id}`);
-            setCustomers(prev => prev.filter(c => c.id !== id));
+            await deleteCustomer(id);
         } catch (err) {
             console.error('Error deleting customer', err);
             notify('Fehler beim Löschen', 'error');

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -7,6 +7,7 @@ import api from '../../utils/api';
 import { useNotification } from '../../context/NotificationContext';
 import { useTranslation } from '../../context/LanguageContext';
 import { useAuth } from "../../context/AuthContext.jsx";
+import { useCustomers } from '../../context/CustomerContext';
 import 'jspdf-autotable';
 import jsPDF from 'jspdf';
 import autoTable from "jspdf-autotable";
@@ -39,7 +40,7 @@ const HourlyDashboard = () => {
 
     const [userProfile, setUserProfile] = useState(null);
     const [dailySummaries, setDailySummaries] = useState([]);
-    const [customers, setCustomers] = useState([]);
+    const { customers, fetchCustomers } = useCustomers();
     const [recentCustomers, setRecentCustomers] = useState([]);
     const [projects, setProjects] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
@@ -152,9 +153,7 @@ const assignCustomerForDay = async (isoDate, customerId) => {
 
     useEffect(() => {
         if (currentUser?.customerTrackingEnabled) {
-            api.get('/api/customers')
-                .then(res => setCustomers(Array.isArray(res.data) ? res.data : []))
-                .catch(err => console.error('Error loading customers', err));
+            fetchCustomers();
             api.get('/api/customers/recent')
                 .then(res => setRecentCustomers(Array.isArray(res.data) ? res.data : []))
                 .catch(err => console.error('Error loading customers', err));
@@ -162,11 +161,10 @@ const assignCustomerForDay = async (isoDate, customerId) => {
                 .then(res => setProjects(Array.isArray(res.data) ? res.data : []))
                 .catch(err => console.error('Error loading projects', err));
         } else {
-            setCustomers([]);
             setRecentCustomers([]);
             setProjects([]);
         }
-    }, [currentUser]);
+    }, [currentUser, fetchCustomers]);
 
     useEffect(() => {
         if (currentUser) {

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -6,6 +6,7 @@ import api from '../../utils/api';
 import { useNotification } from '../../context/NotificationContext';
 import { useTranslation } from '../../context/LanguageContext';
 import { useAuth } from "../../context/AuthContext.jsx";
+import { useCustomers } from '../../context/CustomerContext';
 import 'jspdf-autotable';
 import jsPDF from 'jspdf';
 import { parseISO } from 'date-fns';
@@ -41,7 +42,7 @@ const PercentageDashboard = () => {
 
     const [userProfile, setUserProfile] = useState(null);
     const [dailySummaries, setDailySummaries] = useState([]);
-    const [customers, setCustomers] = useState([]);
+    const { customers, fetchCustomers } = useCustomers();
     const [recentCustomers, setRecentCustomers] = useState([]);
     const [projects, setProjects] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
@@ -102,10 +103,7 @@ const PercentageDashboard = () => {
 
     useEffect(() => {
         if (userProfile?.customerTrackingEnabled) {
-
-            api.get('/api/customers')
-                .then(res => setCustomers(Array.isArray(res.data) ? res.data : []))
-                .catch(err => console.error('Error loading customers', err));
+            fetchCustomers();
             api.get('/api/customers/recent')
                 .then(res => setRecentCustomers(Array.isArray(res.data) ? res.data : []))
                 .catch(err => console.error('Error loading customers', err));
@@ -113,11 +111,10 @@ const PercentageDashboard = () => {
                 .then(res => setProjects(Array.isArray(res.data) ? res.data : []))
                 .catch(err => console.error('Error loading projects', err));
         } else {
-            setCustomers([]);
             setRecentCustomers([]);
             setProjects([]);
         }
-    }, [userProfile]);
+    }, [userProfile, fetchCustomers]);
 
     const fetchHolidaysForUser = useCallback(async (year, cantonAbbreviation) => {
         const cantonKey = cantonAbbreviation || 'GENERAL';


### PR DESCRIPTION
## Summary
- add global `CustomerContext` to store list of customers
- wrap app with `CustomerProvider`
- use customer context in admin and dashboard pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719eb9f55883259c51df8b9bd1929d