### PR TITLE
Add schedule planner placeholder

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
@@ -1,0 +1,59 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.dto.ScheduleEntryDTO;
+import com.chrono.chrono.entities.ScheduleEntry;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.ScheduleEntryRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/admin/schedule")
+public class AdminScheduleEntryController {
+
+    @Autowired
+    private ScheduleEntryRepository entryRepo;
+    @Autowired
+    private UserRepository userRepo;
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+    public List<ScheduleEntryDTO> getEntries(@RequestParam String start, @RequestParam String end) {
+        LocalDate s = LocalDate.parse(start);
+        LocalDate e = LocalDate.parse(end);
+        return entryRepo.findByDateBetween(s, e).stream().map(ScheduleEntryDTO::new).toList();
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+    public ResponseEntity<?> saveEntry(@RequestBody ScheduleEntryDTO dto) {
+        Optional<User> userOpt = userRepo.findById(dto.getUserId());
+        if (userOpt.isEmpty()) {
+            return ResponseEntity.badRequest().body("User not found");
+        }
+        ScheduleEntry entry = (dto.getId() != null) ?
+                entryRepo.findById(dto.getId()).orElse(new ScheduleEntry()) : new ScheduleEntry();
+        entry.setUser(userOpt.get());
+        entry.setDate(dto.getDate());
+        entry.setShift(dto.getShift());
+        entryRepo.save(entry);
+        return ResponseEntity.ok(new ScheduleEntryDTO(entry));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+    public ResponseEntity<?> deleteEntry(@PathVariable Long id) {
+        if (!entryRepo.existsById(id)) {
+            return ResponseEntity.badRequest().body("Entry not found");
+        }
+        entryRepo.deleteById(id);
+        return ResponseEntity.ok("deleted");
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ScheduleEntryDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ScheduleEntryDTO.java
@@ -1,0 +1,33 @@
+package com.chrono.chrono.dto;
+
+import com.chrono.chrono.entities.ScheduleEntry;
+
+import java.time.LocalDate;
+
+public class ScheduleEntryDTO {
+    private Long id;
+    private Long userId;
+    private LocalDate date;
+    private String shift;
+
+    public ScheduleEntryDTO() {}
+
+    public ScheduleEntryDTO(ScheduleEntry entry) {
+        this.id = entry.getId();
+        this.userId = entry.getUser() != null ? entry.getUser().getId() : null;
+        this.date = entry.getDate();
+        this.shift = entry.getShift();
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+
+    public String getShift() { return shift; }
+    public void setShift(String shift) { this.shift = shift; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "schedule_entries")
+public class ScheduleEntry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate date;
+
+    private String shift;
+
+    public ScheduleEntry() {}
+
+    public ScheduleEntry(User user, LocalDate date, String shift) {
+        this.user = user;
+        this.date = date;
+        this.shift = shift;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public LocalDate getDate() { return date; }
+    public void setDate(LocalDate date) { this.date = date; }
+
+    public String getShift() { return shift; }
+    public void setShift(String shift) { this.shift = shift; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.ScheduleEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ScheduleEntryRepository extends JpaRepository<ScheduleEntry, Long> {
+    List<ScheduleEntry> findByDateBetween(LocalDate start, LocalDate end);
+    List<ScheduleEntry> findByDate(LocalDate date);
+}

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -29,6 +29,7 @@ import Impressum from "./pages/Impressum.jsx";
 import AGB from "./pages/AGB.jsx";
 import PayslipsPage from "./pages/PayslipsPage.jsx";
 import AdminPayslipsPage from "./pages/AdminPayslipsPage.jsx";
+import AdminSchedulePlannerPage from "./pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx";
 import PrivateRoute from "./components/PrivateRoute";
 import { useAuth } from "./context/AuthContext";
 import WhatsNewPage from "./pages/WhatsNewPage.jsx";
@@ -149,6 +150,14 @@ function App() {
                     element={
                         <PrivateRoute requiredRole={["ROLE_ADMIN","ROLE_PAYROLL_ADMIN"]}>
                             <AdminPayslipsPage />
+                        </PrivateRoute>
+                    }
+                />
+                <Route
+                    path="/admin/schedule"
+                    element={
+                        <PrivateRoute requiredRole="ROLE_ADMIN">
+                            <AdminSchedulePlannerPage />
                         </PrivateRoute>
                     }
                 />

--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -125,6 +125,7 @@ const Navbar = () => {
                                         </>
                                     )}
                                     <li><Link to="/admin/payslips">{t('navbar.payslips', 'Abrechnungen')}</Link></li>
+                                    <li><Link to="/admin/schedule">{t('navbar.schedulePlanner', 'Dienstplan')}</Link></li>
                                     <li><Link to="/admin/change-password">{t('admin.changePasswordTitle', 'Passwort ändern')}</Link></li>
                                 </>
                             ) : (

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -216,6 +216,7 @@ const translations = {
             projectManagement: "Projekte",
             companyManagement: "Firmen",
             payslips: "Abrechnungen",
+            schedulePlanner: "Dienstplan",
             payments: "Zahlungen",
             myDashboard: "Mein Dashboard",
             chatbot: "Chatbot",
@@ -601,7 +602,11 @@ const translations = {
             selectFile: "Datei wählen",
             myPayslips: "Meine Lohnabrechnungen"
 
-
+        },
+        schedulePlanner: {
+            title: "Dienstplan",
+            auto: "Automatisch",
+            save: "Speichern"
         },
         quickStart: {
             title: "Quick Start",
@@ -896,6 +901,7 @@ const translations = {
             projectManagement: "Projects",
             companyManagement: "Companies",
             payslips: "Payslips",
+            schedulePlanner: "Schedule",
             payments: "Payments",
             myDashboard: "My Dashboard",
             chatbot: "Chatbot",
@@ -1276,7 +1282,11 @@ const translations = {
             selectFile: "Choose file",
             myPayslips: "My Payslips"
 
-
+        },
+        schedulePlanner: {
+            title: "Schedule Planner",
+            auto: "Auto Fill",
+            save: "Save"
         },
         quickStart: {
             title: "Quick Start",

--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import Navbar from '../../components/Navbar';
+import api from '../../utils/api';
+import '../../styles/AdminSchedulePlannerPage.css';
+import { useTranslation } from '../../context/LanguageContext';
+import { startOfWeek, addDays, formatISO } from 'date-fns';
+
+const days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+
+const AdminSchedulePlannerPage = () => {
+  const { t } = useTranslation();
+  const [users, setUsers] = useState([]);
+  const [schedule, setSchedule] = useState({});
+  const [weekStart, setWeekStart] = useState(startOfWeek(new Date(), { weekStartsOn: 1 }));
+  const [dragUser, setDragUser] = useState(null);
+
+  useEffect(() => {
+    api.get('/api/admin/users').then(res => {
+      setUsers(Array.isArray(res.data) ? res.data : []);
+    });
+  }, []);
+
+  useEffect(() => {
+    const start = formatISO(weekStart, { representation: 'date' });
+    const end = formatISO(addDays(weekStart, 6), { representation: 'date' });
+    api.get('/api/admin/schedule', { params: { start, end } })
+      .then(res => {
+        const map = {};
+        (res.data || []).forEach(e => {
+          const dayKey = formatISO(new Date(e.date), { representation: 'date' });
+          map[dayKey] = { userId: e.userId, id: e.id };
+        });
+        setSchedule(map);
+      });
+  }, [weekStart]);
+
+  const assign = (dateKey, userId) => {
+    setSchedule(prev => ({ ...prev, [dateKey]: { ...prev[dateKey], userId } }));
+  };
+
+  const onDragStart = (u) => setDragUser(u);
+  const onDrop = (dateKey) => {
+    if (dragUser) assign(dateKey, dragUser.id);
+    setDragUser(null);
+  };
+  const allowDrop = e => e.preventDefault();
+
+  const autoFill = () => {
+    const newSchedule = {};
+    days.forEach((_, i) => {
+      const dateKey = formatISO(addDays(weekStart, i), { representation: 'date' });
+      const user = users[i % users.length];
+      if (user) newSchedule[dateKey] = { userId: user.id };
+    });
+    setSchedule(newSchedule);
+  };
+
+  const save = () => {
+    Object.entries(schedule).forEach(([dateKey, { userId, id }]) => {
+      api.post('/api/admin/schedule', { id, userId, date: dateKey, shift: 'DAY' });
+    });
+  };
+
+  const weekDates = days.map((_, i) => addDays(weekStart, i));
+  const dateKeys = weekDates.map(d => formatISO(d, { representation: 'date' }));
+
+  const conflictMap = Object.values(schedule).reduce((acc, entry) => {
+    if (!entry?.userId) return acc;
+    acc[entry.userId] = (acc[entry.userId] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="admin-schedule-planner-page scoped-dashboard">
+      <Navbar />
+      <div className="users-list">
+        {users.map(u => (
+          <div
+            key={u.id}
+            className="user-item"
+            draggable
+            onDragStart={() => onDragStart(u)}
+          >
+            {u.username}
+          </div>
+        ))}
+        <button onClick={autoFill}>{t('schedulePlanner.auto', 'Auto Fill')}</button>
+        <button onClick={save}>{t('schedulePlanner.save', 'Save')}</button>
+      </div>
+      <table className="schedule-table">
+        <thead>
+          <tr>
+            {days.map((d, idx) => <th key={d}>{d}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            {dateKeys.map(dateKey => {
+              const entry = schedule[dateKey] || {};
+              const conflict = entry.userId && conflictMap[entry.userId] > 1;
+              const user = users.find(u => u.id === entry.userId);
+              return (
+                <td
+                  key={dateKey}
+                  className={`droppable ${conflict ? 'conflict' : ''}`}
+                  onDragOver={allowDrop}
+                  onDrop={() => onDrop(dateKey)}
+                >
+                  {user ? user.username : '-'}
+                </td>
+              );
+            })}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AdminSchedulePlannerPage;

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPage.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPage.css
@@ -1,0 +1,45 @@
+.admin-schedule-planner-page {
+  padding: var(--ud-gap-lg);
+  display: flex;
+  gap: var(--ud-gap-lg);
+}
+
+.admin-schedule-planner-page .users-list {
+  width: 220px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--ud-radius-sm);
+  background: var(--c-card);
+  padding: var(--ud-gap-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ud-gap-sm);
+  height: fit-content;
+}
+
+.admin-schedule-planner-page .user-item {
+  border: 1px solid var(--c-line);
+  padding: var(--ud-gap-xs) var(--ud-gap-sm);
+  border-radius: var(--ud-radius-xs);
+  background: var(--c-surface);
+  cursor: grab;
+}
+
+.admin-schedule-planner-page .schedule-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.admin-schedule-planner-page th,
+.admin-schedule-planner-page td {
+  border: 1px solid var(--c-line);
+  padding: var(--ud-gap-sm);
+  text-align: center;
+}
+
+.admin-schedule-planner-page td.droppable {
+  min-height: 40px;
+}
+
+.admin-schedule-planner-page td.conflict {
+  background: var(--c-error);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add a new admin scheduling API with schedule entry entity and repository
- extend Admin Schedule Planner UI with drag-and-drop assignment and auto-fill
- improve planner styles and translations

## Testing
- `npm install --silent` *(fails: no output due to network)*
- `npm test --silent` *(fails: vitest not found)*
- `./mvnw -q test` *(fails: could not resolve Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68882d67f3208325b93553de5ab71508