### PR TITLE
Fix chatbot quick links

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
@@ -112,7 +112,7 @@ public class ChatService {
 
             for (Map.Entry<String, String> e : links.entrySet()) {
                 if (lower.contains("wo") && lower.contains(e.getKey())) {
-                    return "Du findest " + e.getKey() + " [hier](" + e.getValue() + ").";
+                    return "Du findest [" + e.getKey() + "](" + e.getValue() + ").";
                 }
             }
         }


### PR DESCRIPTION
## Summary
- quick link answer now wraps the keyword with a hyperlink

## Testing
- `./mvnw -q test` *(fails: could not download parent POM)*
- `npm test --silent` *(fails: vitest not found due to install errors)*

------
https://chatgpt.com/codex/tasks/task_e_68877be8dec48325933f44b52ea444e5