### PR TITLE
Improve auto-fill schedule handling

### DIFF
--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -64,12 +64,29 @@ const AdminSchedulePlannerPage = () => {
     const epochMonday = new Date(2020, 0, 6);
     const weekIndex = Math.abs(differenceInCalendarWeeks(weekStart, epochMonday));
     const startIndex = weekIndex % users.length;
-    const newSchedule = {};
+
+    const newSchedule = { ...schedule };
+    const assigned = new Set(Object.values(newSchedule).map(e => e.userId).filter(Boolean));
+    let userIdx = 0;
+
     days.forEach((_, i) => {
       const dateKey = formatISO(addDays(weekStart, i), { representation: 'date' });
-      const user = users[(startIndex + i) % users.length];
-      if (user) newSchedule[dateKey] = { userId: user.id };
+      if (newSchedule[dateKey] && newSchedule[dateKey].userId) return;
+
+      let attempts = 0;
+      let user;
+      while (attempts < users.length) {
+        user = users[(startIndex + userIdx) % users.length];
+        userIdx += 1;
+        attempts += 1;
+        if (!assigned.has(user.id)) break;
+      }
+
+      if (!user) user = users[(startIndex + userIdx++) % users.length];
+      newSchedule[dateKey] = { ...(newSchedule[dateKey] || {}), userId: user.id };
+      assigned.add(user.id);
     });
+
     setSchedule(newSchedule);
   };
 


### PR DESCRIPTION
## Summary
- refine automatic fill on AdminSchedulePlannerPage so existing entries remain and unused users are chosen first

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm install` *(fails: pcsclite build error)*
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688869b3c3788325b9226fa6f299a216