### PR TITLE
Improve onboarding tour positioning

### DIFF
--- a/Chrono-frontend/src/styles/Onboarding.css
+++ b/Chrono-frontend/src/styles/Onboarding.css
@@ -5,7 +5,7 @@
     right: 0;
     bottom: 0;
     background: var(--modal-backdrop-color, rgba(0,0,0,0.4));
-    z-index: 1000;
+    z-index: 12000; /* Above navigation and modals */
 }
 
 .onboarding-tooltip {
@@ -28,6 +28,14 @@
 
 .onboarding-actions button {
     margin-left: 0.5rem;
+}
+
+.onboarding-highlight {
+    position: relative;
+    z-index: 12001;
+    outline: 3px solid var(--c-pri);
+    outline-offset: 3px;
+    border-radius: 4px;
 }
 
 .feedback-overlay {


### PR DESCRIPTION
## Summary
- adjust onboarding tooltip to highlight elements and scroll into view
- center tooltip relative to highlighted element and update position on scroll
- raise z-index and add highlight styles

## Testing
- `npm test` *(fails: vitest not found)*
- `./mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b77eec88325a8adbe865811b058