### PR TITLE
Fix LanguageContext syntax error

### DIFF
--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -610,6 +610,7 @@ const translations = {
             punch: "Erste Zeiterfassung",
             vacation: "Urlaub beantragen",
             progress: "erledigt",
+        },
         impressumPage: {
             title: "Impressum",
             address: "<strong>Chrono-Logisch</strong><br />Einzelunternehmen<br />Inhaber: Christopher Siefert<br />Lettenstrasse 20<br />CH-9122 Mogelsberg",
@@ -1250,6 +1251,7 @@ const translations = {
             punch: "First time tracking",
             vacation: "Request vacation",
             progress: "done",
+        },
         impressumPage: {
             title: "Imprint",
             address: "<strong>Chrono-Logisch</strong><br />Sole proprietorship<br />Owner: Christopher Siefert<br />Lettenstrasse 20<br />CH-9122 Mogelsberg",


### PR DESCRIPTION
## Summary
- close `quickStart` object with braces before defining `impressumPage`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm install` *(fails: pcsclite build error)*

------
https://chatgpt.com/codex/tasks/task_e_687e3fcd29088325afa2ab8899e037f7