### PR TITLE
Improve weekly summary layout

### DIFF
--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -219,10 +219,19 @@ const HourlyWeekOverview = ({
                 <button onClick={handleNextWeek} className="button-secondary">{t("nextWeek", "Nächste Woche")} →</button>
             </div>
             <div className="weekly-monthly-totals">
-                <p><strong>{t("weeklyHours", "Ges. Std. (Woche)")}:</strong> {minutesToHHMM(weeklyTotalMins)}</p>
-                <p><strong>{t("monthlyHours", "Ges. Std. (Monat)")}:</strong> {minutesToHHMM(monthlyTotalMins)}</p>
+                <div className="summary-item">
+                    <span className="summary-label">{t('weeklyHours', 'Ges. Std. (Woche)')}</span>
+                    <span className="summary-value">{minutesToHHMM(weeklyTotalMins)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">{t('monthlyHours', 'Ges. Std. (Monat)')}</span>
+                    <span className="summary-value">{minutesToHHMM(monthlyTotalMins)}</span>
+                </div>
                 {weeklyEarnings !== null && (
-                    <p><strong>{t('estimatedEarnings', 'gesch\u00e4tzterVerdienst')}:</strong> {weeklyEarnings.toFixed(2)} CHF</p>
+                    <div className="summary-item">
+                        <span className="summary-label">{t('estimatedEarnings', 'gesch\u00e4tzterVerdienst')}</span>
+                        <span className="summary-value">{weeklyEarnings.toFixed(2)} CHF</span>
+                    </div>
                 )}
             </div>
             <TrendChart data={chartData} />

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -193,21 +193,21 @@ const PercentageWeekOverview = ({
             </div>
 
             <div className="weekly-summary">
-                <p>
-                    <strong>{t('weeklyHours', "Ges. Std. (Woche)")}:</strong> {minutesToHHMM(weeklyWorked)}
-                </p>
-                <p>
-                    <strong>{t('expected', "Soll (Woche)")}:</strong> {minutesToHHMM(weeklyExpected)}
-                    <span className="info-badge" title={t('expectedWeekInfo')}>ℹ️</span>
-                </p>
-                <p>
-                    <strong className={(weeklyDiff ?? 0) < 0 ? 'balance-negative' : 'balance-positive'}>
-                        {t('weekBalance', "Saldo (Woche)")}:
-                    </strong>
-                    <span className={(weeklyDiff ?? 0) < 0 ? 'balance-negative' : 'balance-positive'}>
-                        {minutesToHHMM(weeklyDiff)}
+                <div className="summary-item">
+                    <span className="summary-label">{t('weeklyHours', 'Ges. Std. (Woche)')}</span>
+                    <span className="summary-value">{minutesToHHMM(weeklyWorked)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">
+                        {t('expected', 'Soll (Woche)')}
+                        <span className="info-badge" title={t('expectedWeekInfo')}>ℹ️</span>
                     </span>
-                </p>
+                    <span className="summary-value">{minutesToHHMM(weeklyExpected)}</span>
+                </div>
+                <div className="summary-item">
+                    <span className="summary-label">{t('weekBalance', 'Saldo (Woche)')}</span>
+                    <span className={`summary-value ${(weeklyDiff ?? 0) < 0 ? 'balance-negative' : 'balance-positive'}`}>{minutesToHHMM(weeklyDiff)}</span>
+                </div>
             </div>
 
             <div className="week-display">

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -431,14 +431,18 @@ function UserDashboard() {
                     </button>
                 </div>
                 <div className="weekly-summary">
-                    <p><strong>{t('actualTime')}:</strong> {minutesToHHMM(weeklyActualWorkedMinutes)}</p>
-                    <p><strong>{t('expected')}:</strong> {weeklyExpectedStr}</p>
-                    <p>
-                        <strong>{t('weekBalance')}:</strong>
-                        <span className={weeklyActualWorkedMinutes - weeklyExpectedMins < 0 ? 'balance-negative' : 'balance-positive'}>
-                            {weeklyDiffStr}
-                        </span>
-                    </p>
+                    <div className="summary-item">
+                        <span className="summary-label">{t('actualTime')}</span>
+                        <span className="summary-value">{minutesToHHMM(weeklyActualWorkedMinutes)}</span>
+                    </div>
+                    <div className="summary-item">
+                        <span className="summary-label">{t('expected')}</span>
+                        <span className="summary-value">{weeklyExpectedStr}</span>
+                    </div>
+                    <div className="summary-item">
+                        <span className="summary-label">{t('weekBalance')}</span>
+                        <span className={`summary-value ${weeklyActualWorkedMinutes - weeklyExpectedMins < 0 ? 'balance-negative' : 'balance-positive'}`}>{weeklyDiffStr}</span>
+                    </div>
                 </div>
 
                 <TrendChart data={chartData} />

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -336,22 +336,32 @@
 }
 
 .hourly-dashboard.scoped-dashboard .weekly-monthly-totals {
-  /* Spezifisch für HourlyDashboard */
-  text-align: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--ud-gap-md);
   margin-bottom: var(--ud-gap-lg);
-  padding: var(--ud-gap-md);
-  background-color: var(--ud-c-primary-light-bg);
-  border-radius: var(--ud-radius-lg);
 }
-.hourly-dashboard.scoped-dashboard .weekly-monthly-totals p {
-  margin: var(--ud-gap-sm) 0;
+.hourly-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-card);
+  border: 1px solid var(--ud-c-border);
+  border-radius: var(--ud-radius-md);
+  padding: var(--ud-gap-md);
+  text-align: center;
+  box-shadow: var(--ud-shadow-card);
+}
+.hourly-dashboard.scoped-dashboard .summary-label {
+  display: block;
+  font-size: var(--ud-fz-sm);
+  color: var(--ud-c-text-muted);
+  margin-bottom: var(--ud-gap-xs);
+}
+.hourly-dashboard.scoped-dashboard .summary-value {
   font-size: var(--ud-fz-lg);
-  font-weight: 500;
+  font-weight: 600;
   color: var(--ud-c-text);
 }
-.hourly-dashboard.scoped-dashboard .weekly-monthly-totals p strong {
-  color: var(--ud-c-primary-text);
-  font-weight: 600;
+[data-theme="dark"] .hourly-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-surface);
 }
 
 .hourly-dashboard.scoped-dashboard .week-display {

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -275,27 +275,38 @@
 
 /* Wöchentliche Zusammenfassung (Ist, Soll, Saldo) */
 .percentage-dashboard.scoped-dashboard .weekly-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--ud-gap-md);
+  margin-bottom: var(--ud-gap-lg);
+}
+.percentage-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-card);
+  border: 1px solid var(--ud-c-border);
+  border-radius: var(--ud-radius-md);
+  padding: var(--ud-gap-md);
   text-align: center;
-  margin-bottom: var(--ud-gap-lg, 2rem);
-  padding: var(--ud-gap-md, 1.25rem);
-  background-color: var(--ud-c-primary-light-bg, rgba(71, 91, 255, 0.08));
-  border-radius: var(--ud-radius-md, 10px);
+  box-shadow: var(--ud-shadow-card);
 }
-.percentage-dashboard.scoped-dashboard .weekly-summary p {
-  margin: var(--ud-gap-xs, 0.5rem) 0;
-  font-size: var(--ud-fz-lg, 1.125rem);
-  font-weight: 500;
-  color: var(--ud-c-text, #1f2024);
+.percentage-dashboard.scoped-dashboard .summary-label {
+  display: block;
+  font-size: var(--ud-fz-sm);
+  color: var(--ud-c-text-muted);
+  margin-bottom: var(--ud-gap-xs);
 }
-.percentage-dashboard.scoped-dashboard .weekly-summary p strong {
-  color: var(--ud-c-primary-text, var(--c-pri));
+.percentage-dashboard.scoped-dashboard .summary-value {
+  font-size: var(--ud-fz-lg);
   font-weight: 600;
+  color: var(--ud-c-text);
 }
-.percentage-dashboard.scoped-dashboard .weekly-summary .balance-positive {
-  color: var(--ud-c-success-text, #059669);
+.percentage-dashboard.scoped-dashboard .summary-value.balance-positive {
+  color: var(--ud-c-success-text);
 }
-.percentage-dashboard.scoped-dashboard .weekly-summary .balance-negative {
-  color: var(--ud-c-error-text, #dc2626);
+.percentage-dashboard.scoped-dashboard .summary-value.balance-negative {
+  color: var(--ud-c-error-text);
+}
+[data-theme="dark"] .percentage-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-surface);
 }
 /* Dark Mode für .weekly-summary und Textfarben wird durch die Neudefinition der entsprechenden --ud- Variablen abgedeckt. */
 

--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -332,6 +332,35 @@
   background-color: var(--ud-c-card);
 }
 
+.user-dashboard.scoped-dashboard .weekly-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--ud-gap-md);
+  margin-bottom: var(--ud-gap-lg);
+}
+.user-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-card);
+  border: 1px solid var(--ud-c-border);
+  border-radius: var(--ud-radius-md);
+  padding: var(--ud-gap-md);
+  text-align: center;
+  box-shadow: var(--ud-shadow-card);
+}
+.user-dashboard.scoped-dashboard .summary-label {
+  display: block;
+  font-size: var(--ud-fz-sm);
+  color: var(--ud-c-text-muted);
+  margin-bottom: var(--ud-gap-xs);
+}
+.user-dashboard.scoped-dashboard .summary-value {
+  font-size: var(--ud-fz-lg);
+  font-weight: 600;
+  color: var(--ud-c-text);
+}
+[data-theme="dark"] .user-dashboard.scoped-dashboard .summary-item {
+  background: var(--ud-c-surface);
+}
+
 .user-dashboard.scoped-dashboard .week-display {
   display: grid;
   gap: var(--ud-gap-lg);


### PR DESCRIPTION
## Summary
- redesign weekly summary on user dashboard
- add card-style layout and adjust CSS
- update layout for PercentageWeekOverview and HourlyWeekOverview

## Testing
- `npx -y vitest run` *(fails: cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6873b94b43b08325973a708304f18475