### PR TITLE
Fix customer assignment and style day selection

### DIFF
--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -84,7 +84,9 @@ const HourlyDashboard = () => {
 
 const assignCustomerForDay = async (isoDate, customerId) => {
         try {
-            await api.put('/api/timetracking/day/customer', null, { params: { username: currentUser.username, date: isoDate, customerId: customerId || '' } });
+            const params = { username: currentUser.username, date: isoDate };
+            if (customerId) params.customerId = customerId;
+            await api.put('/api/timetracking/day/customer', null, { params });
             fetchWeeklyData(selectedMonday);
             notify(t('customerSaved'), 'success');
         } catch (err) {
@@ -95,7 +97,9 @@ const assignCustomerForDay = async (isoDate, customerId) => {
 
     const assignProjectForDay = async (isoDate, projectId) => {
         try {
-            await api.put('/api/timetracking/day/project', null, { params: { username: currentUser.username, date: isoDate, projectId: projectId || '' } });
+            const params = { username: currentUser.username, date: isoDate };
+            if (projectId) params.projectId = projectId;
+            await api.put('/api/timetracking/day/project', null, { params });
             fetchWeeklyData(selectedMonday);
             notify(t('customerSaved'), 'success');
         } catch (err) {

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -217,7 +217,9 @@ const PercentageDashboard = () => {
 
     const assignCustomerForDay = async (isoDate, customerId) => {
         try {
-            await api.put('/api/timetracking/day/customer', null, { params: { username: userProfile.username, date: isoDate, customerId: customerId || '' } });
+            const params = { username: userProfile.username, date: isoDate };
+            if (customerId) params.customerId = customerId;
+            await api.put('/api/timetracking/day/customer', null, { params });
             fetchDataForUser();
             notify(t('customerSaved'), 'success');
         } catch (err) {
@@ -228,7 +230,9 @@ const PercentageDashboard = () => {
 
     const assignProjectForDay = async (isoDate, projectId) => {
         try {
-            await api.put('/api/timetracking/day/project', null, { params: { username: userProfile.username, date: isoDate, projectId: projectId || '' } });
+            const params = { username: userProfile.username, date: isoDate };
+            if (projectId) params.projectId = projectId;
+            await api.put('/api/timetracking/day/project', null, { params });
             fetchDataForUser();
             notify(t('customerSaved'), 'success');
         } catch (err) {

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -390,6 +390,22 @@
 }
 /* Kein .day-card-meta mit Soll/Diff im HourlyDashboard */
 
+.hourly-dashboard.scoped-dashboard .day-customer-select {
+  display: flex;
+  gap: var(--ud-gap-xs);
+  align-items: center;
+  margin-bottom: var(--ud-gap-sm);
+}
+
+.hourly-dashboard.scoped-dashboard .day-customer-select select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hourly-dashboard.scoped-dashboard .day-customer-select button {
+  flex-shrink: 0;
+}
+
 .hourly-dashboard.scoped-dashboard .week-day-content .time-entry-list {
   list-style: none;
   padding: 0;

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -329,6 +329,22 @@
   padding-bottom: var(--ud-gap-sm, 0.75rem);
   border-bottom: 1px solid var(--ud-c-line, #e2e8f0);
 }
+
+.percentage-dashboard.scoped-dashboard .day-customer-select {
+  display: flex;
+  gap: var(--ud-gap-xs, 0.5rem);
+  align-items: center;
+  margin-bottom: var(--ud-gap-sm, 0.75rem);
+}
+
+.percentage-dashboard.scoped-dashboard .day-customer-select select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.percentage-dashboard.scoped-dashboard .day-customer-select button {
+  flex-shrink: 0;
+}
 .percentage-dashboard.scoped-dashboard .week-day-content {
   font-size: var(--ud-fz-sm, 0.875rem);
   flex-grow: 1;


### PR DESCRIPTION
## Summary
- fix missing `customerId`/`projectId` query params when clearing value
- add styling for the day-level customer/project select section

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: missing `winscard.h` when building pcsclite)*

------
https://chatgpt.com/codex/tasks/task_e_68727d825d70832582234c1cf9d2bef5