### PR TITLE
Improve admin schedule planner styling

### DIFF
--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -76,9 +76,9 @@ const WeekNavigator = () => {
   });
 
   return (
-      <div className="week-controls">
+      <div className="schedule-planner__controls">
         <button onClick={() => changeWeek(-1)}>&laquo;</button>
-        <span className={`week-display${isCurrentWeek ? ' current' : ''}`}>{weekLabel} | {rangeLabel}</span>
+        <span className={`schedule-planner__week-display${isCurrentWeek ? ' schedule-planner__week-display--current' : ''}`}>{weekLabel} | {rangeLabel}</span>
         <button onClick={() => changeWeek(1)}>&raquo;</button>
         <input type="date" value={format(weekStart, 'yyyy-MM-dd')} onChange={(e) => setWeekStart(new Date(e.target.value))} />
         <div className="copy-weeks">
@@ -128,9 +128,9 @@ const UserList = ({ setSchedule }) => {
   };
 
   return (
-      <div className="users-list">
+      <div className="schedule-planner__users">
         {isLoadingUsers ? <p>Lade Benutzer...</p> : users.map(u => (
-            <div key={u.id} className="user-item" draggable onDragStart={() => setDragUser(u)}>
+            <div key={u.id} className="schedule-planner__user-item" draggable onDragStart={() => setDragUser(u)}>
               {u.username}
             </div>
         ))}
@@ -180,7 +180,7 @@ const ScheduleTable = ({ schedule, setSchedule }) => {
   }, {});
 
   return (
-      <table className="schedule-table">
+      <table className="schedule-planner__table">
         <thead>
         <tr>{days.map(d => <th key={d}>{d}</th>)}</tr>
         </thead>
@@ -193,7 +193,7 @@ const ScheduleTable = ({ schedule, setSchedule }) => {
             const today = isSameDay(new Date(dateKey), new Date());
             return (
                 <td key={dateKey}
-                    className={`droppable ${conflict ? 'conflict' : ''} ${today ? 'today' : ''}`}
+                    className={`schedule-planner__cell--droppable ${conflict ? 'schedule-planner__cell--conflict' : ''} ${today ? 'schedule-planner__cell--today' : ''}`}
                     onDragOver={(e) => e.preventDefault()}
                     onDrop={() => onDrop(dateKey)}>
                   {user ? user.username : '—'}
@@ -238,8 +238,8 @@ const AdminSchedulePlannerPage = () => {
   return (
       <>
         <Navbar />
-        <div className="admin-schedule-planner-page scoped-dashboard">
-          <div className="main-content">
+        <div className="schedule-planner scoped-dashboard">
+          <div className="schedule-planner__main">
             <WeekNavigator />
             {isLoading ? (
                 <div className="loading-indicator">Lade Arbeitsplan...</div>

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
@@ -13,6 +13,28 @@
   box-sizing: border-box;
 }
 
+.schedule-planner__main {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+/* Dark Mode Farben */
+[data-theme="dark"] .schedule-planner {
+  --c-primary: #58a6ff;
+  --c-danger: #f87171;
+  --c-text: var(--brand-gray-200);
+  --c-text-muted: var(--brand-gray-400);
+  --c-bg: #0d1117;
+  --c-bg-surface: #161b22;
+  --c-border: #30363d;
+  --shadow-color: rgb(0 0 0 / 0.4);
+  --shadow-sm: 0 1px 2px 0 var(--shadow-color);
+  --shadow-md: 0 4px 6px -1px var(--shadow-color), 0 2px 4px -2px var(--shadow-color);
+  --shadow-lg: 0 10px 15px -3px var(--shadow-color), 0 4px 6px -4px var(--shadow-color);
+}
+
 /* ─ Steuerung der Woche ───────────────── */
 .schedule-planner__controls {
   display: flex;


### PR DESCRIPTION
## Summary
- apply scoped schedule planner styles in JSX
- add dark theme variables for schedule planner
- tweak layout styles for main content

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e891d9188325a483dee8b3a43bad