### PR TITLE
Update legal pages design

### DIFF
--- a/Chrono-frontend/src/pages/AGB.jsx
+++ b/Chrono-frontend/src/pages/AGB.jsx
@@ -7,6 +7,7 @@ const AGB = () => {
     return (
         <>
         <Navbar />
+        <div className="legal-wrapper">
         <div className="legal-page">
             <h1>Allgemeine Geschäftsbedingungen (AGB)</h1>
 
@@ -155,6 +156,7 @@ const AGB = () => {
                 </a>{" "}
                 von Montag bis Freitag (11:00–15:00) zur Verfügung.
             </p>
+        </div>
         </div>
         </>
     );

--- a/Chrono-frontend/src/pages/Impressum.jsx
+++ b/Chrono-frontend/src/pages/Impressum.jsx
@@ -7,6 +7,7 @@ const Impressum = () => {
     return (
         <>
         <Navbar />
+        <div className="legal-wrapper">
         <div className="legal-page">
             <h1>Impressum</h1>
 
@@ -42,6 +43,7 @@ const Impressum = () => {
             <p>
                 <em>Stand: Mai 2025</em>
             </p>
+        </div>
         </div>
         </>
     );

--- a/Chrono-frontend/src/styles/LegalPages.css
+++ b/Chrono-frontend/src/styles/LegalPages.css
@@ -1,4 +1,29 @@
-.legal-page {
+.legal-wrapper {
+  /* Farben wie LandingPage */
+  --c-text: #1e2438;
+  --c-bg: #f6f9ff;
+  --c-card: rgba(255, 255, 255, 0.82);
+  --c-border: #d5d8e7;
+  --c-muted: #506080;
+  --c-pri: #4285ff;
+  --c-pri-dim: #356dff;
+
+  min-height: 100vh;
+  background: var(--c-bg);
+  padding: 2rem 1rem;
+}
+
+[data-theme="dark"] .legal-wrapper {
+  --c-text: #e6ecff;
+  --c-bg: #0b1020;
+  --c-card: rgba(25, 28, 46, 0.7);
+  --c-border: #3b3f54;
+  --c-muted: #95a3c6;
+  --c-pri: #5b8fff;
+  --c-pri-dim: #407bff;
+}
+
+.legal-wrapper .legal-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 2rem;
@@ -11,15 +36,15 @@
               border-color var(--u-dur) var(--u-ease);
 }
 
-.legal-page h1,
-.legal-page h2 {
+.legal-wrapper .legal-page h1,
+.legal-wrapper .legal-page h2 {
   color: var(--c-text);
 }
 
-.legal-page a {
+.legal-wrapper .legal-page a {
   color: var(--c-pri);
 }
 
-.legal-page ul {
+.legal-wrapper .legal-page ul {
   padding-left: 1.2rem;
 }

--- a/Chrono-frontend/src/styles/Login.css
+++ b/Chrono-frontend/src/styles/Login.css
@@ -9,19 +9,20 @@
 */
 
 /* --------------------------- Variablen für LIGHT --------------------------- */
-.scoped-login {
-  --c-text: #1f1f1f;
-  --c-bg: #f7f8fa;
-  --c-card: #ffffff;
-  --c-border: #d1d4e2;
-  --c-muted: #545863;
 
-  --c-primary: #475bff;
-  --c-primary-hover: #6b7cff;
+.scoped-login {
+  --c-text: #1e2438; /* wie LandingPage */
+  --c-bg: #f6f9ff;
+  --c-card: rgba(255, 255, 255, 0.82);
+  --c-border: #d5d8e7;
+  --c-muted: #506080;
+
+  --c-primary: #4285ff;
+  --c-primary-hover: #356dff;
   --c-danger: #ed5757;
   --c-secondary: #48bb78; /* z.B. für Punch-Messages */
 
-  --radius: 8px;
+  --radius: 16px;
   --transition: 0.3s;
   --font-family: "Poppins", system-ui, sans-serif;
 
@@ -31,18 +32,18 @@
 
 /* --------------------------- Variablen für DARK --------------------------- */
 [data-theme="dark"] .scoped-login {
-  --c-text: #e4e6eb;
-  --c-bg: #18191a;
-  --c-card: #242526;
-  --c-border: #484a4d;
-  --c-muted: #9da1b2;
+  --c-text: #e6ecff;
+  --c-bg: #0b1020;
+  --c-card: rgba(25, 28, 46, 0.7);
+  --c-border: #3b3f54;
+  --c-muted: #95a3c6;
 
-  --c-primary: #475bff;
-  --c-primary-hover: #6b7cff;
+  --c-primary: #5b8fff;
+  --c-primary-hover: #407bff;
   --c-danger: #ed5757;
   --c-secondary: #48bb78;
 
-  --radius: 8px;
+  --radius: 16px;
   --transition: 0.3s;
   /* Font-Family bleibt gleich */
 }


### PR DESCRIPTION
## Summary
- wrap AGB and Impressum content in `.legal-wrapper`
- style legal pages with the landing page color palette

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879794ce2548325963ed4da5c3e4756