### PR TITLE
Add week navigation in schedule planner

### DIFF
--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -606,7 +606,9 @@ const translations = {
         schedulePlanner: {
             title: "Dienstplan",
             auto: "Automatisch",
-            save: "Speichern"
+            save: "Speichern",
+            prevWeek: "Vorherige Woche",
+            nextWeek: "Nächste Woche"
         },
         quickStart: {
             title: "Quick Start",
@@ -1286,7 +1288,9 @@ const translations = {
         schedulePlanner: {
             title: "Schedule Planner",
             auto: "Auto Fill",
-            save: "Save"
+            save: "Save",
+            prevWeek: "Prev Week",
+            nextWeek: "Next Week"
         },
         quickStart: {
             title: "Quick Start",

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPage.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPage.css
@@ -11,6 +11,32 @@
   box-sizing: border-box;
 }
 
+/* ───────────────── Week Controls ───────────────── */
+.admin-schedule-planner-page .week-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--ud-gap-sm);
+  margin-bottom: var(--ud-gap-md);
+}
+
+.admin-schedule-planner-page .week-controls button {
+  padding: .4em .8em;
+  border: none;
+  border-radius: var(--ud-radius-sm);
+  background: var(--c-muted);
+  color: var(--c-card);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.admin-schedule-planner-page .week-controls input[type="date"] {
+  padding: .4em;
+  border: 1px solid var(--c-border);
+  border-radius: var(--ud-radius-sm);
+  background: var(--c-surface);
+  color: inherit;
+}
+
 /* ───────────────── Users‑Liste ───────────────── */
 .admin-schedule-planner-page .users-list {
   flex: 0 0 250px;


### PR DESCRIPTION
## Summary
- improve the AdminSchedulePlanner by allowing week navigation and a simple rotation based autofill algorithm
- add UI texts for the new controls
- style the week navigation controls

## Testing
- `npm test` *(fails: vitest not found)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68886146dfc08325af73a08721c690ce