### PR TITLE
Add inline day notes to schedule entries

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
@@ -34,15 +34,20 @@ public class AdminScheduleEntryController {
     @PostMapping
     @PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
     public ResponseEntity<?> saveEntry(@RequestBody ScheduleEntryDTO dto) {
-        Optional<User> userOpt = userRepo.findById(dto.getUserId());
-        if (userOpt.isEmpty()) {
-            return ResponseEntity.badRequest().body("User not found");
+        User user = null;
+        if (dto.getUserId() != null) {
+            Optional<User> userOpt = userRepo.findById(dto.getUserId());
+            if (userOpt.isEmpty()) {
+                return ResponseEntity.badRequest().body("User not found");
+            }
+            user = userOpt.get();
         }
         ScheduleEntry entry = (dto.getId() != null) ?
                 entryRepo.findById(dto.getId()).orElse(new ScheduleEntry()) : new ScheduleEntry();
-        entry.setUser(userOpt.get());
+        entry.setUser(user);
         entry.setDate(dto.getDate());
         entry.setShift(dto.getShift());
+        entry.setNote(dto.getNote());
         entryRepo.save(entry);
         return ResponseEntity.ok(new ScheduleEntryDTO(entry));
     }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ScheduleEntryDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ScheduleEntryDTO.java
@@ -9,6 +9,7 @@ public class ScheduleEntryDTO {
     private Long userId;
     private LocalDate date;
     private String shift;
+    private String note;
 
     public ScheduleEntryDTO() {}
 
@@ -17,6 +18,7 @@ public class ScheduleEntryDTO {
         this.userId = entry.getUser() != null ? entry.getUser().getId() : null;
         this.date = entry.getDate();
         this.shift = entry.getShift();
+        this.note = entry.getNote();
     }
 
     public Long getId() { return id; }
@@ -30,4 +32,7 @@ public class ScheduleEntryDTO {
 
     public String getShift() { return shift; }
     public void setShift(String shift) { this.shift = shift; }
+
+    public String getNote() { return note; }
+    public void setNote(String note) { this.note = note; }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
@@ -18,6 +18,9 @@ public class ScheduleEntry {
 
     private String shift;
 
+    @Column(length = 1000)
+    private String note;
+
     public ScheduleEntry() {}
 
     public ScheduleEntry(User user, LocalDate date, String shift) {
@@ -37,4 +40,7 @@ public class ScheduleEntry {
 
     public String getShift() { return shift; }
     public void setShift(String shift) { this.shift = shift; }
+
+    public String getNote() { return note; }
+    public void setNote(String note) { this.note = note; }
 }

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
@@ -136,6 +136,11 @@
   animation: shake 0.2s 2;
 }
 
+.schedule-planner.scoped-dashboard .note-icon {
+  margin-left: 4px;
+  cursor: pointer;
+}
+
 @keyframes shake {
   25% { transform: translateX(-3px); }
   50% { transform: translateX(3px); }
@@ -153,3 +158,4 @@
     flex: 0 0 auto;
   }
 }
+


### PR DESCRIPTION
## Summary
- integrate notes directly in `ScheduleEntry`
- remove separate schedule note controller and repository
- extend DTO and controller to persist note text
- add modal dialog in planner UI for editing notes

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a33264060832596b4a03461951d5a