### PR TITLE
Fix jspdf imports and implement half day rule

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/WorkScheduleService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/WorkScheduleService.java
@@ -384,9 +384,31 @@ public class WorkScheduleService {
 
 
     public boolean isHalfDay(User user, LocalDate date) {
-        // TODO: UserScheduleRule prüfen, ob dieser Tag spezifisch als "HALF_DAY" markiert ist.
-        // Diese Methode ist derzeit nicht voll implementiert und liefert immer false.
-        // Sie wird in `computeExpectedWorkMinutes` verwendet, aber hat aktuell keinen Effekt.
+        List<UserScheduleRule> rules = ruleRepo.findByUser(user);
+        for (UserScheduleRule rule : rules) {
+            if (rule.getDayMode() == null || !"HALF_DAY".equalsIgnoreCase(rule.getDayMode())) {
+                continue;
+            }
+
+            LocalDate start = rule.getStartDate();
+            if (start != null && date.isBefore(start)) {
+                continue;
+            }
+
+            if (rule.getDayOfWeek() != null && rule.getDayOfWeek() != date.getDayOfWeek().getValue()) {
+                continue;
+            }
+
+            if (rule.getRepeatIntervalDays() != null && rule.getRepeatIntervalDays() > 0 && start != null) {
+                long diff = ChronoUnit.DAYS.between(start, date);
+                if (diff % rule.getRepeatIntervalDays() == 0) {
+                    return true;
+                }
+            } else {
+                // Regel gilt einmalig oder jede Woche bei passendem dayOfWeek
+                return true;
+            }
+        }
         return false;
     }
 }

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -9,7 +9,6 @@ import { useTranslation } from '../../context/LanguageContext';
 import { useAuth } from "../../context/AuthContext.jsx";
 import { useUserData } from '../../hooks/useUserData';
 import { useCustomers } from '../../context/CustomerContext';
-import 'jspdf-autotable';
 import jsPDF from 'jspdf';
 import autoTable from "jspdf-autotable";
 

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -7,7 +7,6 @@ import { useNotification } from '../../context/NotificationContext';
 import { useTranslation } from '../../context/LanguageContext';
 import { useAuth } from "../../context/AuthContext.jsx";
 import { useCustomers } from '../../context/CustomerContext';
-import 'jspdf-autotable';
 import jsPDF from 'jspdf';
 import { parseISO } from 'date-fns';
 import { useUserData } from '../../hooks/useUserData';

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -10,7 +10,6 @@ import { parseISO } from 'date-fns';
 
 import '../../styles/global.css';
 import '../../styles/UserDashboardScoped.css';
-import "jspdf-autotable"; // Für PDF Export
 import jsPDF from "jspdf"; // Für PDF Export
 import autoTable from "jspdf-autotable"; // Importiere autoTable explizit
 


### PR DESCRIPTION
## Summary
- remove redundant jspdf-autotable side-effect imports in dashboards
- implement rule-based half day detection in `WorkScheduleService`

## Testing
- `npm install` *(fails: pcsclite build missing winscard.h)*
- `npx vitest run` *(fails: vitest not installed)*
- `./mvnw test` *(fails: couldn't resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873c6fdc33c8325a7cb06b90affcfc2