### PR TITLE
Fix Percentage dashboard not loaded

### DIFF
--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -14,6 +14,7 @@ import jsPDF from "jspdf"; // Für PDF Export
 import autoTable from "jspdf-autotable"; // Importiere autoTable explizit
 
 import HourlyDashboard from '../../pages/HourlyDashboard/HourlyDashboard.jsx'; // Für den Fall, dass ein User stündlich ist
+import PercentageDashboard from '../../pages/PercentageDashboard/PercentageDashboard.jsx';
 
 import {
     getMondayOfWeek,
@@ -375,12 +376,7 @@ function UserDashboard() {
         return <HourlyDashboard />;
     }
     if (userProfile.isPercentage) {
-        // Annahme: Es gibt eine PercentageDashboard Komponente
-        // import PercentageDashboard from '../PercentageDashboard/PercentageDashboard';
-        // return <PercentageDashboard />;
-        // Für dieses Beispiel leite auf eine dedizierte Route weiter oder zeige Nachricht
-        // Da das PercentageDashboard eigene Logik hat, ist eine eigene Komponente/Route besser
-        // return <Navigate to="/percentage-dashboard" replace />; // Besser wäre, es direkt hier zu rendern
+        return <PercentageDashboard />;
     }
 
     return (


### PR DESCRIPTION
## Summary
- import PercentageDashboard in UserDashboard
- render PercentageDashboard when the user is a percentage-based worker

## Testing
- `npm test` *(fails: pcsclite build error)*

------
https://chatgpt.com/codex/tasks/task_e_6873e2d4c2c88325b93e78c760b41dff