### PR TITLE
Adjust chat button layout

### DIFF
--- a/Chrono-frontend/src/styles/FloatingButtons.css
+++ b/Chrono-frontend/src/styles/FloatingButtons.css
@@ -1,16 +1,16 @@
 /* src/styles/FloatingButtons.css */
 
 /* Scope: .scoped-floating-buttons */
-.scoped-floating-buttons .floating-buttons-container {
+.scoped-floating-buttons.floating-buttons-container {
     /* DIES ist jetzt der EINZIGE Ort für die Positionierung */
     position: fixed;
     bottom: 20px;
     right: 20px;
     z-index: 1000; /* Stellt sicher, dass es über dem Seiteninhalt liegt */
 
-    /* Diese Regeln ordnen die Buttons (Help & Chat) untereinander an */
+    /* Die Buttons (Help & Chat) liegen nebeneinander */
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 16px; /* Abstand zwischen den Buttons */
+    flex-direction: row;
+    align-items: center;
+    gap: 12px; /* Abstand zwischen den Buttons */
 }

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -9,6 +9,7 @@
   --c-pri-dim: #5d74ff;
   --c-pri-rgb: 55, 91, 255;
   --c-danger: #e5484d;
+  --c-text-on-pri: #ffffff;
 
   /* Base colors (light) */
   --c-text: #202124;
@@ -49,6 +50,7 @@
   --c-pri: #7aa8ff;
   --c-pri-dim: #92b7ff;
   --c-pri-rgb: 122, 168, 255;
+  --c-text-on-pri: #ffffff;
 
   --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.45);
   --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.75);
@@ -70,6 +72,7 @@
       --c-pri: #7aa8ff;
       --c-pri-dim: #92b7ff;
       --c-pri-rgb: 122, 168, 255;
+      --c-text-on-pri: #ffffff;
 
       --u-shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.45);
       --u-shadow-lg: 0 18px 36px rgba(0, 0, 0, 0.75);


### PR DESCRIPTION
## Summary
- place floating action buttons next to each other
- add `--c-text-on-pri` token for dark and light theme so chat widget text stays legible
- fix CSS selector so floating buttons stay in bottom right

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688521e97ef883258375b95f16eba4b9