### PR TITLE
Add Instagram link

### DIFF
--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -557,6 +557,7 @@ const translations = {
         sessionExpired: "Session abgelaufen. Bitte erneut einloggen.",
         impressum: "Impressum",
         agb: "AGB",
+        instagram: "Instagram",
         changelogModal: {
             whatsNew: "Was ist neu in Version",
             published: "Veröffentlicht am",
@@ -1186,6 +1187,7 @@ const translations = {
         sessionExpired: "Session expired. Please log in again.",
         impressum: "Impressum",
         agb: "Terms",
+        instagram: "Instagram",
         changelogModal: {
             whatsNew: "What's new in version",
             published: "Published on",

--- a/Chrono-frontend/src/pages/LandingPage.jsx
+++ b/Chrono-frontend/src/pages/LandingPage.jsx
@@ -246,7 +246,8 @@ const LandingPage = () => {
                     <div className="social-icons"></div>
                     <div style={{ marginTop: "1rem" }}>
                         <Link to="/impressum" style={{ marginRight: "1rem" }}>Impressum</Link>
-                        <Link to="/agb">AGB</Link>
+                        <Link to="/agb" style={{ marginRight: "1rem" }}>AGB</Link>
+                        <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer">Instagram</a>
                     </div>
                 </div>
             </footer>

--- a/Chrono-frontend/src/pages/Login.jsx
+++ b/Chrono-frontend/src/pages/Login.jsx
@@ -171,6 +171,7 @@ const Login = () => {
             <div className="impressum-agb-footer">
                 <Link to="/impressum">{t("impressum")}</Link>
                 <Link to="/agb">{t("agb")}</Link>
+                <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer">{t("instagram", "Instagram")}</a>
             </div>
         </div>
     );

--- a/Chrono-frontend/src/pages/Registration.jsx
+++ b/Chrono-frontend/src/pages/Registration.jsx
@@ -453,7 +453,8 @@ const Registration = () => {
                     </section>
                     <div style={{ marginTop: "40px", textAlign: "center", fontSize: "0.9rem" }}>
                         <Link to="/impressum" style={{ marginRight: "1rem" }}>Impressum</Link>
-                        <Link to="/agb">AGB</Link>
+                        <Link to="/agb" style={{ marginRight: "1rem" }}>AGB</Link>
+                        <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer">Instagram</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add `instagram` translation
- link to Instagram in login, registration and landing pages

## Testing
- `npm test` *(fails: No test files found)*
- `./mvnw -q test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68858ee98d288325929bf071ef7e0323