### PR TITLE
Fix onboarding tour visibility and dark-mode style

### DIFF
--- a/Chrono-frontend/src/components/OnboardingTour.jsx
+++ b/Chrono-frontend/src/components/OnboardingTour.jsx
@@ -16,6 +16,7 @@ export default function OnboardingTour() {
     const { t } = useTranslation();
     const [index, setIndex] = useState(0);
     const [pos, setPos] = useState({ top: 0, left: 0 });
+    const [visible, setVisible] = useState(false);
     const [showFeedback, setShowFeedback] = useState(false);
     const [feedback, setFeedback] = useState('');
     const [showConfetti, setShowConfetti] = useState(false);
@@ -28,21 +29,36 @@ export default function OnboardingTour() {
     }, [show]);
 
     useEffect(() => {
-        const step = steps[index];
-        const target = document.getElementById(step.id);
-        const rect = target ? target.getBoundingClientRect() : null;
-        if (rect && tooltipRef.current) {
-            const { offsetWidth: w, offsetHeight: h } = tooltipRef.current;
-            let top = rect.bottom + 8;
-            let left = rect.left;
-            if (top + h > window.innerHeight) {
-                top = rect.top - h - 8;
+        if (!show) return;
+
+        const updatePos = () => {
+            const step = steps[index];
+            const target = document.getElementById(step.id);
+            const rect = target ? target.getBoundingClientRect() : null;
+            if (rect && tooltipRef.current) {
+                const { offsetWidth: w, offsetHeight: h } = tooltipRef.current;
+                let top = rect.bottom + 8;
+                let left = rect.left;
+                if (top + h > window.innerHeight) {
+                    top = rect.top - h - 8;
+                }
+                if (left + w > window.innerWidth) {
+                    left = window.innerWidth - w - 8;
+                }
+                setPos({ top, left });
+                setVisible(true);
+            } else {
+                setVisible(false);
             }
-            if (left + w > window.innerWidth) {
-                left = window.innerWidth - w - 8;
-            }
-            setPos({ top, left });
-        }
+        };
+
+        updatePos();
+        window.addEventListener('resize', updatePos);
+        const interval = setInterval(updatePos, 500);
+        return () => {
+            window.removeEventListener('resize', updatePos);
+            clearInterval(interval);
+        };
     }, [index, show]);
 
     const handleKey = (e) => {
@@ -55,7 +71,7 @@ export default function OnboardingTour() {
         }
     };
 
-    if (!show) return null;
+    if (!show || !visible) return null;
 
     const step = steps[index];
 

--- a/Chrono-frontend/src/context/OnboardingContext.jsx
+++ b/Chrono-frontend/src/context/OnboardingContext.jsx
@@ -7,11 +7,13 @@ const OnboardingContext = createContext({
 });
 
 export function OnboardingProvider({ children }) {
-    const [show, setShow] = useState(() => {
-        return localStorage.getItem('onboardingDone') !== 'true';
-    });
+    const [show, setShow] = useState(false);
 
-    const start = () => setShow(true);
+    const start = () => {
+        if (localStorage.getItem('onboardingDone') !== 'true') {
+            setShow(true);
+        }
+    };
     const finish = () => {
         setShow(false);
         localStorage.setItem('onboardingDone', 'true');

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -37,11 +37,13 @@ import UserCorrectionsPanel from './UserCorrectionsPanel';
 import PrintReportModal from "../../components/PrintReportModal.jsx";
 import CustomerTimeAssignModal from '../../components/CustomerTimeAssignModal';
 import QuickStart from '../../components/QuickStart.jsx';
+import { useOnboarding } from '../../context/OnboardingContext';
 
 function UserDashboard() {
     const { currentUser, fetchCurrentUser } = useAuth();
     const { notify } = useNotification();
     const { t } = useTranslation();
+    const { start } = useOnboarding();
 
     const [userProfile, setUserProfile] = useState(null);
     const [dailySummaries, setDailySummaries] = useState([]);
@@ -75,6 +77,12 @@ function UserDashboard() {
     const [dailySummaryForCorrection, setDailySummaryForCorrection] = useState(null);
 
     const defaultExpectedHours = userProfile?.dailyWorkHours ?? 8.5;
+
+    useEffect(() => {
+        if (localStorage.getItem('onboardingDone') !== 'true') {
+            start();
+        }
+    }, [start]);
 
     const loadProfileAndInitialData = useCallback(async () => {
         try {

--- a/Chrono-frontend/src/styles/Onboarding.css
+++ b/Chrono-frontend/src/styles/Onboarding.css
@@ -4,16 +4,18 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.4);
+    background: var(--modal-backdrop-color, rgba(0,0,0,0.4));
     z-index: 1000;
 }
 
 .onboarding-tooltip {
     position: absolute;
-    background: #fff;
+    background: var(--c-surface);
+    color: var(--c-text);
     padding: 1rem;
     border-radius: 4px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    box-shadow: var(--u-shadow-sm, 0 2px 6px rgba(0,0,0,0.2));
+    border: 1px solid var(--c-border);
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -34,7 +36,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0,0,0,0.5);
+    background: var(--modal-backdrop-color, rgba(0,0,0,0.5));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -42,10 +44,12 @@
 }
 
 .feedback-popup {
-    background: #fff;
+    background: var(--c-surface);
+    color: var(--c-text);
     padding: 1rem;
     border-radius: 4px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    box-shadow: var(--u-shadow-sm, 0 2px 6px rgba(0,0,0,0.2));
+    border: 1px solid var(--c-border);
 }
 .feedback-popup textarea {
     width: 100%;


### PR DESCRIPTION
## Summary
- delay automatic onboarding start until dashboard is shown
- hide the tooltip until the target element exists and reposition on resize
- colour onboarding popups using design tokens for light/dark mode

## Testing
- `npm install` *(fails: pcsclite build error)*

------
https://chatgpt.com/codex/tasks/task_e_687e425725ac8325afb2c0c95c5d2598