### PR TITLE
Fix holidays API call in user data hook

### DIFF
--- a/Chrono-frontend/src/hooks/useUserData.js
+++ b/Chrono-frontend/src/hooks/useUserData.js
@@ -23,7 +23,9 @@ export const useUserData = () => {
                 api.get('/api/vacation/my'),
                 api.get(`/api/correction/my?username=${currentUser.username}`),
                 api.get('/api/sick-leave/my'),
-                api.get('/api/holidays')
+                api.get('/api/holidays', {
+                    params: { year: new Date().getFullYear() }
+                })
             ]);
 
             const [profileRes, summariesRes, vacationsRes, corrRes, sickRes, holiRes] = results;


### PR DESCRIPTION
## Summary
- add `year` parameter when requesting holidays in `useUserData`

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6873ae7cbe9c8325ae57db8e3b88f0a3