### PR TITLE
Enhance translation for payslips

### DIFF
--- a/Chrono-backend/pom.xml
+++ b/Chrono-backend/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.5.13.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/AuditConfig.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/AuditConfig.java
@@ -1,0 +1,17 @@
+package com.chrono.chrono.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AuditConfig implements WebMvcConfigurer {
+    @Autowired
+    private ReadAccessInterceptor interceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(interceptor);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/DataInitializer.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/DataInitializer.java
@@ -61,7 +61,10 @@ public class DataInitializer implements CommandLineRunner {
 
             Role adminRole = roleRepository.findByRoleName("ROLE_ADMIN")
                     .orElseGet(() -> roleRepository.save(new Role("ROLE_ADMIN")));
+            Role payrollRole = roleRepository.findByRoleName("ROLE_PAYROLL_ADMIN")
+                    .orElseGet(() -> roleRepository.save(new Role("ROLE_PAYROLL_ADMIN")));
             adminUser.getRoles().add(adminRole);
+            adminUser.getRoles().add(payrollRole);
 
             userRepository.save(adminUser);
             System.out.println("[DataInitializer] Admin-Konto ('" + adminUsername + "') wurde erstellt.");

--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/ReadAccessInterceptor.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/ReadAccessInterceptor.java
@@ -1,0 +1,34 @@
+package com.chrono.chrono.config;
+
+import com.chrono.chrono.entities.ReadAccessAudit;
+import com.chrono.chrono.repositories.ReadAccessAuditRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+
+@Component
+public class ReadAccessInterceptor implements HandlerInterceptor {
+    @Autowired
+    private ReadAccessAuditRepository repo;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if ("GET".equalsIgnoreCase(request.getMethod())) {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth != null && auth.isAuthenticated()) {
+                ReadAccessAudit log = new ReadAccessAudit();
+                log.setUsername(auth.getName());
+                log.setPath(request.getRequestURI());
+                log.setTimestamp(LocalDateTime.now());
+                repo.save(log);
+            }
+        }
+        return true;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/PayslipController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/PayslipController.java
@@ -1,0 +1,101 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.entities.Payslip;
+import com.chrono.chrono.dto.PayslipDTO;
+import com.chrono.chrono.services.PayrollService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/payslips")
+public class PayslipController {
+    @Autowired
+    private PayrollService payrollService;
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    @PostMapping("/generate")
+    public ResponseEntity<PayslipDTO> generate(
+            @RequestParam Long userId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end) {
+        Payslip ps = payrollService.generatePayslip(userId, start, end);
+        return ResponseEntity.ok(new PayslipDTO(ps));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<PayslipDTO>> list(@PathVariable Long userId) {
+        List<Payslip> list = payrollService.getPayslipsForUser(userId);
+        return ResponseEntity.ok(list.stream().map(PayslipDTO::new).toList());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @PostMapping("/approve/{id}")
+    public ResponseEntity<Void> approve(@PathVariable Long id,
+                                        @RequestParam(required = false) String comment) {
+        payrollService.approvePayslip(id, comment);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @PostMapping("/approve-all")
+    public ResponseEntity<Void> approveAll(@RequestParam(required = false) Long userId,
+                                           @RequestParam(required = false) String comment) {
+        if (userId != null) {
+            payrollService.approveAllForUser(userId, comment);
+        } else {
+            payrollService.approveAll(comment);
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @GetMapping("/admin/all")
+    public ResponseEntity<List<PayslipDTO>> all() {
+        return ResponseEntity.ok(payrollService.getAllPayslips().stream().map(PayslipDTO::new).toList());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @GetMapping("/admin/pending")
+    public ResponseEntity<List<PayslipDTO>> pending() {
+        return ResponseEntity.ok(payrollService.getPendingPayslips().stream().map(PayslipDTO::new).toList());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @GetMapping("/admin/export")
+    public ResponseEntity<String> exportCsv(@RequestParam(defaultValue = "en") String lang) {
+        StringBuilder sb = new StringBuilder();
+        if ("de".equalsIgnoreCase(lang)) {
+            sb.append("BenutzerID,Start,Ende,Brutto,Abzuege,Netto\n");
+        } else {
+            sb.append("userId,periodStart,periodEnd,gross,deductions,net\n");
+        }
+        payrollService.getAllPayslips().forEach(ps -> {
+            sb.append(ps.getUser().getId()).append(',')
+              .append(ps.getPeriodStart()).append(',')
+              .append(ps.getPeriodEnd()).append(',')
+              .append(ps.getGrossSalary()).append(',')
+              .append(ps.getDeductions()).append(',')
+              .append(ps.getNetSalary()).append('\n');
+        });
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=payslips.csv");
+        return ResponseEntity.ok().headers(headers).body(sb.toString());
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @GetMapping("/admin/backup")
+    public ResponseEntity<String> backup() {
+        // simple CSV backup using same export
+        return exportCsv();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserController.java
@@ -49,6 +49,22 @@ public class UserController {
         return convertToDTO(user);
     }
 
+    @PostMapping("/api/users/{id}/opt-out")
+    public ResponseEntity<Void> optOut(@PathVariable Long id) {
+        User u = userRepository.findById(id).orElseThrow();
+        u.setOptOut(true);
+        userRepository.save(u);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/users/{id}")
+    public ResponseEntity<Void> softDelete(@PathVariable Long id) {
+        User u = userRepository.findById(id).orElseThrow();
+        u.setDeleted(true);
+        userRepository.save(u);
+        return ResponseEntity.ok().build();
+    }
+
     private UserDTO convertToDTO(User user) {
         UserDTO dto = new UserDTO();
         dto.setUsername(user.getUsername());
@@ -59,6 +75,9 @@ public class UserController {
         dto.setIsPercentage(user.getIsPercentage());
         dto.setAnnualVacationDays(user.getAnnualVacationDays());
         dto.setWorkPercentage(user.getWorkPercentage());
+        dto.setHourlyRate(user.getHourlyRate());
+        dto.setBankAccount(user.getBankAccount());
+        dto.setSocialSecurityNumber(user.getSocialSecurityNumber());
         dto.setTrackingBalanceInMinutes(user.getTrackingBalanceInMinutes());
         if (user.getLastCustomer() != null) {
             dto.setLastCustomerId(user.getLastCustomer().getId());

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/PayslipDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/PayslipDTO.java
@@ -1,0 +1,65 @@
+package com.chrono.chrono.dto;
+
+import com.chrono.chrono.entities.Payslip;
+import java.time.LocalDate;
+
+public class PayslipDTO {
+    private Long id;
+    private Long userId;
+    private LocalDate periodStart;
+    private LocalDate periodEnd;
+    private Double grossSalary;
+    private Double deductions;
+    private Double netSalary;
+    private Double allowances;
+    private Double bonuses;
+    private Double oneTimePayments;
+    private Double taxFreeAllowances;
+    private String bankAccount;
+    private String socialSecurityNumber;
+    private String payType;
+    private boolean locked;
+    private String pdfPath;
+    private Integer version;
+    private boolean approved;
+
+    public PayslipDTO(Payslip ps) {
+        this.id = ps.getId();
+        this.userId = ps.getUser() != null ? ps.getUser().getId() : null;
+        this.periodStart = ps.getPeriodStart();
+        this.periodEnd = ps.getPeriodEnd();
+        this.grossSalary = ps.getGrossSalary();
+        this.deductions = ps.getDeductions();
+        this.netSalary = ps.getNetSalary();
+        this.allowances = ps.getAllowances();
+        this.bonuses = ps.getBonuses();
+        this.oneTimePayments = ps.getOneTimePayments();
+        this.taxFreeAllowances = ps.getTaxFreeAllowances();
+        this.bankAccount = ps.getBankAccount();
+        this.socialSecurityNumber = ps.getSocialSecurityNumber();
+        this.payType = ps.getPayType();
+        this.locked = ps.isLocked();
+        this.pdfPath = ps.getPdfPath();
+        this.version = ps.getVersion();
+        this.approved = ps.isApproved();
+    }
+
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public LocalDate getPeriodStart() { return periodStart; }
+    public LocalDate getPeriodEnd() { return periodEnd; }
+    public Double getGrossSalary() { return grossSalary; }
+    public Double getDeductions() { return deductions; }
+    public Double getNetSalary() { return netSalary; }
+    public Double getAllowances() { return allowances; }
+    public Double getBonuses() { return bonuses; }
+    public Double getOneTimePayments() { return oneTimePayments; }
+    public Double getTaxFreeAllowances() { return taxFreeAllowances; }
+    public String getBankAccount() { return bankAccount; }
+    public String getSocialSecurityNumber() { return socialSecurityNumber; }
+    public String getPayType() { return payType; }
+    public boolean isLocked() { return locked; }
+    public String getPdfPath() { return pdfPath; }
+    public Integer getVersion() { return version; }
+    public boolean isApproved() { return approved; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserDTO.java
@@ -29,6 +29,11 @@ public class UserDTO {
     private Integer trackingBalanceInMinutes;
     private Boolean isPercentage;
     private Integer workPercentage;
+    private Double hourlyRate;
+    private String bankAccount;
+    private String socialSecurityNumber;
+    private Boolean deleted;
+    private Boolean optOut;
     private Long companyId;
     private String companyCantonAbbreviation;
     private Boolean customerTrackingEnabled; // Kept
@@ -62,6 +67,11 @@ public class UserDTO {
         this.trackingBalanceInMinutes = user.getTrackingBalanceInMinutes();
         this.isPercentage = user.getIsPercentage();
         this.workPercentage = user.getWorkPercentage();
+        this.hourlyRate = user.getHourlyRate();
+        this.bankAccount = user.getBankAccount();
+        this.socialSecurityNumber = user.getSocialSecurityNumber();
+        this.deleted = user.isDeleted();
+        this.optOut = user.isOptOut();
         this.companyId = (user.getCompany() != null) ? user.getCompany().getId() : null;
         this.companyCantonAbbreviation = (user.getCompany() != null) ? user.getCompany().getCantonAbbreviation() : null;
         this.lastCustomerId = user.getLastCustomer() != null ? user.getLastCustomer().getId() : null;
@@ -74,8 +84,10 @@ public class UserDTO {
                    Integer expectedWorkDays, Double dailyWorkHours, Integer breakDuration, String color,
                    Integer scheduleCycle, List<Map<String, Double>> weeklySchedule, LocalDate scheduleEffectiveDate,
                    Boolean isHourly, Integer annualVacationDays, Integer trackingBalanceInMinutes,
-                   Boolean isPercentage, Integer workPercentage, Long companyId,
-                   Long lastCustomerId, String lastCustomerName, Boolean customerTrackingEnabled) { // Kept
+                   Boolean isPercentage, Integer workPercentage, Double hourlyRate, String bankAccount,
+                   String socialSecurityNumber, Long companyId,
+                   Long lastCustomerId, String lastCustomerName, Boolean customerTrackingEnabled,
+                   Boolean deleted, Boolean optOut) { // Kept
         this.id = id;
         this.username = username;
         this.password = password;
@@ -95,10 +107,15 @@ public class UserDTO {
         this.trackingBalanceInMinutes = trackingBalanceInMinutes != null ? trackingBalanceInMinutes : 0;
         this.isPercentage = isPercentage != null ? isPercentage : false;
         this.workPercentage = workPercentage != null ? workPercentage : 100;
+        this.hourlyRate = hourlyRate;
+        this.bankAccount = bankAccount;
+        this.socialSecurityNumber = socialSecurityNumber;
         this.companyId = companyId;
         this.lastCustomerId = lastCustomerId;
         this.lastCustomerName = lastCustomerName;
         this.customerTrackingEnabled = customerTrackingEnabled; // Kept
+        this.deleted = deleted;
+        this.optOut = optOut;
     }
 
     // ----- Getters -----
@@ -121,6 +138,11 @@ public class UserDTO {
     public Integer getTrackingBalanceInMinutes() { return trackingBalanceInMinutes; }
     public Boolean getIsPercentage() { return isPercentage; }
     public Integer getWorkPercentage() { return workPercentage; }
+    public Double getHourlyRate() { return hourlyRate; }
+    public String getBankAccount() { return bankAccount; }
+    public String getSocialSecurityNumber() { return socialSecurityNumber; }
+    public Boolean getDeleted() { return deleted; }
+    public Boolean getOptOut() { return optOut; }
     public Long getCompanyId() { return companyId; }
     public String getCompanyCantonAbbreviation() { return companyCantonAbbreviation; }
     public Long getLastCustomerId() { return lastCustomerId; }
@@ -147,6 +169,11 @@ public class UserDTO {
     public void setTrackingBalanceInMinutes(Integer trackingBalanceInMinutes) { this.trackingBalanceInMinutes = trackingBalanceInMinutes; }
     public void setIsPercentage(Boolean isPercentage) { this.isPercentage = isPercentage; }
     public void setWorkPercentage(Integer workPercentage) { this.workPercentage = workPercentage; }
+    public void setHourlyRate(Double hourlyRate) { this.hourlyRate = hourlyRate; }
+    public void setBankAccount(String bankAccount) { this.bankAccount = bankAccount; }
+    public void setSocialSecurityNumber(String socialSecurityNumber) { this.socialSecurityNumber = socialSecurityNumber; }
+    public void setDeleted(Boolean deleted) { this.deleted = deleted; }
+    public void setOptOut(Boolean optOut) { this.optOut = optOut; }
     public void setCompanyId(Long companyId) { this.companyId = companyId; }
     public void setCompanyCantonAbbreviation(String companyCantonAbbreviation) { this.companyCantonAbbreviation = companyCantonAbbreviation; }
     public void setLastCustomerId(Long lastCustomerId) { this.lastCustomerId = lastCustomerId; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/Payslip.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/Payslip.java
@@ -1,0 +1,96 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import jakarta.persistence.Convert;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "payslips")
+public class Payslip {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate periodStart;
+    private LocalDate periodEnd;
+    private Double grossSalary;
+    private Double deductions;
+    private Double netSalary;
+    private Double allowances;
+    private Double bonuses;
+    private Double oneTimePayments;
+    private Double taxFreeAllowances;
+
+    @Convert(converter = com.chrono.chrono.utils.EncryptionConverter.class)
+    private String bankAccount;
+    @Convert(converter = com.chrono.chrono.utils.EncryptionConverter.class)
+    private String socialSecurityNumber;
+
+    private String payType;
+    private boolean locked = false;
+    private String pdfPath;
+
+    @Version
+    private Integer version;
+
+    @Column(name = "approved", nullable = false)
+    private boolean approved = false;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public LocalDate getPeriodStart() { return periodStart; }
+    public void setPeriodStart(LocalDate periodStart) { this.periodStart = periodStart; }
+
+    public LocalDate getPeriodEnd() { return periodEnd; }
+    public void setPeriodEnd(LocalDate periodEnd) { this.periodEnd = periodEnd; }
+
+    public Double getGrossSalary() { return grossSalary; }
+    public void setGrossSalary(Double grossSalary) { this.grossSalary = grossSalary; }
+
+    public Double getDeductions() { return deductions; }
+    public void setDeductions(Double deductions) { this.deductions = deductions; }
+
+    public Double getNetSalary() { return netSalary; }
+    public void setNetSalary(Double netSalary) { this.netSalary = netSalary; }
+
+    public Double getAllowances() { return allowances; }
+    public void setAllowances(Double allowances) { this.allowances = allowances; }
+
+    public Double getBonuses() { return bonuses; }
+    public void setBonuses(Double bonuses) { this.bonuses = bonuses; }
+
+    public Double getOneTimePayments() { return oneTimePayments; }
+    public void setOneTimePayments(Double oneTimePayments) { this.oneTimePayments = oneTimePayments; }
+
+    public Double getTaxFreeAllowances() { return taxFreeAllowances; }
+    public void setTaxFreeAllowances(Double taxFreeAllowances) { this.taxFreeAllowances = taxFreeAllowances; }
+
+    public String getBankAccount() { return bankAccount; }
+    public void setBankAccount(String bankAccount) { this.bankAccount = bankAccount; }
+
+    public String getSocialSecurityNumber() { return socialSecurityNumber; }
+    public void setSocialSecurityNumber(String socialSecurityNumber) { this.socialSecurityNumber = socialSecurityNumber; }
+
+    public String getPayType() { return payType; }
+    public void setPayType(String payType) { this.payType = payType; }
+
+    public boolean isLocked() { return locked; }
+    public void setLocked(boolean locked) { this.locked = locked; }
+
+    public String getPdfPath() { return pdfPath; }
+    public void setPdfPath(String pdfPath) { this.pdfPath = pdfPath; }
+
+    public Integer getVersion() { return version; }
+    public void setVersion(Integer version) { this.version = version; }
+
+    public boolean isApproved() { return approved; }
+    public void setApproved(boolean approved) { this.approved = approved; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/PayslipAudit.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/PayslipAudit.java
@@ -1,0 +1,49 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payslip_audit")
+public class PayslipAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payslip_id")
+    private Payslip payslip;
+
+    @Column(nullable = false)
+    private String action;
+
+    @Column(nullable = false)
+    private String author;
+
+    private String comment;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    public PayslipAudit() {}
+
+    public PayslipAudit(Payslip payslip, String action, String author, String comment) {
+        this.payslip = payslip;
+        this.action = action;
+        this.author = author;
+        this.comment = comment;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public Payslip getPayslip() { return payslip; }
+    public void setPayslip(Payslip payslip) { this.payslip = payslip; }
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+    public String getAuthor() { return author; }
+    public void setAuthor(String author) { this.author = author; }
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/ReadAccessAudit.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/ReadAccessAudit.java
@@ -1,0 +1,35 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "read_access_audit")
+public class ReadAccessAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String path;
+
+    private LocalDateTime timestamp;
+
+    public ReadAccessAudit() {}
+
+    public ReadAccessAudit(String username, String path) {
+        this.username = username;
+        this.path = path;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // getters and setters
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPath() { return path; }
+    public void setPath(String path) { this.path = path; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/User.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/User.java
@@ -13,9 +13,11 @@ import java.util.List;
 import java.util.ArrayList; // Import für ArrayList
 import com.chrono.chrono.entities.TimeTrackingEntry;
 import com.chrono.chrono.converters.WeeklyScheduleConverter;
+import jakarta.persistence.Convert;
 
 @Entity
 @Table(name = "users")
+@EntityListeners(com.chrono.chrono.entities.listeners.UserAuditListener.class)
 public class User {
 
     @Id
@@ -36,6 +38,18 @@ public class User {
 
     @Column(unique = true) // E-Mail sollte normalerweise eindeutig sein
     private String email;
+
+    @Convert(converter = com.chrono.chrono.utils.EncryptionConverter.class)
+    private String bankAccount;
+
+    @Convert(converter = com.chrono.chrono.utils.EncryptionConverter.class)
+    private String socialSecurityNumber;
+
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "opt_out", nullable = false)
+    private boolean optOut = false;
 
     @Column(nullable = false)
     private Integer trackingBalanceInMinutes = 0; // Default-Wert direkt hier
@@ -106,6 +120,9 @@ public class User {
     @Column(name = "work_percentage") // Standardwert 100 ist hier nicht nötig, wird im Getter gehandhabt
     private Integer workPercentage;
 
+    @Column(name = "hourly_rate")
+    private Double hourlyRate;
+
     public User() {}
 
     public static Map<String, Double> getDefaultWeeklyScheduleMap() {
@@ -142,6 +159,18 @@ public class User {
 
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
+
+    public String getBankAccount() { return bankAccount; }
+    public void setBankAccount(String bankAccount) { this.bankAccount = bankAccount; }
+
+    public String getSocialSecurityNumber() { return socialSecurityNumber; }
+    public void setSocialSecurityNumber(String socialSecurityNumber) { this.socialSecurityNumber = socialSecurityNumber; }
+
+    public boolean isDeleted() { return deleted; }
+    public void setDeleted(boolean deleted) { this.deleted = deleted; }
+
+    public boolean isOptOut() { return optOut; }
+    public void setOptOut(boolean optOut) { this.optOut = optOut; }
 
     public Integer getTrackingBalanceInMinutes() {
         return trackingBalanceInMinutes != null ? trackingBalanceInMinutes : 0;
@@ -205,4 +234,7 @@ public class User {
     public void setWorkPercentage(Integer workPercentage) {
         this.workPercentage = (workPercentage != null && workPercentage >= 0 && workPercentage <=100 ? workPercentage : 100);
     }
+
+    public Double getHourlyRate() { return hourlyRate; }
+    public void setHourlyRate(Double hourlyRate) { this.hourlyRate = hourlyRate; }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/UserAudit.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/UserAudit.java
@@ -1,0 +1,44 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_audit")
+public class UserAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String fieldName;
+    private String oldValue;
+    private String newValue;
+    private LocalDateTime timestamp;
+
+    public UserAudit() {}
+
+    public UserAudit(User user, String fieldName, String oldValue, String newValue) {
+        this.user = user;
+        this.fieldName = fieldName;
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // getters and setters
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getFieldName() { return fieldName; }
+    public void setFieldName(String fieldName) { this.fieldName = fieldName; }
+    public String getOldValue() { return oldValue; }
+    public void setOldValue(String oldValue) { this.oldValue = oldValue; }
+    public String getNewValue() { return newValue; }
+    public void setNewValue(String newValue) { this.newValue = newValue; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
@@ -1,0 +1,61 @@
+package com.chrono.chrono.entities.listeners;
+
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.entities.UserAudit;
+import com.chrono.chrono.repositories.UserAuditRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PreUpdate;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class UserAuditListener {
+    private static final Map<Long, User> PREVIOUS = new HashMap<>();
+
+    private static UserAuditRepository repo;
+
+    @Autowired
+    public void init(UserAuditRepository r) {
+        repo = r;
+    }
+
+    @PostLoad
+    public void postLoad(User user) {
+        PREVIOUS.put(user.getId(), copy(user));
+    }
+
+    @PreUpdate
+    public void preUpdate(User user) {
+        User old = PREVIOUS.get(user.getId());
+        if (old != null) {
+            if (diff(old.getBankAccount(), user.getBankAccount())) {
+                repo.save(new UserAudit(user, "bankAccount", old.getBankAccount(), user.getBankAccount()));
+            }
+            if (diff(old.getSocialSecurityNumber(), user.getSocialSecurityNumber())) {
+                repo.save(new UserAudit(user, "socialSecurityNumber", old.getSocialSecurityNumber(), user.getSocialSecurityNumber()));
+            }
+            if (diff(old.getEmail(), user.getEmail())) {
+                repo.save(new UserAudit(user, "email", old.getEmail(), user.getEmail()));
+            }
+        }
+        PREVIOUS.put(user.getId(), copy(user));
+    }
+
+    private boolean diff(String a, String b) {
+        if (a == null && b == null) return false;
+        if (a == null || b == null) return true;
+        return !a.equals(b);
+    }
+
+    private User copy(User u) {
+        User c = new User();
+        c.setId(u.getId());
+        c.setBankAccount(u.getBankAccount());
+        c.setSocialSecurityNumber(u.getSocialSecurityNumber());
+        c.setEmail(u.getEmail());
+        return c;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipAuditRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipAuditRepository.java
@@ -1,0 +1,6 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.PayslipAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayslipAuditRepository extends JpaRepository<PayslipAudit, Long> {}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipRepository.java
@@ -1,0 +1,14 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.Payslip;
+import com.chrono.chrono.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PayslipRepository extends JpaRepository<Payslip, Long> {
+    List<Payslip> findByUser(User user);
+    List<Payslip> findByUserAndApproved(User user, boolean approved);
+    List<Payslip> findByApproved(boolean approved);
+    List<Payslip> findByUserAndPeriodStartAndPeriodEnd(User user, java.time.LocalDate start, java.time.LocalDate end);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ReadAccessAuditRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ReadAccessAuditRepository.java
@@ -1,0 +1,7 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.ReadAccessAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReadAccessAuditRepository extends JpaRepository<ReadAccessAudit, Long> {
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/UserAuditRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/UserAuditRepository.java
@@ -1,0 +1,7 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.UserAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAuditRepository extends JpaRepository<UserAudit, Long> {
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
@@ -1,6 +1,8 @@
 package com.chrono.chrono.services;
 
 import com.chrono.chrono.dto.ApplicationData;
+import com.chrono.chrono.entities.Payslip;
+import com.chrono.chrono.entities.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -9,8 +11,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class EmailService {
 
+    private final JavaMailSender mailSender;
+
     @Autowired
-    private JavaMailSender mailSender;
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
 
     public void sendRegistrationMail(ApplicationData data) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -45,5 +51,25 @@ public class EmailService {
         message.setText(mailText);
 
         mailSender.send(message);
+    }
+
+    public void sendPayslipGeneratedMail(User user, Payslip payslip) {
+        if (user.getEmail() == null) return;
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("siefertchristopher@chrono-logisch.ch");
+        msg.setTo(user.getEmail());
+        msg.setSubject("Neue Gehaltsabrechnung bereit");
+        msg.setText("Ihre Abrechnung vom " + payslip.getPeriodStart() + " bis " + payslip.getPeriodEnd() + " ist erstellt.");
+        mailSender.send(msg);
+    }
+
+    public void sendPayslipApprovedMail(User user, Payslip payslip) {
+        if (user.getEmail() == null) return;
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("siefertchristopher@chrono-logisch.ch");
+        msg.setTo(user.getEmail());
+        msg.setSubject("Gehaltsabrechnung freigegeben");
+        msg.setText("Ihre Abrechnung vom " + payslip.getPeriodStart() + " bis " + payslip.getPeriodEnd() + " wurde freigegeben.");
+        mailSender.send(msg);
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
@@ -1,0 +1,147 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Payslip;
+import com.chrono.chrono.entities.PayslipAudit;
+import com.chrono.chrono.entities.TimeTrackingEntry;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.PayslipAuditRepository;
+import com.chrono.chrono.repositories.PayslipRepository;
+import com.chrono.chrono.repositories.TimeTrackingEntryRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.EmailService;
+import com.chrono.chrono.services.PdfService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class PayrollService {
+    @Autowired
+    private PayslipRepository payslipRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TimeTrackingEntryRepository timeTrackingEntryRepository;
+    @Autowired
+    private PayslipAuditRepository payslipAuditRepository;
+    @Autowired
+    private EmailService emailService;
+    @Autowired
+    private PdfService pdfService;
+
+    private static final double TAX_RATE = 0.15; // simple example tax
+    private static final double SOCIAL_RATE = 0.05; // social deductions
+    private static final double OVERTIME_BONUS = 0.25;
+
+    private void audit(Payslip ps, String action, String author, String comment) {
+        PayslipAudit log = new PayslipAudit(ps, action, author, comment);
+        payslipAuditRepository.save(log);
+    }
+
+    @Transactional
+    public Payslip generatePayslip(Long userId, LocalDate start, LocalDate end) {
+        User user = userRepository.findById(userId).orElseThrow();
+        LocalDateTime startDt = start.atStartOfDay();
+        LocalDateTime endDt = end.plusDays(1).atStartOfDay();
+        List<TimeTrackingEntry> entries = timeTrackingEntryRepository
+                .findByUserAndEntryTimestampBetweenOrderByEntryTimestampAsc(user, startDt, endDt);
+        long minutes = 0;
+        LocalDateTime lastStart = null;
+        for (TimeTrackingEntry e : entries) {
+            if (e.getPunchType() == TimeTrackingEntry.PunchType.START) {
+                lastStart = e.getEntryTimestamp();
+            } else if (e.getPunchType() == TimeTrackingEntry.PunchType.ENDE && lastStart != null) {
+                minutes += Duration.between(lastStart, e.getEntryTimestamp()).toMinutes();
+                lastStart = null;
+            }
+        }
+        double hours = minutes / 60.0;
+        double rate = user.getHourlyRate() != null ? user.getHourlyRate() : 0.0;
+        double overtimeHours = Math.max(0, hours - 160);
+        double baseHours = hours - overtimeHours;
+        double gross = baseHours * rate + overtimeHours * rate * (1 + OVERTIME_BONUS);
+        double deductions = gross * (TAX_RATE + SOCIAL_RATE);
+        double net = gross - deductions;
+        Payslip ps = new Payslip();
+        ps.setUser(user);
+        ps.setPeriodStart(start);
+        ps.setPeriodEnd(end);
+        Integer maxVersion = payslipRepository.findByUserAndPeriodStartAndPeriodEnd(user, start, end)
+                .stream().map(Payslip::getVersion).max(Integer::compareTo).orElse(0);
+        ps.setVersion(maxVersion == null ? 0 : maxVersion + 1);
+        ps.setGrossSalary(gross);
+        ps.setDeductions(deductions);
+        ps.setNetSalary(net);
+        ps.setAllowances(0.0);
+        ps.setBonuses(0.0);
+        ps.setOneTimePayments(0.0);
+        ps.setTaxFreeAllowances(0.0);
+        ps.setBankAccount(user.getBankAccount());
+        ps.setSocialSecurityNumber(user.getSocialSecurityNumber());
+        ps.setPayType(user.getIsHourly() != null && user.getIsHourly() ? "hourly" : "salary");
+        ps.setApproved(false);
+        Payslip saved = payslipRepository.save(ps);
+        audit(saved, "GENERATED", user.getUsername(), null);
+        emailService.sendPayslipGeneratedMail(user, saved);
+        return saved;
+    }
+
+    public List<Payslip> getPayslipsForUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return payslipRepository.findByUserAndApproved(user, true);
+    }
+
+    @Transactional
+    public void approvePayslip(Long id, String comment) {
+        Payslip ps = payslipRepository.findById(id).orElseThrow();
+        ps.setApproved(true);
+        ps.setLocked(true);
+        String pdf = pdfService.generatePayslipPdf(ps);
+        ps.setPdfPath(pdf);
+        payslipRepository.save(ps);
+        audit(ps, "APPROVED", "ADMIN", comment);
+        emailService.sendPayslipApprovedMail(ps.getUser(), ps);
+    }
+
+    @Transactional
+    public void approveAllForUser(Long userId, String comment) {
+        User user = userRepository.findById(userId).orElseThrow();
+        List<Payslip> slips = payslipRepository.findByUser(user);
+        for (Payslip ps : slips) {
+            ps.setApproved(true);
+            ps.setLocked(true);
+            String pdf = pdfService.generatePayslipPdf(ps);
+            ps.setPdfPath(pdf);
+            audit(ps, "APPROVED", "ADMIN", comment);
+            emailService.sendPayslipApprovedMail(ps.getUser(), ps);
+        }
+        payslipRepository.saveAll(slips);
+    }
+
+    @Transactional
+    public void approveAll(String comment) {
+        List<Payslip> slips = payslipRepository.findAll();
+        for (Payslip ps : slips) {
+            ps.setApproved(true);
+            ps.setLocked(true);
+            String pdf = pdfService.generatePayslipPdf(ps);
+            ps.setPdfPath(pdf);
+            audit(ps, "APPROVED", "ADMIN", comment);
+            emailService.sendPayslipApprovedMail(ps.getUser(), ps);
+        }
+        payslipRepository.saveAll(slips);
+    }
+
+    public List<Payslip> getAllPayslips() {
+        return payslipRepository.findAll();
+    }
+
+    public List<Payslip> getPendingPayslips() {
+        return payslipRepository.findByApproved(false);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollValidationService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollValidationService.java
@@ -1,0 +1,22 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Payslip;
+import com.chrono.chrono.repositories.PayslipRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PayrollValidationService {
+    @Autowired
+    private PayslipRepository payslipRepository;
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void validatePayslips() {
+        payslipRepository.findAll().forEach(ps -> {
+            if (ps.getNetSalary() < 0) {
+                System.err.println("Invalid payslip " + ps.getId());
+            }
+        });
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PdfService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PdfService.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Payslip;
+import org.springframework.stereotype.Service;
+
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.pdf.PdfWriter;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Service
+public class PdfService {
+    public String generatePayslipPdf(Payslip ps) {
+        String path = "/tmp/payslip-" + ps.getId() + ".pdf";
+        Document doc = new Document();
+        try {
+            PdfWriter.getInstance(doc, new FileOutputStream(path));
+            doc.open();
+            doc.add(new Paragraph("Payslip " + ps.getId()));
+            doc.add(new Paragraph("Period: " + ps.getPeriodStart() + " - " + ps.getPeriodEnd()));
+            doc.add(new Paragraph("Net salary: " + ps.getNetSalary()));
+        } catch (DocumentException | IOException e) {
+            return null;
+        } finally {
+            doc.close();
+        }
+        return path;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/utils/EncryptionConverter.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/utils/EncryptionConverter.java
@@ -1,0 +1,51 @@
+package com.chrono.chrono.utils;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Arrays;
+
+@Converter
+public class EncryptionConverter implements AttributeConverter<String, String> {
+    private static final String ALGO = "AES";
+    private static final SecretKey KEY;
+
+    static {
+        String env = System.getenv("ENCRYPT_KEY");
+        byte[] keyBytes = Arrays.copyOf((env != null ? env : "defaultsecretkey").getBytes(StandardCharsets.UTF_8), 16);
+        KEY = new SecretKeySpec(keyBytes, ALGO);
+    }
+
+    private Cipher cipher(int mode) throws Exception {
+        Cipher c = Cipher.getInstance(ALGO);
+        c.init(mode, KEY);
+        return c;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            byte[] enc = cipher(Cipher.ENCRYPT_MODE).doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(enc);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            byte[] dec = cipher(Cipher.DECRYPT_MODE).doFinal(Base64.getDecoder().decode(dbData));
+            return new String(dec, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/PayrollServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/PayrollServiceTest.java
@@ -1,0 +1,61 @@
+package com.chrono.chrono;
+
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.services.PayrollService;
+import com.chrono.chrono.services.EmailService;
+import com.chrono.chrono.services.PdfService;
+import com.chrono.chrono.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({PayrollService.class, PayrollServiceTest.TestConfig.class})
+public class PayrollServiceTest {
+    @Autowired
+    private PayrollService payrollService;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void testGeneratePayslip() {
+        User u = new User();
+        u.setUsername("t");
+        u.setPassword("p");
+        u.setHourlyRate(10.0);
+        userRepository.save(u);
+        var ps = payrollService.generatePayslip(u.getId(), LocalDate.now().minusDays(10), LocalDate.now());
+        assertNotNull(ps.getGrossSalary());
+        assertTrue(ps.getNetSalary() <= ps.getGrossSalary());
+        payrollService.approvePayslip(ps.getId(), null);
+        var saved = payrollService.getAllPayslips().get(0);
+        assertTrue(saved.isLocked());
+        assertNotNull(saved.getPdfPath());
+    }
+}
+
+@Configuration
+class TestConfig {
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return new org.springframework.mail.javamail.JavaMailSenderImpl();
+    }
+
+    @Bean
+    public EmailService emailService(JavaMailSender sender) {
+        return new EmailService(sender);
+    }
+
+    @Bean
+    public PdfService pdfService() {
+        return new PdfService();
+    }
+}

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -27,6 +27,8 @@ import CompanyManagementPage from "./pages/CompanyManagementPage.jsx";
 import PrintReport from "./pages/PrintReport.jsx";
 import Impressum from "./pages/Impressum.jsx";
 import AGB from "./pages/AGB.jsx";
+import PayslipsPage from "./pages/PayslipsPage.jsx";
+import AdminPayslipsPage from "./pages/AdminPayslipsPage.jsx";
 import PrivateRoute from "./components/PrivateRoute";
 import { useAuth } from "./context/AuthContext";
 
@@ -70,6 +72,14 @@ function App() {
                     element={
                         <PrivateRoute>
                             <PersonalDataPage />
+                        </PrivateRoute>
+                    }
+                />
+                <Route
+                    path="/payslips"
+                    element={
+                        <PrivateRoute>
+                            <PayslipsPage />
                         </PrivateRoute>
                     }
                 />
@@ -128,6 +138,14 @@ function App() {
                     element={
                         <PrivateRoute requiredRole="ROLE_ADMIN">
                             <AdminChangePassword />
+                        </PrivateRoute>
+                    }
+                />
+                <Route
+                    path="/admin/payslips"
+                    element={
+                        <PrivateRoute requiredRole={["ROLE_ADMIN","ROLE_PAYROLL_ADMIN"]}>
+                            <AdminPayslipsPage />
                         </PrivateRoute>
                     }
                 />

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -532,6 +532,19 @@ const translations = {
             title: "Alle Änderungen und Updates",
             loading: "Lade Verlauf...",
         },
+        payslips: {
+            title: "Meine Gehaltsabrechnungen",
+            pendingTitle: "Offene Gehaltsabrechnungen",
+            approve: "Freigeben",
+            approveAll: "Alle freigeben",
+            exportCsv: "CSV Export",
+            backup: "Backup",
+            print: "Drucken",
+            period: "Zeitraum",
+            user: "Benutzer",
+            gross: "Brutto",
+            net: "Netto"
+        },
         notFound: {
             pageNotFound: "404 - Seite nicht gefunden",
         },
@@ -1062,6 +1075,19 @@ const translations = {
         whatsNewPage: {
             title: "All changes and updates",
             loading: "Loading history...",
+        },
+        payslips: {
+            title: "My Payslips",
+            pendingTitle: "Pending Payslips",
+            approve: "Approve",
+            approveAll: "Approve All",
+            exportCsv: "CSV Export",
+            backup: "Backup",
+            print: "Print",
+            period: "Period",
+            user: "User",
+            gross: "Gross",
+            net: "Net"
         },
         notFound: {
             pageNotFound: "404 - Page not found",

--- a/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
+import api from '../utils/api';
+import '../styles/AdminPayslipsPageScoped.css';
+import { useTranslation } from '../context/LanguageContext';
+
+const AdminPayslipsPage = () => {
+  const [payslips, setPayslips] = useState([]);
+  const { t } = useTranslation();
+
+  const fetchPending = () => {
+    api.get('/api/payslips/admin/pending').then(res => {
+      setPayslips(res.data);
+    });
+  };
+
+  const approve = (id) => {
+    const comment = prompt(t('payslips.approve'));
+    api.post(`/api/payslips/approve/${id}`, null, { params: { comment } }).then(() => fetchPending());
+  };
+
+  const approveAll = () => {
+    const comment = prompt(t('payslips.approveAll'));
+    api.post('/api/payslips/approve-all', null, { params: { comment } }).then(() => fetchPending());
+  };
+
+  const exportCsv = () => {
+    api.get('/api/payslips/admin/export', { responseType: 'blob' }).then(res => {
+      const url = window.URL.createObjectURL(new Blob([res.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'payslips.csv');
+      document.body.appendChild(link);
+      link.click();
+    });
+  };
+
+  useEffect(() => {
+    fetchPending();
+  }, []);
+
+  const backup = () => {
+    api.get('/api/payslips/admin/backup');
+  };
+
+  return (
+    <div className="admin-payslips-page scoped-dashboard">
+      <Navbar />
+      <h2>{t('payslips.pendingTitle')}</h2>
+      <button className="approve-all" onClick={approveAll}>{t('payslips.approveAll')}</button>
+      <button className="approve-all" onClick={exportCsv}>{t('payslips.exportCsv')}</button>
+      <button className="approve-all" onClick={backup}>{t('payslips.backup')}</button>
+      <table className="payslip-table">
+        <thead>
+          <tr>
+            <th>{t('payslips.user')}</th>
+            <th>{t('payslips.period', 'Zeitraum')}</th>
+            <th>{t('payslips.gross')}</th>
+            <th>{t('payslips.net')}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {payslips.map(ps => (
+            <tr key={ps.id}>
+              <td>{ps.userId}</td>
+              <td>{ps.periodStart} - {ps.periodEnd}</td>
+              <td>{ps.grossSalary?.toFixed(2)} CHF</td>
+              <td>{ps.netSalary?.toFixed(2)} CHF</td>
+              <td><button onClick={() => approve(ps.id)}>{t('payslips.approve')}</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AdminPayslipsPage;

--- a/Chrono-frontend/src/pages/PayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/PayslipsPage.jsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
+import api from '../utils/api';
+import '../styles/PayslipsPageScoped.css';
+import { useAuth } from '../context/AuthContext';
+import { useTranslation } from '../context/LanguageContext';
+import jsPDF from 'jspdf';
+
+const PayslipsPage = () => {
+  const { currentUser } = useAuth();
+  const { t } = useTranslation();
+  const [payslips, setPayslips] = useState([]);
+
+  const handlePrint = (ps) => {
+    const doc = new jsPDF();
+    doc.setFontSize(16);
+    doc.text(t('payslips.title'), 105, 20, { align: 'center' });
+    doc.setFontSize(12);
+    doc.text(`${t('payslips.period')}: ${ps.periodStart} - ${ps.periodEnd}`, 20, 40);
+    doc.text(`${t('payslips.gross')}: ${ps.grossSalary?.toFixed(2)} CHF`, 20, 50);
+    doc.text(`${t('payslips.net')}: ${ps.netSalary?.toFixed(2)} CHF`, 20, 60);
+    doc.save(`Payslip_${ps.periodStart}_${ps.periodEnd}.pdf`);
+  };
+
+  useEffect(() => {
+    if (!currentUser) return;
+    api.get(`/api/payslips/user/${currentUser.id}`).then(res => {
+      setPayslips(res.data);
+    });
+  }, [currentUser]);
+
+  return (
+    <div className="payslips-page scoped-dashboard">
+      <Navbar />
+      <h2>{t('payslips.title')}</h2>
+      <table className="payslip-table">
+        <thead>
+          <tr>
+            <th>{t('payslips.period', 'Zeitraum')}</th>
+            <th>{t('payslips.gross')}</th>
+            <th>{t('payslips.net')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {payslips.map(ps => (
+            <tr key={ps.id}>
+              <td>{ps.periodStart} - {ps.periodEnd}</td>
+              <td>{ps.grossSalary?.toFixed(2)} CHF</td>
+              <td>{ps.netSalary?.toFixed(2)} CHF</td>
+              <td>
+                <button onClick={() => handlePrint(ps)}>{t('payslips.print')}</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PayslipsPage;

--- a/Chrono-frontend/src/styles/AdminPayslipsPageScoped.css
+++ b/Chrono-frontend/src/styles/AdminPayslipsPageScoped.css
@@ -1,0 +1,32 @@
+.admin-payslips-page.scoped-dashboard {
+  --c-bg: #f4f6ff;
+  --c-text: #1e1f22;
+  --c-card: #ffffff;
+  --c-border: #d5d8e5;
+  background: var(--c-bg);
+  color: var(--c-text);
+  min-height: 100vh;
+  padding: 1.5rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.payslip-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.payslip-table th,
+.payslip-table td {
+  border: 1px solid var(--c-border);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.approve-all {
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  cursor: pointer;
+}

--- a/Chrono-frontend/src/styles/PayslipsPageScoped.css
+++ b/Chrono-frontend/src/styles/PayslipsPageScoped.css
@@ -1,0 +1,42 @@
+.payslips-page.scoped-dashboard {
+  --c-text: #1e1f22;
+  --c-bg: #f4f6ff;
+  --c-card: #ffffff;
+  --c-border: #d5d8e5;
+  font-family: "Poppins", sans-serif;
+  background: var(--c-bg);
+  color: var(--c-text);
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+[data-theme="dark"] .payslips-page.scoped-dashboard {
+  --c-text: #e5e7ec;
+  --c-bg: #15171c;
+  --c-card: #212429;
+  --c-border: #3a3f4b;
+}
+
+.payslip-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.payslip-table th,
+.payslip-table td {
+  border: 1px solid var(--c-border);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.payslip-table th {
+  background: var(--c-card);
+}
+
+.payslip-table button {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- translate payroll pages fully
- update AdminPayslipsPage and PayslipsPage to use language keys
- localise PDF labels for salary information

## Testing
- `sh mvnw -q test` *(failed: cannot open maven-wrapper.properties)*
- `npm test --silent` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791b6270ac83258b698ea1edea96ae