### PR TITLE
Add contact form and style legal pages

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
                     auth.requestMatchers("/api/nfc/write-sector0").permitAll();
                     // Den Mail-Endpunkt öffentlich freigeben
                     auth.requestMatchers(HttpMethod.POST, "/api/apply").permitAll();
+                    auth.requestMatchers(HttpMethod.POST, "/api/contact").permitAll();
                     // Schütze Admin-Endpunkte – nur Nutzer mit ROLE_ADMIN dürfen zugreifen
                     auth.requestMatchers("/api/admin/**").hasRole("ADMIN");
                     auth.requestMatchers("/api/superadmin/**").hasRole("SUPERADMIN");

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ContactController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ContactController.java
@@ -1,0 +1,21 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.dto.ContactMessage;
+import com.chrono.chrono.services.EmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/contact")
+public class ContactController {
+
+    @Autowired
+    private EmailService emailService;
+
+    @PostMapping
+    public ResponseEntity<?> sendContact(@RequestBody ContactMessage message) {
+        emailService.sendContactMail(message);
+        return ResponseEntity.ok().body("{\"success\":true}");
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ContactMessage.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ContactMessage.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ContactMessage {
+    private String name;
+    private String email;
+    private String message;
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
@@ -1,6 +1,7 @@
 package com.chrono.chrono.services;
 
 import com.chrono.chrono.dto.ApplicationData;
+import com.chrono.chrono.dto.ContactMessage;
 import com.chrono.chrono.entities.Payslip;
 import com.chrono.chrono.entities.User;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,18 @@ public class EmailService {
         message.setText(mailText);
 
         mailSender.send(message);
+    }
+
+    public void sendContactMail(ContactMessage contact) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom("siefertchristopher@chrono-logisch.ch");
+        msg.setTo("siefertchristopher@chrono-logisch.ch");
+        msg.setSubject("Kontaktanfrage von " + contact.getName());
+        String text = "Name: " + contact.getName() + "\n" +
+                "E-Mail: " + contact.getEmail() + "\n\n" +
+                contact.getMessage();
+        msg.setText(text);
+        mailSender.send(msg);
     }
 
     public void sendPayslipGeneratedMail(User user, Payslip payslip) {

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -511,6 +511,13 @@ const translations = {
             step3Text: "Echtzeit-Insights & Abwesenheiten verwalten.",
             newsletterPlaceholder: "Deine E-Mail",
             newsletterButton: "Abonnieren",
+            contactTitle: "Kontakt",
+            contactName: "Name",
+            contactEmail: "E-Mail",
+            contactMessage: "Nachricht",
+            contactButton: "Absenden",
+            contactSuccess: "Nachricht gesendet!",
+            contactError: "Fehler beim Senden.",
         },
 
         // Falls du "search", "darkMode", "lightMode" usw. nutzt
@@ -1058,6 +1065,13 @@ const translations = {
             step3Text: "Realtime insights & absence management.",
             newsletterPlaceholder: "Your email",
             newsletterButton: "Subscribe",
+            contactTitle: "Contact",
+            contactName: "Name",
+            contactEmail: "Email",
+            contactMessage: "Message",
+            contactButton: "Send",
+            contactSuccess: "Message sent!",
+            contactError: "Failed to send message.",
         },
 
         // Falls du "search", "darkMode", "lightMode" etc. nutzt

--- a/Chrono-frontend/src/pages/AGB.jsx
+++ b/Chrono-frontend/src/pages/AGB.jsx
@@ -1,9 +1,13 @@
 // src/pages/AGB.jsx
 import React from 'react';
+import Navbar from '../components/Navbar';
+import '../styles/LegalPages.css';
 
 const AGB = () => {
     return (
-        <div style={{ maxWidth: '800px', margin: '0 auto', padding: '20px' }}>
+        <>
+        <Navbar />
+        <div className="legal-page">
             <h1>Allgemeine Geschäftsbedingungen (AGB)</h1>
 
             <h2>1. Geltungsbereich</h2>
@@ -152,6 +156,7 @@ const AGB = () => {
                 von Montag bis Freitag (11:00–15:00) zur Verfügung.
             </p>
         </div>
+        </>
     );
 };
 

--- a/Chrono-frontend/src/pages/Impressum.jsx
+++ b/Chrono-frontend/src/pages/Impressum.jsx
@@ -1,9 +1,13 @@
 // src/pages/Impressum.jsx
 import React from 'react';
+import Navbar from '../components/Navbar';
+import '../styles/LegalPages.css';
 
 const Impressum = () => {
     return (
-        <div style={{ maxWidth: '800px', margin: '0 auto', padding: '20px' }}>
+        <>
+        <Navbar />
+        <div className="legal-page">
             <h1>Impressum</h1>
 
             <p>
@@ -39,6 +43,7 @@ const Impressum = () => {
                 <em>Stand: Mai 2025</em>
             </p>
         </div>
+        </>
     );
 };
 

--- a/Chrono-frontend/src/pages/LandingPage.jsx
+++ b/Chrono-frontend/src/pages/LandingPage.jsx
@@ -4,6 +4,9 @@ import { Link } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import "../styles/LandingPageScoped.css";
 import { useTranslation } from "../context/LanguageContext";
+import { useState } from "react";
+import { useNotification } from "../context/NotificationContext";
+import api from "../utils/api";
 
 /* ---------- Sub-Components ------------------------------------------ */
 const FeatureCard = ({ icon, title, text }) => (
@@ -24,6 +27,29 @@ const StepCard = ({ n, title, text }) => (
 
 const LandingPage = () => {
     const { t } = useTranslation();
+    const { notify } = useNotification();
+    const [contact, setContact] = useState({ name: "", email: "", message: "" });
+    const [sending, setSending] = useState(false);
+
+    const handleContactChange = (e) => {
+        setContact({ ...contact, [e.target.name]: e.target.value });
+    };
+
+    const submitContact = async (e) => {
+        e.preventDefault();
+        if (sending) return;
+        setSending(true);
+        try {
+            await api.post("/api/contact", contact);
+            notify(t("landingPage.contactSuccess", "Nachricht gesendet."));
+            setContact({ name: "", email: "", message: "" });
+        } catch (err) {
+            console.error(err);
+            notify(t("landingPage.contactError", "Fehler beim Senden."));
+        } finally {
+            setSending(false);
+        }
+    };
 
     const features = [
         {
@@ -161,6 +187,41 @@ const LandingPage = () => {
                                 <StepCard key={idx} n={s.n} title={s.title} text={s.text} />
                             ))}
                         </div>
+                    </div>
+                </section>
+
+                {/* CONTACT ----------------------------------------------------- */}
+                <section className="contact-section site-section" id="contact">
+                    <div className="section-inner">
+                        <h3>{t('landingPage.contactTitle', 'Kontakt')}</h3>
+                        <form className="contact-form" onSubmit={submitContact}>
+                            <input
+                                name="name"
+                                type="text"
+                                placeholder={t('landingPage.contactName', 'Name')}
+                                value={contact.name}
+                                onChange={handleContactChange}
+                                required
+                            />
+                            <input
+                                name="email"
+                                type="email"
+                                placeholder={t('landingPage.contactEmail', 'E-Mail')}
+                                value={contact.email}
+                                onChange={handleContactChange}
+                                required
+                            />
+                            <textarea
+                                name="message"
+                                placeholder={t('landingPage.contactMessage', 'Nachricht')}
+                                value={contact.message}
+                                onChange={handleContactChange}
+                                required
+                            />
+                            <button className="btn primary" disabled={sending}>
+                                {t('landingPage.contactButton', 'Absenden')}
+                            </button>
+                        </form>
                     </div>
                 </section>
 

--- a/Chrono-frontend/src/styles/LandingPageScoped.css
+++ b/Chrono-frontend/src/styles/LandingPageScoped.css
@@ -254,6 +254,28 @@ header.landing-hero p {
   margin-bottom: 0.7rem;
 }
 
+/* ---------- CONTACT -------------------------------------------------- */
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  max-width: 420px;
+  margin: 0 auto;
+}
+.contact-form input,
+.contact-form textarea {
+  padding: 0.9rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface-glass);
+  backdrop-filter: blur(8px);
+  color: var(--c-text-main);
+}
+.contact-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
 /* ---------- NEWSLETTER ---------------------------------------------- */
 .newsletter-form {
   display: flex;

--- a/Chrono-frontend/src/styles/LegalPages.css
+++ b/Chrono-frontend/src/styles/LegalPages.css
@@ -1,0 +1,25 @@
+.legal-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: var(--u-radius);
+  color: var(--c-text);
+  transition: background var(--u-dur) var(--u-ease),
+              color var(--u-dur) var(--u-ease),
+              border-color var(--u-dur) var(--u-ease);
+}
+
+.legal-page h1,
+.legal-page h2 {
+  color: var(--c-text);
+}
+
+.legal-page a {
+  color: var(--c-pri);
+}
+
+.legal-page ul {
+  padding-left: 1.2rem;
+}


### PR DESCRIPTION
## Summary
- style legal pages in both themes
- add navbar to AGB and Impressum pages
- provide contact form on landing page and translations
- implement backend mail endpoint to send contact messages

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879772bd4ac8325a2404557ec8fe765