### PR TITLE
Filter payslips by admin company

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/PayslipRepository.java
@@ -10,5 +10,6 @@ public interface PayslipRepository extends JpaRepository<Payslip, Long> {
     List<Payslip> findByUser(User user);
     List<Payslip> findByUserAndApproved(User user, boolean approved);
     List<Payslip> findByApproved(boolean approved);
+    List<Payslip> findByUser_Company_IdAndApproved(Long companyId, boolean approved);
     List<Payslip> findByUserAndPeriodStartAndPeriodEnd(User user, java.time.LocalDate start, java.time.LocalDate end);
 }


### PR DESCRIPTION
## Summary
- filter payslips by logged-in admin's company
- add repository method to query payslips by company
- use admin in controller when listing pending/approved payslips

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: vitest not found and npm install failed to build pcsclite)*

------
https://chatgpt.com/codex/tasks/task_e_68877157858083258de1710c61d3b09f