### PR TITLE
Improve dark/light mode on import page

### DIFF
--- a/Chrono-frontend/src/TimeTrackingImport.jsx
+++ b/Chrono-frontend/src/TimeTrackingImport.jsx
@@ -129,10 +129,12 @@ function TimeTrackingImport() {
 
         const { message, importedCount, successMessages, errors: responseErrors } = uploadResponse;
 
+        const msgClass = responseErrors && responseErrors.length > 0 ? 'feedback-warning' : 'feedback-success';
+
         return (
-            <div style={{ marginTop: '20px', padding: '10px', border: '1px solid #eee' }}>
+            <div className="feedback-container">
                 <h4>Import Ergebnis:</h4>
-                {message && <p style={{ color: responseErrors && responseErrors.length > 0 ? 'orange' : 'green' }}>{message}</p>}
+                {message && <p className={msgClass}>{message}</p>}
                 {typeof importedCount === 'number' && <p>Erfolgreich importierte Einträge: {importedCount}</p>}
 
                 {successMessages && successMessages.length > 0 && (
@@ -140,7 +142,7 @@ function TimeTrackingImport() {
                         <h5>Erfolgsmeldungen:</h5>
                         <ul style={{ listStyleType: 'disc', paddingLeft: '20px', maxHeight: '150px', overflowY: 'auto' }}>
                             {successMessages.map((msg, index) => (
-                                <li key={`succ-${index}`} style={{ color: 'green', fontSize: '0.9em' }}>{msg}</li>
+                                <li key={`succ-${index}`} className="feedback-success" style={{ fontSize: '0.9em' }}>{msg}</li>
                             ))}
                         </ul>
                     </div>
@@ -149,7 +151,7 @@ function TimeTrackingImport() {
                 {responseErrors && responseErrors.length > 0 && (
                     <div style={{ marginTop: '10px' }}>
                         <h5>Fehlerdetails ({responseErrors.length}):</h5>
-                        <ul style={{ listStyleType: 'disc', paddingLeft: '20px', maxHeight: '150px', overflowY: 'auto', color: 'red' }}>
+                        <ul style={{ listStyleType: 'disc', paddingLeft: '20px', maxHeight: '150px', overflowY: 'auto' }} className="feedback-warning">
                             {responseErrors.map((err, index) => (
                                 <li key={`err-${index}`} style={{ fontSize: '0.9em' }}>{typeof err === 'object' ? JSON.stringify(err) : err}</li>
                             ))}
@@ -180,12 +182,12 @@ function TimeTrackingImport() {
                                         <td><input value={row.punchType || ''} onChange={e => handleRowChange(idx, 'punchType', e.target.value)} /></td>
                                         <td><input value={row.source || ''} onChange={e => handleRowChange(idx, 'source', e.target.value)} /></td>
                                         <td><input value={row.note || ''} onChange={e => handleRowChange(idx, 'note', e.target.value)} /></td>
-                                        <td style={{color:'red'}}>{row.error}</td>
+                                        <td className="error-cell">{row.error}</td>
                                     </tr>
                                 ))}
                             </tbody>
                         </table>
-                        <button onClick={handleReimport} disabled={isReimporting} style={{marginTop:'10px'}}>
+                        <button onClick={handleReimport} disabled={isReimporting} className="import-button" style={{marginTop:'10px'}}>
                             {isReimporting ? 'Importiere...' : 'Korrigierte Zeilen importieren'}
                         </button>
                         {isReimporting && <div className="import-progress"><div className="import-progress-bar" style={{width: `${reimportProgress}%`}}/></div>}
@@ -197,37 +199,31 @@ function TimeTrackingImport() {
 
 
     return (
-        <div style={{ margin: '20px', padding: '20px', border: '1px solid #ccc', borderRadius: '5px' }}>
-            <h3>Stempelzeiten aus Excel importieren</h3>
-            <form onSubmit={handleSubmit}>
-                <div>
-                    <input
-                        type="file"
-                        onChange={handleFileChange}
-                        accept=".xlsx, .xls"
-                        // ref={fileInputRef} // EINKOMMENTIEREN, falls benötigt
-                        style={{ marginBottom: '10px', padding: '8px', border: '1px solid #ddd', borderRadius: '4px' }}
-                    />
-                </div>
-                <button
-                    type="submit"
-                    disabled={isUploading || !selectedFile}
-                    style={{
-                        padding: '10px 15px',
-                        backgroundColor: isUploading || !selectedFile ? '#ccc' : '#007bff',
-                        color: 'white',
-                        border: 'none',
-                        borderRadius: '4px',
-                        cursor: isUploading || !selectedFile ? 'not-allowed' : 'pointer'
-                    }}
-                >
-                    {isUploading ? 'Wird hochgeladen...' : 'Importieren'}
-                </button>
-                {isUploading && <div className="import-progress" style={{marginTop:'8px'}}><div className="import-progress-bar" style={{width:`${progress}%`}} /></div>}
-            </form>
-            {error && <p style={{ color: 'red', marginTop: '10px' }}>{error}</p>}
-            {renderFeedback()}
-            <div style={{marginTop: '20px', fontSize: '0.9em', color: '#555'}}>
+        <div className="time-import-page">
+            <div className="time-import-container">
+                <h3>Stempelzeiten aus Excel importieren</h3>
+                <form onSubmit={handleSubmit} className="import-form">
+                    <div>
+                        <input
+                            type="file"
+                            onChange={handleFileChange}
+                            accept=".xlsx, .xls"
+                            // ref={fileInputRef} // EINKOMMENTIEREN, falls benötigt
+                            className="file-input"
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={isUploading || !selectedFile}
+                        className="import-button"
+                    >
+                        {isUploading ? 'Wird hochgeladen...' : 'Importieren'}
+                    </button>
+                    {isUploading && <div className="import-progress"><div className="import-progress-bar" style={{width:`${progress}%`}} /></div>}
+                </form>
+                {error && <p className="error-message">{error}</p>}
+                {renderFeedback()}
+                <div className="hint-text">
                 <p><strong>Hinweis zum Excel-Format:</strong></p>
                 <ul>
                     <li>Die erste Zeile wird als Kopfzeile ignoriert.</li>
@@ -239,6 +235,7 @@ function TimeTrackingImport() {
                     <li>Spalte F: Arbeitsende (Format: HH:mm, z.B. 17:00)</li>
                     <li>Spalte G: Tagesnotiz (optional)</li>
                 </ul>
+                </div>
             </div>
         </div>
     );

--- a/Chrono-frontend/src/styles/TimeTrackingImport.css
+++ b/Chrono-frontend/src/styles/TimeTrackingImport.css
@@ -1,25 +1,112 @@
+/* =========================================================================
+   TimeTrackingImport Scoped Styles
+   Supports light and dark mode via CSS variables
+   ========================================================================= */
+
+.time-import-page {
+  font-family: "Poppins", sans-serif;
+  background: var(--c-bg);
+  color: var(--c-text);
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+.time-import-container {
+  max-width: 700px;
+  margin: 0 auto;
+  background: var(--c-card);
+  border: 1px solid var(--c-border);
+  border-radius: var(--u-radius);
+  padding: var(--u-card-padding);
+}
+
+.file-input {
+  padding: 0.5rem;
+  border: 1px solid var(--c-border);
+  border-radius: var(--u-radius-sm);
+  background: var(--c-surface);
+  color: var(--c-text);
+}
+
+.import-button {
+  padding: 0.5rem 1.2rem;
+  background: var(--c-pri);
+  color: #fff;
+  border: none;
+  border-radius: var(--u-radius-sm);
+  cursor: pointer;
+}
+
+.import-button:disabled {
+  background: var(--c-muted);
+  cursor: not-allowed;
+}
+
 .import-progress {
   width: 100%;
   height: 8px;
-  background: #eee;
+  background: var(--c-border);
   border-radius: 4px;
   overflow: hidden;
+  margin-top: 0.5rem;
 }
+
 .import-progress-bar {
   height: 100%;
-  background: #007bff;
+  background: var(--c-pri);
   width: 0;
   transition: width 0.3s;
 }
+
 .invalid-table {
   width: 100%;
   border-collapse: collapse;
+  margin-top: 1rem;
+  background: var(--c-card);
 }
-.invalid-table th, .invalid-table td {
-  border: 1px solid #ccc;
+
+.invalid-table th,
+.invalid-table td {
+  border: 1px solid var(--c-border);
   padding: 4px;
   font-size: 0.8rem;
 }
+
 .invalid-table input {
   width: 100%;
+  background: var(--c-surface);
+  color: var(--c-text);
+  border: 1px solid var(--c-border);
+  border-radius: var(--u-radius-xs);
+}
+
+.invalid-table td.error-cell {
+  color: var(--c-error);
+}
+
+.feedback-container {
+  margin-top: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--c-border);
+  border-radius: var(--u-radius-sm);
+  background: var(--c-card);
+}
+
+.feedback-success {
+  color: var(--c-success);
+}
+
+.feedback-warning {
+  color: var(--c-warn);
+}
+
+.error-message {
+  margin-top: 0.5rem;
+  color: var(--c-error);
+}
+
+.hint-text {
+  margin-top: 1.25rem;
+  font-size: 0.9em;
+  color: var(--c-muted);
 }


### PR DESCRIPTION
## Summary
- update `TimeTrackingImport.css` to use theme variables
- restructure `TimeTrackingImport.jsx` to use CSS classes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879807b15b48325813e019fb9cf9aa7