### PR TITLE
Display assigned customers in day cards

### DIFF
--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -444,6 +444,11 @@
   color: var(--ud-c-text-muted);
   padding-left: 1rem;
 }
+.scoped-dashboard .day-customer-indicator {
+  margin-top: var(--ud-gap-xs);
+  font-size: var(--ud-fz-sm);
+  color: var(--ud-c-text-muted);
+}
 
 .user-dashboard.scoped-dashboard .expected-hours strong,
 .user-dashboard.scoped-dashboard .daily-diff strong {
@@ -1050,6 +1055,9 @@
   }
   .scoped-dashboard .saved-range-list {
     padding-left: 0;
+  }
+  .scoped-dashboard .day-customer-indicator {
+    text-align: left;
   }
 
 }


### PR DESCRIPTION
## Summary
- show customer information in DayCard components
- list customer ranges per day when multiple customers were tracked
- style customer info in dashboard tiles

## Testing
- `npx vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6873c2c66df8832585b117803c05f016