### PR TITLE
Add payslip generator

### DIFF
--- a/Chrono-frontend/src/pages/PayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/PayslipsPage.jsx
@@ -12,6 +12,19 @@ const PayslipsPage = () => {
   const { language, setLanguage } = useContext(LanguageContext);
   const [printLang, setPrintLang] = useState('de');
   const [payslips, setPayslips] = useState([]);
+  const [form, setForm] = useState({ start: '', end: '' });
+
+  const createPayslip = () => {
+    if (!form.start || !form.end || !currentUser) return;
+    api
+      .post('/api/payslips/generate', null, {
+        params: { userId: currentUser.id, start: form.start, end: form.end }
+      })
+      .then(res => {
+        setPayslips(prev => [...prev, res.data]);
+        setForm({ start: '', end: '' });
+      });
+  };
 
   const handlePrint = async (ps) => {
     const prev = language;
@@ -49,6 +62,19 @@ const PayslipsPage = () => {
           <option value="de">DE</option>
           <option value="en">EN</option>
         </select>
+      </div>
+      <div className="generate-form">
+        <input
+          type="date"
+          value={form.start}
+          onChange={e => setForm({ ...form, start: e.target.value })}
+        />
+        <input
+          type="date"
+          value={form.end}
+          onChange={e => setForm({ ...form, end: e.target.value })}
+        />
+        <button onClick={createPayslip}>{t('payslips.generate', 'Erstellen')}</button>
       </div>
       <table className="payslip-table">
         <thead>

--- a/Chrono-frontend/src/styles/PayslipsPageScoped.css
+++ b/Chrono-frontend/src/styles/PayslipsPageScoped.css
@@ -20,6 +20,8 @@
 .payslip-table {
   width: 100%;
   border-collapse: collapse;
+  margin-top: 1rem;
+  background: var(--c-card);
 }
 
 .payslip-table th,
@@ -39,4 +41,42 @@
   background: var(--c-card);
   border: 1px solid var(--c-border);
   cursor: pointer;
+  transition: background 0.2s;
+}
+.payslip-table button:hover {
+  background: var(--c-border);
+}
+
+.generate-form {
+  margin: 1rem 0;
+  display: flex;
+  gap: 0.7rem;
+}
+
+.generate-form input[type="date"] {
+  padding: 0.38rem 0.7rem;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  background: var(--c-card);
+  color: var(--c-text);
+}
+
+.generate-form button {
+  padding: 0.45rem 1.2rem;
+  border: 1px solid var(--c-border);
+  background: var(--c-card);
+  color: var(--c-text);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.generate-form button:hover {
+  background: var(--c-border);
+}
+
+.print-lang-select {
+  margin-bottom: 0.5rem;
+}
+.print-lang-select label {
+  margin-right: 0.4rem;
 }


### PR DESCRIPTION
## Summary
- improve payslip page layout
- add form to create new payslips for a time range
- style page for light and dark mode

## Testing
- `npm test` *(fails: No test files found)*
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687be2ab4250832582252061b323e1e2