### PR TITLE
Display employee names on payslip lists

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/PayslipDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/PayslipDTO.java
@@ -8,6 +8,8 @@ import java.util.List;
 public class PayslipDTO {
     private Long id;
     private Long userId;
+    private String firstName;
+    private String lastName;
     private LocalDate periodStart;
     private LocalDate periodEnd;
     private Double grossSalary;
@@ -32,6 +34,8 @@ public class PayslipDTO {
     public PayslipDTO(Payslip ps) {
         this.id = ps.getId();
         this.userId = ps.getUser() != null ? ps.getUser().getId() : null;
+        this.firstName = ps.getUser() != null ? ps.getUser().getFirstName() : null;
+        this.lastName = ps.getUser() != null ? ps.getUser().getLastName() : null;
         this.periodStart = ps.getPeriodStart();
         this.periodEnd = ps.getPeriodEnd();
         this.grossSalary = ps.getGrossSalary();
@@ -76,4 +80,6 @@ public class PayslipDTO {
     public String getPdfPath() { return pdfPath; }
     public Integer getVersion() { return version; }
     public boolean isApproved() { return approved; }
+    public String getFirstName() { return firstName; }
+    public String getLastName() { return lastName; }
 }

--- a/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminPayslipsPage.jsx
@@ -149,7 +149,7 @@ const AdminPayslipsPage = () => {
           <tbody>
           {payslips.map(ps => (
               <tr key={ps.id}>
-                <td>{ps.userId}</td>
+                <td>{ps.firstName} {ps.lastName}</td>
                 <td>{ps.periodStart} - {ps.periodEnd}</td>
                 <td>{ps.grossSalary?.toFixed(2)} CHF</td>
                 <td>{ps.netSalary?.toFixed(2)} CHF</td>
@@ -192,7 +192,7 @@ const AdminPayslipsPage = () => {
           <tbody>
           {approvedSlips.map(ps => (
               <tr key={ps.id}>
-                <td>{ps.userId}</td>
+                <td>{ps.firstName} {ps.lastName}</td>
                 <td>{ps.periodStart} - {ps.periodEnd}</td>
                 <td>{ps.grossSalary?.toFixed(2)} CHF</td>
                 <td>{ps.netSalary?.toFixed(2)} CHF</td>


### PR DESCRIPTION
## Summary
- expose `firstName` and `lastName` in `PayslipDTO`
- show employee names instead of user IDs in admin payslip tables

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687bee6c0fc0832587c225321dc3f4aa