### PR TITLE
Add overtime question handling to chat

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ChatController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ChatController.java
@@ -2,10 +2,14 @@ package com.chrono.chrono.controller;
 
 import com.chrono.chrono.dto.ChatRequest;
 import com.chrono.chrono.dto.ChatResponse;
+import com.chrono.chrono.entities.User;
 import com.chrono.chrono.services.ChatService;
+import com.chrono.chrono.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/chat")
@@ -14,9 +18,16 @@ public class ChatController {
     @Autowired
     private ChatService chatService;
 
+    @Autowired
+    private UserService userService;
+
     @PostMapping
-    public ResponseEntity<ChatResponse> chat(@RequestBody ChatRequest req) {
-        String answer = chatService.ask(req.getMessage());
+    public ResponseEntity<ChatResponse> chat(@RequestBody ChatRequest req, Principal principal) {
+        User user = null;
+        if (principal != null) {
+            user = userService.getUserByUsername(principal.getName());
+        }
+        String answer = chatService.ask(req.getMessage(), user);
         return ResponseEntity.ok(new ChatResponse(answer));
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
@@ -14,6 +14,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.chrono.chrono.entities.User;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -74,8 +76,16 @@ public class ChatService {
         }
     }
 
-    public String ask(String message) {
+    public String ask(String message, User user) {
         logger.info("Neue Chat-Anfrage: '{}'", message);
+
+        if (user != null && message != null && message.toLowerCase().contains("überstunden")) {
+            int minutes = user.getTrackingBalanceInMinutes() != null ? user.getTrackingBalanceInMinutes() : 0;
+            int hours = Math.abs(minutes) / 60;
+            int mins = Math.abs(minutes) % 60;
+            String sign = minutes < 0 ? "-" : "";
+            return String.format("Du hast aktuell %s%d:%02d Stunden.", sign, hours, mins);
+        }
 
         try {
             HttpHeaders headers = new HttpHeaders();

--- a/Chrono-backend/src/main/resources/knowledge_base/fuer_alle_benutzer_zeiterfassung.md
+++ b/Chrono-backend/src/main/resources/knowledge_base/fuer_alle_benutzer_zeiterfassung.md
@@ -11,6 +11,11 @@ Dein **persönliches Dashboard** ist die zentrale Übersicht. Dort findest du di
 - Ein **negativer Wert** (z.B. -2:15) bedeutet, du hast Minusstunden.
   Das System zeigt dir auch die Differenz für den aktuellen Tag und die aktuelle Woche an.
 
+## Kann mir der Chatbot meine Überstunden anzeigen?
+Ja. Wenn du in der Anwendung angemeldet bist, kannst du den Chatbot direkt fragen:
+"Wie viele Überstunden habe ich?". Der Assistent liest deinen aktuellen Überstundenstand aus
+deinem Profil aus und antwortet dir mit dem Wert in Stunden und Minuten.
+
 ## Ich habe vergessen, mich einzustempeln. Was kann ich tun?
 Kein Problem. Du kannst eine Korrektur beantragen.
 - Gehe zum Menüpunkt **"Korrekturanträge"**.


### PR DESCRIPTION
## Summary
- extend `ChatController` to pass the authenticated user
- let `ChatService` return the user's overtime when asked
- document chat ability in knowledge base

## Testing
- `npm test` *(fails: No test files found)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886988ef1e483259bc61f4add865058