### PR TITLE
Add company address fields

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/CompanyManagementController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/CompanyManagementController.java
@@ -60,6 +60,10 @@ public class CompanyManagementController {
 
         Company company = new Company();
         company.setName(body.getCompanyName().trim());
+        company.setAddressLine1(body.getAddressLine1());
+        company.setAddressLine2(body.getAddressLine2());
+        company.setPostalCode(body.getPostalCode());
+        company.setCity(body.getCity());
         company.setActive(true);
         if (body.getCantonAbbreviation() != null && !body.getCantonAbbreviation().trim().isEmpty()) {
             company.setCantonAbbreviation(body.getCantonAbbreviation().trim().toUpperCase());
@@ -108,6 +112,10 @@ public class CompanyManagementController {
         Company company = new Company();
         company.setId(null); // Sicherstellen, dass es eine neue Entität ist
         company.setName(companyDTO.getName().trim());
+        company.setAddressLine1(companyDTO.getAddressLine1());
+        company.setAddressLine2(companyDTO.getAddressLine2());
+        company.setPostalCode(companyDTO.getPostalCode());
+        company.setCity(companyDTO.getCity());
         company.setActive(companyDTO.isActive()); // Standard auf true oder vom DTO nehmen
         company.setPaid(false); // Standard für neue Firmen
         company.setCanceled(false); // Standard für neue Firmen
@@ -135,6 +143,14 @@ public class CompanyManagementController {
                     if (companyDTO.getName() != null && !companyDTO.getName().trim().isEmpty()) {
                         existingCompany.setName(companyDTO.getName().trim());
                     }
+                    if (companyDTO.getAddressLine1() != null)
+                        existingCompany.setAddressLine1(companyDTO.getAddressLine1());
+                    if (companyDTO.getAddressLine2() != null)
+                        existingCompany.setAddressLine2(companyDTO.getAddressLine2());
+                    if (companyDTO.getPostalCode() != null)
+                        existingCompany.setPostalCode(companyDTO.getPostalCode());
+                    if (companyDTO.getCity() != null)
+                        existingCompany.setCity(companyDTO.getCity());
                     // Das DTO sollte den aktuellen 'active' Status enthalten, nicht nur für den Toggle
                     existingCompany.setActive(companyDTO.isActive());
 
@@ -209,6 +225,10 @@ public class CompanyManagementController {
     public static class CompanyDTO {
         private Long   id;
         private String name;
+        private String addressLine1;
+        private String addressLine2;
+        private String postalCode;
+        private String city;
         private boolean active;
         private int    userCount;
         private boolean paid;
@@ -226,6 +246,10 @@ public class CompanyManagementController {
             CompanyDTO dto = new CompanyDTO();
             dto.id = co.getId();
             dto.name = co.getName();
+            dto.addressLine1 = co.getAddressLine1();
+            dto.addressLine2 = co.getAddressLine2();
+            dto.postalCode = co.getPostalCode();
+            dto.city = co.getCity();
             dto.active = co.isActive();
             dto.userCount = co.getUsers() != null ? co.getUsers().size() : 0;
             dto.paid = co.isPaid();
@@ -244,6 +268,10 @@ public class CompanyManagementController {
         // Getter
         public Long getId() { return id; }
         public String getName() { return name; }
+        public String getAddressLine1() { return addressLine1; }
+        public String getAddressLine2() { return addressLine2; }
+        public String getPostalCode() { return postalCode; }
+        public String getCity() { return city; }
         public boolean isActive() { return active; }
         public int getUserCount() { return userCount; }
         public boolean isPaid() { return paid; }
@@ -260,6 +288,10 @@ public class CompanyManagementController {
         // Setter (wichtig für @RequestBody)
         public void setId(Long id) { this.id = id; }
         public void setName(String name) { this.name = name; }
+        public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
+        public void setAddressLine2(String addressLine2) { this.addressLine2 = addressLine2; }
+        public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+        public void setCity(String city) { this.city = city; }
         public void setActive(boolean active) { this.active = active; }
         public void setUserCount(int userCount) { this.userCount = userCount; }
         public void setPaid(boolean paid) { this.paid = paid; }
@@ -281,6 +313,10 @@ public class CompanyManagementController {
         private String adminFirstName;
         private String adminLastName;
         private String adminEmail;
+        private String addressLine1;
+        private String addressLine2;
+        private String postalCode;
+        private String city;
         private String cantonAbbreviation; // NEU
         private String slackWebhookUrl;
         private String teamsWebhookUrl;
@@ -301,6 +337,14 @@ public class CompanyManagementController {
         public void setAdminLastName(String adminLastName) { this.adminLastName = adminLastName; }
         public String getAdminEmail() { return adminEmail; }
         public void setAdminEmail(String adminEmail) { this.adminEmail = adminEmail; }
+        public String getAddressLine1() { return addressLine1; }
+        public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
+        public String getAddressLine2() { return addressLine2; }
+        public void setAddressLine2(String addressLine2) { this.addressLine2 = addressLine2; }
+        public String getPostalCode() { return postalCode; }
+        public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
         public String getCantonAbbreviation() { return cantonAbbreviation; } // NEU
         public void setCantonAbbreviation(String cantonAbbreviation) { this.cantonAbbreviation = cantonAbbreviation; } // NEU
         public String getSlackWebhookUrl() { return slackWebhookUrl; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/CompanyDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/CompanyDTO.java
@@ -4,6 +4,10 @@ public class CompanyDTO {
 
     private Long   id;
     private String name;
+    private String addressLine1;
+    private String addressLine2;
+    private String postalCode;
+    private String city;
     private boolean active;
     private int    userCount;   // Anzahl der User in dieser Firma
     private boolean paid;
@@ -31,6 +35,18 @@ public class CompanyDTO {
 
     public String getName()           { return name; }
     public void setName(String name)  { this.name = name; }
+
+    public String getAddressLine1() { return addressLine1; }
+    public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
+
+    public String getAddressLine2() { return addressLine2; }
+    public void setAddressLine2(String addressLine2) { this.addressLine2 = addressLine2; }
+
+    public String getPostalCode() { return postalCode; }
+    public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+
+    public String getCity() { return city; }
+    public void setCity(String city) { this.city = city; }
 
     public boolean isActive()         { return active; }
     public void setActive(boolean a)  { this.active = a; }
@@ -60,6 +76,10 @@ public class CompanyDTO {
                 co.isCanceled()
         );
         dto.setCustomerTrackingEnabled(co.getCustomerTrackingEnabled());
+        dto.setAddressLine1(co.getAddressLine1());
+        dto.setAddressLine2(co.getAddressLine2());
+        dto.setPostalCode(co.getPostalCode());
+        dto.setCity(co.getCity());
         return dto;
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/Company.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/Company.java
@@ -18,6 +18,12 @@ public class Company {
 
     private String name;
 
+    // Firmensitz für Rechnungen
+    private String addressLine1;
+    private String addressLine2;
+    private String postalCode;
+    private String city;
+
     private boolean active = true;
 
     // Zahlungsinformationen
@@ -61,6 +67,18 @@ public class Company {
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
+
+    public String getAddressLine1() { return addressLine1; }
+    public void setAddressLine1(String addressLine1) { this.addressLine1 = addressLine1; }
+
+    public String getAddressLine2() { return addressLine2; }
+    public void setAddressLine2(String addressLine2) { this.addressLine2 = addressLine2; }
+
+    public String getPostalCode() { return postalCode; }
+    public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
+
+    public String getCity() { return city; }
+    public void setCity(String city) { this.city = city; }
 
     public boolean isActive() { return active; }
     public void setActive(boolean active) { this.active = active; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PdfService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PdfService.java
@@ -63,10 +63,25 @@ public class PdfService {
             // Firmendaten (rechts)
             String companyName = ps.getUser() != null && ps.getUser().getCompany() != null
                     ? ps.getUser().getCompany().getName() : "";
+            String address1 = ps.getUser() != null && ps.getUser().getCompany() != null
+                    ? ps.getUser().getCompany().getAddressLine1() : null;
+            String address2 = ps.getUser() != null && ps.getUser().getCompany() != null
+                    ? ps.getUser().getCompany().getAddressLine2() : null;
+            String postal = ps.getUser() != null && ps.getUser().getCompany() != null
+                    ? ps.getUser().getCompany().getPostalCode() : null;
+            String city = ps.getUser() != null && ps.getUser().getCompany() != null
+                    ? ps.getUser().getCompany().getCity() : null;
 
             PdfPCell companyCell = new PdfPCell();
             companyCell.addElement(new Phrase(companyName,
                     FontFactory.getFont(FontFactory.HELVETICA_BOLD, 13)));
+            if (address1 != null && !address1.isBlank())
+                companyCell.addElement(new Phrase(address1, FontFactory.getFont(FontFactory.HELVETICA, 10)));
+            if (address2 != null && !address2.isBlank())
+                companyCell.addElement(new Phrase(address2, FontFactory.getFont(FontFactory.HELVETICA, 10)));
+            String plzOrt = ((postal != null ? postal : "") + " " + (city != null ? city : "")).trim();
+            if (!plzOrt.isBlank())
+                companyCell.addElement(new Phrase(plzOrt, FontFactory.getFont(FontFactory.HELVETICA, 10)));
             companyCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
             companyCell.setVerticalAlignment(Element.ALIGN_TOP);
             companyCell.setBorder(Rectangle.NO_BORDER);

--- a/Chrono-backend/src/main/resources/db/schema.sql
+++ b/Chrono-backend/src/main/resources/db/schema.sql
@@ -28,6 +28,10 @@ CREATE TABLE IF NOT EXISTS projects (
 ALTER TABLE time_tracking_entries ADD COLUMN IF NOT EXISTS customer_id BIGINT;
 ALTER TABLE time_tracking_entries ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id);
 ALTER TABLE companies ADD COLUMN IF NOT EXISTS customer_tracking_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS address_line1 VARCHAR(255);
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS address_line2 VARCHAR(255);
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS postal_code VARCHAR(50);
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS city VARCHAR(255);
 ALTER TABLE users ADD COLUMN IF NOT EXISTS last_customer_id BIGINT;
 ALTER TABLE users ADD CONSTRAINT fk_last_customer FOREIGN KEY (last_customer_id) REFERENCES customers(id);
 ALTER TABLE time_tracking_entries ADD COLUMN IF NOT EXISTS project_id BIGINT;

--- a/Chrono-frontend/src/pages/CompanyManagementPage.jsx
+++ b/Chrono-frontend/src/pages/CompanyManagementPage.jsx
@@ -16,6 +16,10 @@ const CompanyManagementPage = () => {
     // Neues Formular: "Nur Firma anlegen"
     const [newCompanyName, setNewCompanyName] = useState('');
     const [newCompanyCanton, setNewCompanyCanton] = useState(''); // NEU
+    const [newAddressLine1, setNewAddressLine1] = useState('');
+    const [newAddressLine2, setNewAddressLine2] = useState('');
+    const [newPostalCode, setNewPostalCode] = useState('');
+    const [newCity, setNewCity] = useState('');
     const [newSlackWebhook, setNewSlackWebhook] = useState('');
     const [newTeamsWebhook, setNewTeamsWebhook] = useState('');
     const [newNotifyVacation, setNewNotifyVacation] = useState(false);
@@ -30,6 +34,10 @@ const CompanyManagementPage = () => {
         adminEmail: '',
         adminFirstName: '',
         adminLastName: '',
+        addressLine1: '',
+        addressLine2: '',
+        postalCode: '',
+        city: '',
         companyCanton: '' // NEU
         ,
         slackWebhookUrl: '',
@@ -75,6 +83,10 @@ const CompanyManagementPage = () => {
             // NEU: cantonAbbreviation im Payload
             const payload = {
                 name: newCompanyName.trim(),
+                addressLine1: newAddressLine1.trim() || null,
+                addressLine2: newAddressLine2.trim() || null,
+                postalCode: newPostalCode.trim() || null,
+                city: newCity.trim() || null,
                 active: true,
                 cantonAbbreviation: newCompanyCanton.trim().toUpperCase() || null,
                 slackWebhookUrl: newSlackWebhook || null,
@@ -85,6 +97,10 @@ const CompanyManagementPage = () => {
             };
             await api.post('/api/superadmin/companies', payload);
             setNewCompanyName('');
+            setNewAddressLine1('');
+            setNewAddressLine2('');
+            setNewPostalCode('');
+            setNewCity('');
             setNewCompanyCanton(''); // NEU
             setNewSlackWebhook('');
             setNewTeamsWebhook('');
@@ -118,6 +134,10 @@ const CompanyManagementPage = () => {
                 adminEmail: createWithAdmin.adminEmail,
                 adminFirstName: createWithAdmin.adminFirstName,
                 adminLastName: createWithAdmin.adminLastName,
+                addressLine1: createWithAdmin.addressLine1.trim() || null,
+                addressLine2: createWithAdmin.addressLine2.trim() || null,
+                postalCode: createWithAdmin.postalCode.trim() || null,
+                city: createWithAdmin.city.trim() || null,
                 // NEU: cantonAbbreviation im Payload
                 cantonAbbreviation: createWithAdmin.companyCanton.trim().toUpperCase() || null,
                 slackWebhookUrl: createWithAdmin.slackWebhookUrl || null,
@@ -137,6 +157,10 @@ const CompanyManagementPage = () => {
                 adminEmail: '',
                 adminFirstName: '',
                 adminLastName: '',
+                addressLine1: '',
+                addressLine2: '',
+                postalCode: '',
+                city: '',
                 companyCanton: '', // NEU
                 slackWebhookUrl: '',
                 teamsWebhookUrl: '',
@@ -198,6 +222,10 @@ const CompanyManagementPage = () => {
         setEditingCompany({
             ...company,
             cantonAbbreviation: company.cantonAbbreviation || '',
+            addressLine1: company.addressLine1 || '',
+            addressLine2: company.addressLine2 || '',
+            postalCode: company.postalCode || '',
+            city: company.city || '',
             slackWebhookUrl: company.slackWebhookUrl || '',
             teamsWebhookUrl: company.teamsWebhookUrl || '',
             notifyVacation: company.notifyVacation || false,
@@ -216,6 +244,10 @@ const CompanyManagementPage = () => {
                 active: editingCompany.active,
                 // NEU: cantonAbbreviation im Payload
                 cantonAbbreviation: editingCompany.cantonAbbreviation.trim().toUpperCase() || null,
+                addressLine1: editingCompany.addressLine1.trim() || null,
+                addressLine2: editingCompany.addressLine2.trim() || null,
+                postalCode: editingCompany.postalCode.trim() || null,
+                city: editingCompany.city.trim() || null,
                 slackWebhookUrl: editingCompany.slackWebhookUrl,
                 teamsWebhookUrl: editingCompany.teamsWebhookUrl,
                 notifyVacation: editingCompany.notifyVacation,
@@ -294,6 +326,31 @@ const CompanyManagementPage = () => {
                                 onChange={(e) => setNewCompanyName(e.target.value)}
                                 required
                             />
+                            <input
+                                type="text"
+                                placeholder="Adresse 1"
+                                value={newAddressLine1}
+                                onChange={(e) => setNewAddressLine1(e.target.value)}
+                            />
+                            <input
+                                type="text"
+                                placeholder="Adresse 2"
+                                value={newAddressLine2}
+                                onChange={(e) => setNewAddressLine2(e.target.value)}
+                            />
+                            <input
+                                type="text"
+                                placeholder="PLZ"
+                                value={newPostalCode}
+                                onChange={(e) => setNewPostalCode(e.target.value)}
+                                style={{ width: '80px' }}
+                            />
+                            <input
+                                type="text"
+                                placeholder="Ort"
+                                value={newCity}
+                                onChange={(e) => setNewCity(e.target.value)}
+                            />
                             {/* NEUES FELD für Kanton */}
                             <input
                                 type="text"
@@ -354,6 +411,31 @@ const CompanyManagementPage = () => {
                                     setCreateWithAdmin({ ...createWithAdmin, companyName: e.target.value })
                                 }
                                 required
+                            />
+                            <input
+                                type="text"
+                                placeholder="Adresse 1"
+                                value={createWithAdmin.addressLine1}
+                                onChange={(e) => setCreateWithAdmin({ ...createWithAdmin, addressLine1: e.target.value })}
+                            />
+                            <input
+                                type="text"
+                                placeholder="Adresse 2"
+                                value={createWithAdmin.addressLine2}
+                                onChange={(e) => setCreateWithAdmin({ ...createWithAdmin, addressLine2: e.target.value })}
+                            />
+                            <input
+                                type="text"
+                                placeholder="PLZ"
+                                value={createWithAdmin.postalCode}
+                                onChange={(e) => setCreateWithAdmin({ ...createWithAdmin, postalCode: e.target.value })}
+                                style={{ width: '80px' }}
+                            />
+                            <input
+                                type="text"
+                                placeholder="Ort"
+                                value={createWithAdmin.city}
+                                onChange={(e) => setCreateWithAdmin({ ...createWithAdmin, city: e.target.value })}
                             />
                             {/* NEUES FELD für Kanton */}
                             <input
@@ -463,6 +545,31 @@ const CompanyManagementPage = () => {
                                                     setEditingCompany({ ...editingCompany, name: e.target.value })
                                                 }
                                                 required
+                                            />
+                                            <input
+                                                type="text"
+                                                placeholder="Adresse 1"
+                                                value={editingCompany.addressLine1}
+                                                onChange={(e) => setEditingCompany({ ...editingCompany, addressLine1: e.target.value })}
+                                            />
+                                            <input
+                                                type="text"
+                                                placeholder="Adresse 2"
+                                                value={editingCompany.addressLine2}
+                                                onChange={(e) => setEditingCompany({ ...editingCompany, addressLine2: e.target.value })}
+                                            />
+                                            <input
+                                                type="text"
+                                                placeholder="PLZ"
+                                                value={editingCompany.postalCode}
+                                                onChange={(e) => setEditingCompany({ ...editingCompany, postalCode: e.target.value })}
+                                                style={{ width: '80px' }}
+                                            />
+                                            <input
+                                                type="text"
+                                                placeholder="Ort"
+                                                value={editingCompany.city}
+                                                onChange={(e) => setEditingCompany({ ...editingCompany, city: e.target.value })}
                                             />
                                             <input
                                                 type="text"


### PR DESCRIPTION
## Summary
- add address fields to `Company` entity and DTOs
- expose address edits in controllers and frontend management page
- display company address on generated PDF payslips
- extend database schema for new columns

## Testing
- `npm run build`
- `npm test --silent` *(fails: No test files found)*
- `./mvnw -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a597521948325b857efdb27e87d60