### PR TITLE
Add scoped wrappers for some components

### DIFF
--- a/Chrono-frontend/src/TimeTrackingImport.jsx
+++ b/Chrono-frontend/src/TimeTrackingImport.jsx
@@ -199,7 +199,7 @@ function TimeTrackingImport() {
 
 
     return (
-        <div className="time-import-page">
+        <div className="scoped-time-import time-import-page">
             <div className="time-import-container">
                 <h3>Stempelzeiten aus Excel importieren</h3>
                 <form onSubmit={handleSubmit} className="import-form">

--- a/Chrono-frontend/src/components/ActionButtons.jsx
+++ b/Chrono-frontend/src/components/ActionButtons.jsx
@@ -7,7 +7,7 @@ import '../styles/FloatingButtons.css';
 const ActionButtons = () => {
     return (
         // Dieser Container wird vom neuen Stylesheet korrekt positioniert
-        <div className="floating-buttons-container">
+        <div className="scoped-floating-buttons floating-buttons-container">
             <HelpButton />
             <ChatWidget />
         </div>

--- a/Chrono-frontend/src/components/ChangelogModal.jsx
+++ b/Chrono-frontend/src/components/ChangelogModal.jsx
@@ -15,7 +15,7 @@ const ChangelogModal = ({ changelog, onClose }) => {
     };
 
     return (
-        <ModalOverlay visible className="changelog-backdrop" onClick={handleBackdropClick}>
+        <ModalOverlay visible className="changelog-backdrop scoped-changelog" onClick={handleBackdropClick}>
             <div className="changelog-modal">
                 <div className="changelog-header">
                     <h2>{t('changelogModal.whatsNew')} {changelog.version}?</h2>

--- a/Chrono-frontend/src/components/HelpButton.jsx
+++ b/Chrono-frontend/src/components/HelpButton.jsx
@@ -4,6 +4,8 @@ import '../styles/HelpButton.css';
 
 export default function HelpButton() {
     return (
-        <Link to="/help" id="help-button" className="help-button">?</Link>
+        <div className="scoped-help-button">
+            <Link to="/help" id="help-button" className="help-button">?</Link>
+        </div>
     );
 }

--- a/Chrono-frontend/src/components/QuickStart.jsx
+++ b/Chrono-frontend/src/components/QuickStart.jsx
@@ -24,7 +24,8 @@ export default function QuickStart() {
     const progress = Math.round(completed / tasks.length * 100);
 
     return (
-        <div className="quickstart-widget">
+        <div className="scoped-quickstart">
+            <div className="quickstart-widget">
             <h3>{t('quickStart.title')}</h3>
             <ul>
                 {tasks.map(tk => (
@@ -37,6 +38,7 @@ export default function QuickStart() {
                 ))}
             </ul>
             <div className="qs-progress">{progress}% {t('quickStart.progress')}</div>
+            </div>
         </div>
     );
 }

--- a/Chrono-frontend/src/components/TrendChart.jsx
+++ b/Chrono-frontend/src/components/TrendChart.jsx
@@ -4,7 +4,8 @@ import '../styles/TrendChart.css';
 function TrendChart({ data }) {
   const max = Math.max(...data.map(d => Math.max(d.workedMinutes, d.expectedMinutes || 0)), 1);
   return (
-    <div className="trend-chart">
+    <div className="scoped-trend-chart">
+      <div className="trend-chart">
       {data.map(d => (
         <div key={d.date} className="trend-bar-wrapper">
           <div className="trend-bars">
@@ -16,6 +17,7 @@ function TrendChart({ data }) {
           <span className="trend-label">{new Date(d.date).toLocaleDateString()}</span>
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/Chrono-frontend/src/context/NotificationContext.jsx
+++ b/Chrono-frontend/src/context/NotificationContext.jsx
@@ -28,7 +28,7 @@ export function NotificationProvider({ children }) {
             {children}
 
             {visible && (
-                <ModalOverlay visible className="notification-overlay">
+                <ModalOverlay visible className="notification-overlay scoped-notification">
                     <div className="notification-modal">
                         <p>{message}</p>
                         <button onClick={closeNotification}>{t('ok')}</button>

--- a/Chrono-frontend/src/pages/WhatsNewPage.jsx
+++ b/Chrono-frontend/src/pages/WhatsNewPage.jsx
@@ -27,7 +27,7 @@ const WhatsNewPage = () => {
     return (
         <div>
             <Navbar />
-            <div className="page-container">
+            <div className="page-container scoped-changelog">
                 <h1>{t('whatsNewPage.title')}</h1>
                 {loading ? (
                     <p>{t('whatsNewPage.loading')}</p>

--- a/Chrono-frontend/src/styles/Changelog.css
+++ b/Chrono-frontend/src/styles/Changelog.css
@@ -1,17 +1,18 @@
+/* Scope: .scoped-changelog */
 /* ==========================================================
  * Changelog.css (Finale Korrektur mit korrekten CSS-Variablen)
  * ==========================================================
  */
 
 /* --- Styling für das Modal-Backdrop --- */
-.changelog-backdrop {
+.scoped-changelog .changelog-backdrop {
   /* Grundlayout über global.css */
   background-color: var(--modal-backdrop-color, rgba(0, 0, 0, 0.8));
   padding: 1rem;
 }
 
 /* --- Styling für das Modal selbst --- */
-.changelog-modal {
+.scoped-changelog .changelog-modal {
   /* KORREKTUR: --c-card und --c-text statt --card-bg-color und --text-color */
   background: var(--c-card);
   color: var(--c-text);
@@ -28,7 +29,7 @@
 }
 
 /* --- Header für Modal & Verlauf --- */
-.changelog-header {
+.scoped-changelog .changelog-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -39,12 +40,12 @@
   border-bottom: 1px solid var(--c-border);
 }
 
-.changelog-header h2 {
+.scoped-changelog .changelog-header h2 {
   margin: 0;
   font-size: 1.25rem;
 }
 
-.changelog-close-btn {
+.scoped-changelog .changelog-close-btn {
   background: none;
   border: none;
   font-size: 2rem;
@@ -54,24 +55,24 @@
   color: var(--c-muted);
   transition: color 0.2s ease;
 }
-.changelog-close-btn:hover {
+.scoped-changelog .changelog-close-btn:hover {
   color: var(--c-text);
 }
 
 /* --- Hauptinhalt des Modals --- */
-.changelog-content {
+.scoped-changelog .changelog-content {
   padding: 1.5rem;
   max-height: 70vh;
   overflow-y: auto;
 }
 
-.changelog-content h3 {
+.scoped-changelog .changelog-content h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
   font-size: 1.5rem;
 }
 
-.changelog-date {
+.scoped-changelog .changelog-date {
   font-size: 0.9rem;
   /* KORREKTUR: --c-muted für die sekundäre Farbe */
   color: var(--c-muted);
@@ -80,33 +81,33 @@
 }
 
 /* --- Formatierung für den Markdown-Textkörper --- */
-.changelog-body {
+.scoped-changelog .changelog-body {
   line-height: 1.7;
   font-size: 1rem;
 }
 
-.changelog-body p,
-.changelog-body ul,
-.changelog-body ol {
+.scoped-changelog .changelog-body p,
+.scoped-changelog .changelog-body ul,
+.scoped-changelog .changelog-body ol {
   margin-bottom: 1rem;
 }
 
-.changelog-body ul,
-.changelog-body ol {
+.scoped-changelog .changelog-body ul,
+.scoped-changelog .changelog-body ol {
   padding-left: 25px;
 }
 
-.changelog-body li {
+.scoped-changelog .changelog-body li {
   margin-bottom: 0.5rem;
 }
 
-.changelog-body strong {
+.scoped-changelog .changelog-body strong {
   font-weight: 600;
   color: var(--c-text);
 }
 
 /* --- Footer für das Modal --- */
-.changelog-footer {
+.scoped-changelog .changelog-footer {
   padding: 1rem 1.5rem;
   text-align: right;
   /* KORREKTUR: --c-surface als subtiler Hintergrund */
@@ -120,12 +121,12 @@
   padding: 1rem 2rem;
 }
 
-.changelog-history {
+.scoped-changelog .changelog-history {
   max-width: 900px;
   margin: 0 auto;
 }
 
-.changelog-history-item {
+.scoped-changelog .changelog-history-item {
   /* KORREKTUR: --c-card und --c-border */
   background: var(--c-card);
   border: 1px solid var(--c-border);
@@ -139,26 +140,26 @@
     box-shadow 0.2s ease;
 }
 
-.changelog-history-item:hover {
+.scoped-changelog .changelog-history-item:hover {
   transform: translateY(-4px);
   box-shadow: var(--u-shadow-lg);
 }
 
 /* In der Verlaufs-Seite hat der Header einen anderen Look */
-.changelog-history-item .changelog-header {
+.scoped-changelog .changelog-history-item .changelog-header {
   background-color: var(--c-surface);
   border-bottom: 1px solid var(--c-border);
 }
 
-.changelog-history-item .changelog-header h2 {
+.scoped-changelog .changelog-history-item .changelog-header h2 {
   font-size: 1.1rem;
 }
 
-.changelog-history-item .changelog-date {
+.scoped-changelog .changelog-history-item .changelog-date {
   font-size: 0.8rem;
   margin-bottom: 0;
 }
 
-.changelog-history-item .changelog-body {
+.scoped-changelog .changelog-history-item .changelog-body {
   padding: 1.5rem;
 }

--- a/Chrono-frontend/src/styles/FloatingButtons.css
+++ b/Chrono-frontend/src/styles/FloatingButtons.css
@@ -1,4 +1,5 @@
-.floating-buttons-container {
+/* Scope: .scoped-floating-buttons */
+.scoped-floating-buttons .floating-buttons-container {
     position: fixed;
     bottom: 20px;
     right: 20px;
@@ -8,12 +9,12 @@
     align-items: flex-end;
     gap: 16px;
 }
-.chat-widget {
+.scoped-floating-buttons .chat-widget {
     position: relative;
     display: flex;
     justify-content: flex-end;
 }
-.chat-toggle {
+.scoped-floating-buttons .chat-toggle {
     width: 60px;
     height: 60px;
     border-radius: 50%;
@@ -26,16 +27,16 @@
     align-items: center;
     transition: all 0.3s ease;
 }
-.chat-toggle:hover {
+.scoped-floating-buttons .chat-toggle:hover {
     transform: scale(1.1);
     background: var(--c-pri-hover);
 }
-.chat-toggle svg {
+.scoped-floating-buttons .chat-toggle svg {
     fill: var(--c-text-on-pri);
     width: 28px;
     height: 28px;
 }
-.chat-box {
+.scoped-floating-buttons .chat-box {
     position: absolute;
     bottom: calc(100% + 16px);
     right: 0;

--- a/Chrono-frontend/src/styles/HelpButton.css
+++ b/Chrono-frontend/src/styles/HelpButton.css
@@ -1,4 +1,5 @@
-.help-button {
+/* Scope: .scoped-help-button */
+.scoped-help-button .help-button {
     position: fixed;
     bottom: 1rem;
     right: 1rem;

--- a/Chrono-frontend/src/styles/LegalPages.css
+++ b/Chrono-frontend/src/styles/LegalPages.css
@@ -1,3 +1,4 @@
+/* Scope: .legal-wrapper */
 .legal-wrapper {
   /* Farben wie LandingPage */
   --c-text: #1e2438;

--- a/Chrono-frontend/src/styles/Notification.css
+++ b/Chrono-frontend/src/styles/Notification.css
@@ -1,7 +1,8 @@
+/* Scope: .scoped-notification */
 /* Notification.css oder global */
 
 
-.notification-modal {
+.scoped-notification .notification-modal {
   background: var(--c-card);
   color: var(--c-text);
   padding: 1.5rem 2rem;
@@ -15,7 +16,7 @@
 }
 
 /* Button anpassen */
-.notification-modal button {
+.scoped-notification .notification-modal button {
   margin-top: 1rem;
   background: var(--c-pri);
   color: #fff;
@@ -25,6 +26,6 @@
   cursor: pointer;
   transition: background var(--u-dur) var(--u-ease);
 }
-.notification-modal button:hover {
+.scoped-notification .notification-modal button:hover {
   background: var(--c-pri-dim);
 }

--- a/Chrono-frontend/src/styles/QuickStart.css
+++ b/Chrono-frontend/src/styles/QuickStart.css
@@ -1,16 +1,17 @@
-.quickstart-widget {
+/* Scope: .scoped-quickstart */
+.scoped-quickstart .quickstart-widget {
     border: 1px solid #ccc;
     padding: 1rem;
     margin-bottom: 1rem;
     border-radius: 4px;
 }
-.quickstart-widget ul {
+.scoped-quickstart .quickstart-widget ul {
     list-style: none;
     padding: 0;
 }
-.quickstart-widget li {
+.scoped-quickstart .quickstart-widget li {
     margin-bottom: 0.5rem;
 }
-.qs-progress {
+.scoped-quickstart .qs-progress {
     font-weight: bold;
 }

--- a/Chrono-frontend/src/styles/TimeTrackingImport.css
+++ b/Chrono-frontend/src/styles/TimeTrackingImport.css
@@ -1,9 +1,10 @@
+/* Scope: .scoped-time-import */
 /* =========================================================================
    TimeTrackingImport Scoped Styles
    Supports light and dark mode via CSS variables
    ========================================================================= */
 
-.time-import-page {
+.scoped-time-import .time-import-page {
   font-family: "Poppins", sans-serif;
   background: var(--c-bg);
   color: var(--c-text);
@@ -11,7 +12,7 @@
   padding: 1.5rem;
 }
 
-.time-import-container {
+.scoped-time-import .time-import-container {
   max-width: 700px;
   margin: 0 auto;
   background: var(--c-card);
@@ -20,7 +21,7 @@
   padding: var(--u-card-padding);
 }
 
-.file-input {
+.scoped-time-import .file-input {
   padding: 0.5rem;
   border: 1px solid var(--c-border);
   border-radius: var(--u-radius-sm);
@@ -28,7 +29,7 @@
   color: var(--c-text);
 }
 
-.import-button {
+.scoped-time-import .import-button {
   padding: 0.5rem 1.2rem;
   background: var(--c-pri);
   color: #fff;
@@ -37,12 +38,12 @@
   cursor: pointer;
 }
 
-.import-button:disabled {
+.scoped-time-import .import-button:disabled {
   background: var(--c-muted);
   cursor: not-allowed;
 }
 
-.import-progress {
+.scoped-time-import .import-progress {
   width: 100%;
   height: 8px;
   background: var(--c-border);
@@ -51,22 +52,22 @@
   margin-top: 0.5rem;
 }
 
-.import-progress-bar {
+.scoped-time-import .import-progress-bar {
   height: 100%;
   background: var(--c-pri);
   width: 0;
   transition: width 0.3s;
 }
 
-.invalid-table {
+.scoped-time-import .invalid-table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 1rem;
   background: var(--c-card);
 }
 
-.invalid-table th,
-.invalid-table td {
+.scoped-time-import .invalid-table th,
+.scoped-time-import .invalid-table td {
   border: 1px solid var(--c-border);
   padding: 4px;
   font-size: 0.8rem;
@@ -80,11 +81,11 @@
   border-radius: var(--u-radius-xs);
 }
 
-.invalid-table td.error-cell {
+.scoped-time-import .invalid-table td.error-cell {
   color: var(--c-error);
 }
 
-.feedback-container {
+.scoped-time-import .feedback-container {
   margin-top: 1.25rem;
   padding: 1rem;
   border: 1px solid var(--c-border);
@@ -92,20 +93,20 @@
   background: var(--c-card);
 }
 
-.feedback-success {
+.scoped-time-import .feedback-success {
   color: var(--c-success);
 }
 
-.feedback-warning {
+.scoped-time-import .feedback-warning {
   color: var(--c-warn);
 }
 
-.error-message {
+.scoped-time-import .error-message {
   margin-top: 0.5rem;
   color: var(--c-error);
 }
 
-.hint-text {
+.scoped-time-import .hint-text {
   margin-top: 1.25rem;
   font-size: 0.9em;
   color: var(--c-muted);

--- a/Chrono-frontend/src/styles/TrendChart.css
+++ b/Chrono-frontend/src/styles/TrendChart.css
@@ -1,30 +1,31 @@
-.trend-chart {
+/* Scope: .scoped-trend-chart */
+.scoped-trend-chart .trend-chart {
   display: flex;
   align-items: flex-end;
   gap: 8px;
   height: 150px;
   margin: 20px 0;
 }
-.trend-bar-wrapper {
+.scoped-trend-chart .trend-bar-wrapper {
   flex: 1;
   text-align: center;
 }
-.trend-bars {
+.scoped-trend-chart .trend-bars {
   display: flex;
   align-items: flex-end;
   height: 100%;
 }
-.trend-bar {
+.scoped-trend-chart .trend-bar {
   width: 40%;
   border-radius: 4px 4px 0 0;
 }
-.expected-bar {
+.scoped-trend-chart .expected-bar {
   background: #ccc;
   margin-right: 2px;
 }
-.actual-bar {
+.scoped-trend-chart .actual-bar {
   background: #4caf50;
 }
-.trend-label {
+.scoped-trend-chart .trend-label {
   font-size: 0.7rem;
 }


### PR DESCRIPTION
## Summary
- scope QuickStart styles with `.scoped-quickstart`
- add scoped wrapper around QuickStart component
- scope TimeTrackingImport styles and markup
- scope TrendChart styles and component
- scope HelpButton
- scope floating action buttons
- scope notification overlay
- scope changelog modal and history page
- note scope on legal pages CSS

## Testing
- `npx vitest run` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_688518507e9c83259888aa7dfb99fe3a