### PR TITLE
Fix customer tracking not visible in percentage dashboard

### DIFF
--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -104,7 +104,8 @@ const PercentageDashboard = () => {
     }, [loadProfileAndInitialData]);
 
     useEffect(() => {
-        if (userProfile?.customerTrackingEnabled) {
+        const trackingEnabled = userProfile?.customerTrackingEnabled ?? currentUser?.customerTrackingEnabled;
+        if (trackingEnabled) {
             fetchCustomers();
             api.get('/api/customers/recent')
                 .then(res => setRecentCustomers(Array.isArray(res.data) ? res.data : []))
@@ -116,7 +117,7 @@ const PercentageDashboard = () => {
             setRecentCustomers([]);
             setProjects([]);
         }
-    }, [userProfile, fetchCustomers]);
+    }, [userProfile, currentUser, fetchCustomers]);
 
     const fetchHolidaysForUser = useCallback(async (year, cantonAbbreviation) => {
         const cantonKey = cantonAbbreviation || 'GENERAL';

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -1,5 +1,6 @@
 // src/pages/PercentageDashboard/PercentageWeekOverview.jsx
 import React, { useState, useEffect } from 'react';
+import { useAuth } from '../../context/AuthContext.jsx';
 import PropTypes from 'prop-types';
 // Removed: import { useTranslation } from '../../context/LanguageContext'; // t wird als Prop übergeben
 
@@ -42,11 +43,12 @@ const PercentageWeekOverview = ({
                                     assignProjectForDay,
                                     vacationRequests,
                                     sickLeaves,
-                                    holidaysForUserCanton
+                                holidaysForUserCanton
                                 }) => {
 
     // Immer 7 Tage für eine volle Wochenansicht (Mo-So)
     const weekDates = Array.from({ length: 7 }, (_, i) => addDays(monday, i)); // Mo-So
+    const { currentUser } = useAuth();
     const [selectedCustomers, setSelectedCustomers] = useState({});
     const [selectedProjects, setSelectedProjects] = useState({});
     const [startTimes, setStartTimes] = useState({});
@@ -150,7 +152,7 @@ const PercentageWeekOverview = ({
 
             <div className="punch-section">
                 <h4>{t("manualPunchTitle", "Manuelles Stempeln")}</h4>
-                {userProfile?.customerTrackingEnabled && (
+                {(userProfile?.customerTrackingEnabled ?? currentUser?.customerTrackingEnabled) && (
                     <>
                         <select value={selectedCustomerId} onChange={e => setSelectedCustomerId(e.target.value)}>
                             <option value="">{t('noCustomer')}</option>
@@ -247,7 +249,7 @@ const PercentageWeekOverview = ({
                             showCorrection
                             onRequestCorrection={() => openCorrectionModal(dayObj, summary)}
                         >
-                            {userProfile?.customerTrackingEnabled && (
+                            {(userProfile?.customerTrackingEnabled ?? currentUser?.customerTrackingEnabled) && (
                                 <div className="day-customer-select">
                                     <label>
                                         <span>{t('customerLabel', 'Kunde')}</span>

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -14,6 +14,7 @@ import jsPDF from "jspdf"; // Für PDF Export
 import autoTable from "jspdf-autotable"; // Importiere autoTable explizit
 
 import HourlyDashboard from '../../pages/HourlyDashboard/HourlyDashboard.jsx'; // Für den Fall, dass ein User stündlich ist
+import PercentageDashboard from '../../pages/PercentageDashboard/PercentageDashboard.jsx';
 
 import {
     getMondayOfWeek,
@@ -375,12 +376,7 @@ function UserDashboard() {
         return <HourlyDashboard />;
     }
     if (userProfile.isPercentage) {
-        // Annahme: Es gibt eine PercentageDashboard Komponente
-        // import PercentageDashboard from '../PercentageDashboard/PercentageDashboard';
-        // return <PercentageDashboard />;
-        // Für dieses Beispiel leite auf eine dedizierte Route weiter oder zeige Nachricht
-        // Da das PercentageDashboard eigene Logik hat, ist eine eigene Komponente/Route besser
-        // return <Navigate to="/percentage-dashboard" replace />; // Besser wäre, es direkt hier zu rendern
+        return <PercentageDashboard />;
     }
 
     return (


### PR DESCRIPTION
## Summary
- check `currentUser.customerTrackingEnabled` when loading customers
- show customer selection in PercentageWeekOverview if enabled

## Testing
- `npm test` *(failed: `npm` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873e2d4c2c88325b93e78c760b41dff