### PR TITLE
Add simple schedule planner

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserScheduleController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserScheduleController.java
@@ -1,0 +1,52 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.dto.UserScheduleDTO;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/user/schedule")
+public class UserScheduleController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @GetMapping
+    public ResponseEntity<UserScheduleDTO> getSchedule(Principal principal) {
+        User user = userRepository.findByUsername(principal.getName())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        UserScheduleDTO dto = new UserScheduleDTO(
+                user.getScheduleCycle(),
+                user.getWeeklySchedule(),
+                user.getScheduleEffectiveDate()
+        );
+
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping
+    @Transactional
+    public ResponseEntity<?> updateSchedule(@RequestBody UserScheduleDTO dto, Principal principal) {
+        User user = userRepository.findByUsername(principal.getName())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        if (dto.getScheduleCycle() != null) {
+            user.setScheduleCycle(dto.getScheduleCycle());
+        }
+        if (dto.getWeeklySchedule() != null) {
+            user.setWeeklySchedule(dto.getWeeklySchedule());
+        }
+        if (dto.getScheduleEffectiveDate() != null) {
+            user.setScheduleEffectiveDate(dto.getScheduleEffectiveDate());
+        }
+        userRepository.save(user);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserScheduleDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserScheduleDTO.java
@@ -1,0 +1,43 @@
+package com.chrono.chrono.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public class UserScheduleDTO {
+    private Integer scheduleCycle;
+    private List<Map<String, Double>> weeklySchedule;
+    private LocalDate scheduleEffectiveDate;
+
+    public UserScheduleDTO() {}
+
+    public UserScheduleDTO(Integer scheduleCycle, List<Map<String, Double>> weeklySchedule, LocalDate scheduleEffectiveDate) {
+        this.scheduleCycle = scheduleCycle;
+        this.weeklySchedule = weeklySchedule;
+        this.scheduleEffectiveDate = scheduleEffectiveDate;
+    }
+
+    public Integer getScheduleCycle() {
+        return scheduleCycle;
+    }
+
+    public void setScheduleCycle(Integer scheduleCycle) {
+        this.scheduleCycle = scheduleCycle;
+    }
+
+    public List<Map<String, Double>> getWeeklySchedule() {
+        return weeklySchedule;
+    }
+
+    public void setWeeklySchedule(List<Map<String, Double>> weeklySchedule) {
+        this.weeklySchedule = weeklySchedule;
+    }
+
+    public LocalDate getScheduleEffectiveDate() {
+        return scheduleEffectiveDate;
+    }
+
+    public void setScheduleEffectiveDate(LocalDate scheduleEffectiveDate) {
+        this.scheduleEffectiveDate = scheduleEffectiveDate;
+    }
+}

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -33,6 +33,7 @@ import PrivateRoute from "./components/PrivateRoute";
 import { useAuth } from "./context/AuthContext";
 import WhatsNewPage from "./pages/WhatsNewPage.jsx";
 import TimeTrackingImport from "./TimeTrackingImport.jsx";
+import SchedulePlanner from "./pages/SchedulePlanner.jsx";
 
 // NEU: Nur noch der ActionButtons Container wird importiert
 import ActionButtons from "./components/ActionButtons.jsx";
@@ -75,6 +76,14 @@ function App() {
                     element={
                         <PrivateRoute>
                             <PersonalDataPage />
+                        </PrivateRoute>
+                    }
+                />
+                <Route
+                    path="/schedule"
+                    element={
+                        <PrivateRoute>
+                            <SchedulePlanner />
                         </PrivateRoute>
                     }
                 />

--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -132,6 +132,7 @@ const Navbar = () => {
                                     <li><Link to="/user">{t('navbar.myDashboard', 'Mein Dashboard')}</Link></li>
                                     <li><Link id="payslips-link" to="/payslips">{t('navbar.payslips', 'Abrechnungen')}</Link></li>
                                     <li><Link to="/profile">{t('navbar.profile', 'Mein Profil')}</Link></li>
+                                    <li><Link to="/schedule">{t("navbar.schedule", "Plan")}</Link></li>
                                     <li><Link to="/chat">{t('navbar.chatbot', 'Chatbot')}</Link></li>
                                 </>
                             )}

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -639,13 +639,18 @@ const translations = {
             sending: "Anfrage wird gesendet...",
             thanks: "Vielen Dank für Ihre Anfrage!",
             backHome: "Zurück zur Startseite"
-
+        },
+        schedulePlanner: {
+            title: "Arbeitsplan",
+            cycle: "Zyklus in Wochen",
+            effective: "Gültig ab",
+            loadError: "Fehler beim Laden: ",
+            saveSuccess: "Plan gespeichert",
+            saveError: "Fehler beim Speichern: "
         },
         notFound: {
             pageNotFound: "404 - Seite nicht gefunden",
         },
-
-
     },
 
     // =============== ENGLISCH ===============
@@ -1279,6 +1284,14 @@ const translations = {
             sending: "Sending request...",
             thanks: "Thank you for your request!",
             backHome: "Back to homepage"
+        },
+        schedulePlanner: {
+            title: "Work Schedule",
+            cycle: "Cycle in weeks",
+            effective: "Effective from",
+            loadError: "Load error: ",
+            saveSuccess: "Schedule saved",
+            saveError: "Save error: "
         },
         notFound: {
             pageNotFound: "404 - Page not found",

--- a/Chrono-frontend/src/pages/SchedulePlanner.jsx
+++ b/Chrono-frontend/src/pages/SchedulePlanner.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import Navbar from '../components/Navbar';
+import { useNotification } from '../context/NotificationContext';
+import { useTranslation } from '../context/LanguageContext';
+import api from '../utils/api';
+import '../styles/SchedulePlanner.css';
+
+const days = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
+
+const defaultSchedule = {
+    monday: 8.0,
+    tuesday: 8.0,
+    wednesday: 8.0,
+    thursday: 8.0,
+    friday: 8.0,
+    saturday: 0.0,
+    sunday: 0.0
+};
+
+const SchedulePlanner = () => {
+    const { notify } = useNotification();
+    const { t } = useTranslation();
+    const [scheduleCycle, setScheduleCycle] = useState(1);
+    const [weekSchedule, setWeekSchedule] = useState(defaultSchedule);
+    const [effectiveDate, setEffectiveDate] = useState('');
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        api.get('/api/user/schedule')
+            .then(res => {
+                const data = res.data;
+                if (data.scheduleCycle) setScheduleCycle(data.scheduleCycle);
+                if (Array.isArray(data.weeklySchedule) && data.weeklySchedule.length > 0) {
+                    setWeekSchedule({ ...defaultSchedule, ...data.weeklySchedule[0] });
+                }
+                if (data.scheduleEffectiveDate) setEffectiveDate(data.scheduleEffectiveDate);
+            })
+            .catch(err => {
+                const msg = err.response?.data?.message || err.message;
+                notify(t('schedulePlanner.loadError', 'Fehler beim Laden: ') + msg, 'error');
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    const handleChange = (day, value) => {
+        setWeekSchedule(prev => ({ ...prev, [day]: parseFloat(value) }));
+    };
+
+    const saveSchedule = () => {
+        const payload = {
+            scheduleCycle,
+            weeklySchedule: [weekSchedule],
+            scheduleEffectiveDate: effectiveDate || null
+        };
+        api.post('/api/user/schedule', payload)
+            .then(() => notify(t('schedulePlanner.saveSuccess', 'Plan gespeichert'), 'success'))
+            .catch(err => {
+                const msg = err.response?.data?.message || err.message;
+                notify(t('schedulePlanner.saveError', 'Fehler beim Speichern: ') + msg, 'error');
+            });
+    };
+
+    if (loading) return <div>Loading...</div>;
+
+    return (
+        <div className="schedule-planner scoped">
+            <Navbar />
+            <div className="page-content">
+                <h2>{t('schedulePlanner.title', 'Arbeitsplan')}</h2>
+                <div className="schedule-form">
+                    <label>{t('schedulePlanner.cycle', 'Zyklus in Wochen')}</label>
+                    <input type="number" min="1" value={scheduleCycle} onChange={e => setScheduleCycle(parseInt(e.target.value, 10) || 1)} />
+                    <label>{t('schedulePlanner.effective', 'Gültig ab')}</label>
+                    <input type="date" value={effectiveDate} onChange={e => setEffectiveDate(e.target.value)} />
+                    <table className="schedule-table">
+                        <thead>
+                            <tr>{days.map(d => <th key={d}>{d}</th>)}</tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                {days.map(d => (
+                                    <td key={d}>
+                                        <input type="number" step="0.25" value={weekSchedule[d]} onChange={e => handleChange(d, e.target.value)} />
+                                    </td>
+                                ))}
+                            </tr>
+                        </tbody>
+                    </table>
+                    <button className="button-primary" onClick={saveSchedule}>{t('save', 'Speichern')}</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SchedulePlanner;

--- a/Chrono-frontend/src/styles/SchedulePlanner.css
+++ b/Chrono-frontend/src/styles/SchedulePlanner.css
@@ -1,0 +1,16 @@
+.schedule-planner.scoped {
+  padding: var(--u-gap-md);
+}
+
+.schedule-planner.scoped table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--u-gap-sm);
+}
+
+.schedule-planner.scoped th,
+.schedule-planner.scoped td {
+  border: 1px solid var(--c-line);
+  padding: 4px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- implement `UserScheduleController` and `UserScheduleDTO`
- add a Schedule Planner page with form and table
- include minimal styles and route
- expose new navigation link and translations

## Testing
- `npm test` *(fails: vitest not found)*
- `./mvnw test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68882581ac548325b66816dee1dd7c05