### PR TITLE
Fix payslip PDF regeneration

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
@@ -193,25 +193,35 @@ public class PayrollService {
     }
 
 
-    @Transactional(readOnly = true)
+    @Transactional
     public byte[] getPayslipPdf(Long id) {
         Payslip ps = payslipRepository.findById(id).orElseThrow();
-        if (ps.getPdfPath() == null) {
+        String path = ps.getPdfPath();
+        byte[] data = null;
+
+        if (path != null) {
+            try {
+                data = java.nio.file.Files.readAllBytes(java.nio.file.Path.of(path));
+            } catch (java.io.IOException ignore) {
+                // file missing - will regenerate
+            }
+        }
+
+        if (data == null) {
             String generated = pdfService.generatePayslipPdf(ps);
             if (generated == null) {
                 return null;
             }
             ps.setPdfPath(generated);
             payslipRepository.save(ps);
-        }
-        try {
-            if (ps.getPdfPath() != null) {
-                return java.nio.file.Files.readAllBytes(java.nio.file.Path.of(ps.getPdfPath()));
+            try {
+                data = java.nio.file.Files.readAllBytes(java.nio.file.Path.of(generated));
+            } catch (java.io.IOException ignore) {
+                return null;
             }
-        } catch (java.io.IOException e) {
-            // handle error if needed
         }
-        return null;
+
+        return data;
 
     }
 }


### PR DESCRIPTION
## Summary
- detect missing PDF file and regenerate when printing a payslip

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM; network unreachable)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1ac1df94832586ac74a1ac344f48