### PR TITLE
Move language switch into navbar

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -1,10 +1,10 @@
 /****************************************
  * Navbar.jsx · mit Hamburger-Menü und Changelog
  ****************************************/
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { useTranslation } from '../context/LanguageContext';
+import { LanguageContext, useTranslation } from '../context/LanguageContext';
 
 // Importiere dein CSS:
 import '../styles/Navbar.css';
@@ -17,6 +17,7 @@ import ChangelogModal from './ChangelogModal'; // Stellen Sie sicher, dass diese
 const Navbar = () => {
     const { authToken, logout, currentUser } = useAuth();
     const { t } = useTranslation();
+    const { language, setLanguage } = useContext(LanguageContext);
     const location = useLocation();
 
     // Bestimme, ob es sich um eine "öffentliche" Seite handelt
@@ -175,6 +176,15 @@ const Navbar = () => {
                         <button onClick={toggleTheme}>
                             {theme === 'light' ? t('darkMode', 'Dark Mode') : t('lightMode', 'Light Mode')}
                         </button>
+                    </li>
+                    <li>
+                        <div className="language-switch">
+                            <label>{t('navbar.languageLabel', 'Sprache')}:</label>
+                            <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+                                <option value="de">DE</option>
+                                <option value="en">EN</option>
+                            </select>
+                        </div>
                     </li>
                 </ul>
             </nav>

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -208,6 +208,7 @@ const translations = {
             whatsNew: "Was ist neu?",
             history: "Update-Verlauf",
             brightness: "Helligkeit",
+            languageLabel: "Sprache",
         },
         // ----------------------------------------------------------------------
         // Dashboard title / corrections
@@ -767,6 +768,7 @@ const translations = {
             whatsNew: "What's New?",
             history: "Update History",
             brightness: "brightness",
+            languageLabel: "Language",
         },
         // ----------------------------------------------------------------------
         // Dashboard / corrections

--- a/Chrono-frontend/src/pages/Login.jsx
+++ b/Chrono-frontend/src/pages/Login.jsx
@@ -1,11 +1,11 @@
 // src/pages/Login.jsx
-import { useState, useEffect, useRef, useContext } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import Navbar from '../components/Navbar';
 import '../styles/Login.css';
 import api from '../utils/api';
-import { LanguageContext, useTranslation } from '../context/LanguageContext';
+import { useTranslation } from '../context/LanguageContext';
 import { Howl } from 'howler';
 import stampMp3 from '/sounds/stamp.mp3';
 
@@ -28,7 +28,6 @@ const Login = () => {
     const { login} = useAuth();
     const navigate = useNavigate();
     const location = useLocation();
-    const { language, setLanguage } = useContext(LanguageContext);
     const { t } = useTranslation();
 
     const [form, setForm] = useState({ username: '', password: '' });
@@ -127,16 +126,7 @@ const Login = () => {
                         {error && <p className="error-message">{error}</p>}
                         {punchMsg && <div className="punch-message">{punchMsg}</div>}
 
-                        <div className="language-switch">
-                            <label>{t('login.languageLabel', 'Sprache')}:</label>
-                            <select
-                                value={language}
-                                onChange={(e) => setLanguage(e.target.value)}
-                            >
-                                <option value="de">DE</option>
-                                <option value="en">EN</option>
-                            </select>
-                        </div>
+
 
                         <form onSubmit={handleSubmit}>
                             <label htmlFor="username">

--- a/Chrono-frontend/src/styles/Login.css
+++ b/Chrono-frontend/src/styles/Login.css
@@ -138,34 +138,6 @@
 }
 
 /* Sprache-Selector */
-.scoped-login .language-switch {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
-}
-
-.scoped-login .language-switch label {
-  margin-right: 0.75rem;
-  font-weight: bold;
-  color: var(--c-text);
-}
-
-.scoped-login .language-switch select {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius);
-  font-size: 1rem;
-  color: var(--c-text);
-  background-color: #fff; /* wird im Dark Mode überschrieben */
-  transition:
-    border-color 0.2s,
-    box-shadow 0.2s;
-}
-.scoped-login .language-switch select:focus {
-  border-color: var(--c-primary);
-  box-shadow: 0 0 5px rgba(90, 103, 216, 0.5);
-}
 
 /* Meldungen (Fehler/Punch) */
 .scoped-login .error-message {
@@ -235,7 +207,6 @@
 [data-theme="dark"] .scoped-login .login-left-content h1,
 [data-theme="dark"] .scoped-login .login-left-content p,
 [data-theme="dark"] .scoped-login .login-left-content form label,
-[data-theme="dark"] .scoped-login .language-switch label,
 [data-theme="dark"] .scoped-login .register-cta,
 [data-theme="dark"] .scoped-login .error-message,
 [data-theme="dark"] .scoped-login .punch-message {
@@ -251,11 +222,6 @@
   color: #bcbcbc;
 }
 
-[data-theme="dark"] .scoped-login .language-switch select {
-  background-color: #3a3b3c;
-  border: 1px solid var(--c-border);
-  color: #f0f0f0;
-}
 
 /* Rechte Spalte im Dark Mode -> dunklere Overlay */
 [data-theme="dark"] .scoped-login .login-right {
@@ -310,18 +276,7 @@
   }
 
   /* Sprache-Switch in eine Zeile, minimal kleiner */
-  .scoped-login .language-switch {
-    justify-content: center;
-    margin-bottom: 1rem;
-  }
-  .scoped-login .language-switch label {
-    font-size: 0.85rem;
-    margin-right: 0.5rem;
-  }
-  .scoped-login .language-switch select {
-    font-size: 0.85rem;
-    padding: 0.4rem 0.7rem;
-  }
+
 
   /* Registrierungshinweis + Error kompakter */
   .scoped-login .register-cta,

--- a/Chrono-frontend/src/styles/Navbar.css
+++ b/Chrono-frontend/src/styles/Navbar.css
@@ -279,6 +279,22 @@
   min-width: 30px; /* Platz für "100%" */
   text-align: right;
 }
+.scoped-navbar .language-switch {
+  display: flex;
+  align-items: center;
+  gap: var(--ud-gap-xs, 0.5rem);
+}
+.scoped-navbar .language-switch label {
+  font-size: 0.85rem;
+  color: var(--nav-text-muted);
+}
+.scoped-navbar .language-switch select {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--nav-border);
+  border-radius: var(--nav-radius);
+  background-color: var(--nav-bg);
+  color: var(--nav-text);
+}
 .scoped-navbar .navbar-links button.theme-toggle {
   /* Button für Theme-Wechsel */
   background-color: transparent;


### PR DESCRIPTION
## Summary
- drop language selection from the login page
- add dropdown for language selection in the navbar
- style the new language switch
- update translations with `languageLabel` for navbar

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68797de532ac8325b8a133e5f86c1873