### PR TITLE
Add payslip scheduler

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/PayslipController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/PayslipController.java
@@ -31,6 +31,22 @@ public class PayslipController {
     }
 
     @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
+    @PostMapping("/schedule")
+    public ResponseEntity<Void> schedule(
+            @RequestParam Long userId,
+            @RequestParam int day) {
+        payrollService.setPayslipSchedule(userId, day);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PAYROLL_ADMIN')")
+    @PostMapping("/schedule-all")
+    public ResponseEntity<Void> scheduleAll(@RequestParam(defaultValue = "1") int day) {
+        payrollService.setPayslipScheduleForAll(day);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or hasRole('USER')")
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<PayslipDTO>> list(@PathVariable Long userId) {
         List<Payslip> list = payrollService.getPayslipsForUser(userId);

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/PayslipSchedule.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/PayslipSchedule.java
@@ -1,0 +1,31 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "payslip_schedules")
+public class PayslipSchedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Integer dayOfMonth;
+    private LocalDate nextRun;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Integer getDayOfMonth() { return dayOfMonth; }
+    public void setDayOfMonth(Integer dayOfMonth) { this.dayOfMonth = dayOfMonth; }
+
+    public LocalDate getNextRun() { return nextRun; }
+    public void setNextRun(LocalDate nextRun) { this.nextRun = nextRun; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/jobs/PayslipScheduleJob.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/jobs/PayslipScheduleJob.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.jobs;
+
+import com.chrono.chrono.entities.PayslipSchedule;
+import com.chrono.chrono.repositories.PayslipScheduleRepository;
+import com.chrono.chrono.services.PayrollService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class PayslipScheduleJob {
+    @Autowired
+    private PayslipScheduleRepository scheduleRepository;
+    @Autowired
+    private PayrollService payrollService;
+
+    @Scheduled(cron = "0 5 0 * * *")
+    @Transactional
+    public void generateScheduledPayslips() {
+        LocalDate today = LocalDate.now();
+        List<PayslipSchedule> due = scheduleRepository.findByNextRunLessThanEqual(today);
+        for (PayslipSchedule s : due) {
+            LocalDate start = s.getNextRun().minusMonths(1).withDayOfMonth(1);
+            LocalDate end = start.plusMonths(1).minusDays(1);
+            payrollService.generatePayslip(s.getUser().getId(), start, end);
+            LocalDate next = s.getNextRun().plusMonths(1);
+            next = next.withDayOfMonth(Math.min(s.getDayOfMonth(), next.lengthOfMonth()));
+            s.setNextRun(next);
+        }
+        scheduleRepository.saveAll(due);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipScheduleRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipScheduleRepository.java
@@ -1,0 +1,14 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.PayslipSchedule;
+import com.chrono.chrono.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface PayslipScheduleRepository extends JpaRepository<PayslipSchedule, Long> {
+    Optional<PayslipSchedule> findByUser(User user);
+    List<PayslipSchedule> findByNextRunLessThanEqual(LocalDate date);
+}

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -576,7 +576,10 @@ const translations = {
             printError: "PDF konnte nicht geladen werden",
             saveLogo: "Logo speichern",
             logoSaved: "Logo gespeichert",
-            logoSaveError: "Fehler beim Speichern"
+            logoSaveError: "Fehler beim Speichern",
+            scheduleDay: "Automatisch am Tag",
+            scheduleButton: "Planen",
+            scheduleAll: "Automatische Abrechnung für alle aktivieren"
 
         },
         notFound: {
@@ -1154,7 +1157,10 @@ const translations = {
             printError: "Failed to load PDF",
             saveLogo: "Save logo",
             logoSaved: "Logo saved",
-            logoSaveError: "Failed to save logo"
+            logoSaveError: "Failed to save logo",
+            scheduleDay: "Automatically on day",
+            scheduleButton: "Schedule",
+            scheduleAll: "Enable automatic payslips for all"
 
         },
         notFound: {

--- a/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
@@ -37,6 +37,11 @@ const AdminPayslipsPage = () => {
     api.post('/api/payslips/approve-all', null, { params: { comment } }).then(() => fetchPending());
   };
 
+  const scheduleAll = () => {
+    const day = parseInt(prompt(t('payslips.scheduleDay'))) || 1;
+    api.post('/api/payslips/schedule-all', null, { params: { day } });
+  };
+
   const exportCsv = () => {
     api.get('/api/payslips/admin/export', { responseType: 'blob' }).then(res => {
       const url = window.URL.createObjectURL(new Blob([res.data]));
@@ -117,6 +122,7 @@ const AdminPayslipsPage = () => {
         <button className="approve-all" onClick={approveAll}>{t('payslips.approveAll')}</button>
         <button className="approve-all" onClick={exportCsv}>{t('payslips.exportCsv')}</button>
         <button className="approve-all" onClick={backup}>{t('payslips.backup')}</button>
+        <button className="approve-all" onClick={scheduleAll}>{t('payslips.scheduleAll')}</button>
         <table className="payslip-table">
           <thead>
           <tr>

--- a/Chrono-frontend/src/pages/PayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/PayslipsPage.jsx
@@ -12,6 +12,27 @@ const PayslipsPage = () => {
   const { language, setLanguage } = useContext(LanguageContext);
   const [printLang, setPrintLang] = useState('de');
   const [payslips, setPayslips] = useState([]);
+  const [form, setForm] = useState({ start: '', end: '' });
+  const [scheduleDay, setScheduleDay] = useState(1);
+
+  const createPayslip = () => {
+    if (!form.start || !form.end || !currentUser) return;
+    api
+      .post('/api/payslips/generate', null, {
+        params: { userId: currentUser.id, start: form.start, end: form.end }
+      })
+      .then(res => {
+        setPayslips(prev => [...prev, res.data]);
+        setForm({ start: '', end: '' });
+      });
+  };
+
+  const saveSchedule = () => {
+    if (!currentUser) return;
+    api.post('/api/payslips/schedule', null, {
+      params: { userId: currentUser.id, day: scheduleDay }
+    });
+  };
 
   const handlePrint = async (ps) => {
     const prev = language;
@@ -49,6 +70,30 @@ const PayslipsPage = () => {
           <option value="de">DE</option>
           <option value="en">EN</option>
         </select>
+      </div>
+      <div className="generate-form">
+        <input
+          type="date"
+          value={form.start}
+          onChange={e => setForm({ ...form, start: e.target.value })}
+        />
+        <input
+          type="date"
+          value={form.end}
+          onChange={e => setForm({ ...form, end: e.target.value })}
+        />
+        <button onClick={createPayslip}>{t('payslips.generate', 'Erstellen')}</button>
+      </div>
+      <div className="schedule-form">
+        <label>{t('payslips.scheduleDay')}:</label>
+        <input
+          type="number"
+          min="1"
+          max="28"
+          value={scheduleDay}
+          onChange={e => setScheduleDay(e.target.value)}
+        />
+        <button onClick={saveSchedule}>{t('payslips.scheduleButton')}</button>
       </div>
       <table className="payslip-table">
         <thead>

--- a/Chrono-frontend/src/styles/PayslipsPageScoped.css
+++ b/Chrono-frontend/src/styles/PayslipsPageScoped.css
@@ -20,6 +20,8 @@
 .payslip-table {
   width: 100%;
   border-collapse: collapse;
+  margin-top: 1rem;
+  background: var(--c-card);
 }
 
 .payslip-table th,
@@ -39,4 +41,69 @@
   background: var(--c-card);
   border: 1px solid var(--c-border);
   cursor: pointer;
+  transition: background 0.2s;
+}
+.payslip-table button:hover {
+  background: var(--c-border);
+}
+
+.generate-form {
+  margin: 1rem 0;
+  display: flex;
+  gap: 0.7rem;
+}
+
+.generate-form input[type="date"] {
+  padding: 0.38rem 0.7rem;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  background: var(--c-card);
+  color: var(--c-text);
+}
+
+.generate-form button {
+  padding: 0.45rem 1.2rem;
+  border: 1px solid var(--c-border);
+  background: var(--c-card);
+  color: var(--c-text);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.generate-form button:hover {
+  background: var(--c-border);
+}
+
+.schedule-form {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.schedule-form input[type="number"] {
+  width: 4rem;
+  padding: 0.3rem;
+  border: 1px solid var(--c-border);
+  border-radius: 4px;
+  background: var(--c-card);
+  color: var(--c-text);
+}
+.schedule-form button {
+  padding: 0.45rem 1.2rem;
+  border: 1px solid var(--c-border);
+  background: var(--c-card);
+  color: var(--c-text);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+.schedule-form button:hover {
+  background: var(--c-border);
+}
+
+.print-lang-select {
+  margin-bottom: 0.5rem;
+}
+.print-lang-select label {
+  margin-right: 0.4rem;
 }


### PR DESCRIPTION
## Summary
- support scheduling automatic payslip creation
- expose new `/api/payslips/schedule` backend endpoint
- add monthly schedule job
- allow users to choose month day on payslip page
- style schedule form and translate labels
- add admin button to activate automatic payslips for all users

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `./mvnw -q test` *(fails: could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687be2ab4250832582252061b323e1e2