### PR TITLE
Add company-specific knowledge base

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminKnowledgeController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminKnowledgeController.java
@@ -1,0 +1,64 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.CompanyKnowledgeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/knowledge")
+@PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+public class AdminKnowledgeController {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CompanyRepository companyRepository;
+    @Autowired
+    private CompanyKnowledgeService knowledgeService;
+
+    private Company getCompany(Principal principal) {
+        User admin = userRepository.findByUsername(principal.getName()).orElse(null);
+        if (admin == null) return null;
+        if (admin.getCompany() == null) {
+            return null;
+        }
+        return companyRepository.findById(admin.getCompany().getId()).orElse(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CompanyKnowledge>> list(Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        return ResponseEntity.ok(knowledgeService.findByCompany(c));
+    }
+
+    @PostMapping
+    public ResponseEntity<CompanyKnowledge> create(@RequestBody CompanyKnowledge doc,
+                                                   Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        doc.setCompany(c);
+        return ResponseEntity.ok(knowledgeService.save(doc));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        List<CompanyKnowledge> docs = knowledgeService.findByCompany(c);
+        boolean belongs = docs.stream().anyMatch(d -> d.getId().equals(id));
+        if (!belongs) return ResponseEntity.status(403).build();
+        knowledgeService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/CompanyKnowledge.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/CompanyKnowledge.java
@@ -1,0 +1,51 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "company_knowledge")
+public class CompanyKnowledge {
+
+    public enum AccessLevel {
+        ALL,
+        ADMIN_ONLY
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AccessLevel accessLevel = AccessLevel.ALL;
+
+    public CompanyKnowledge() {}
+
+    public CompanyKnowledge(Company company, String title, String content, AccessLevel level) {
+        this.company = company;
+        this.title = title;
+        this.content = content;
+        this.accessLevel = level;
+    }
+
+    public Long getId() { return id; }
+    public Company getCompany() { return company; }
+    public void setCompany(Company company) { this.company = company; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public AccessLevel getAccessLevel() { return accessLevel; }
+    public void setAccessLevel(AccessLevel accessLevel) { this.accessLevel = accessLevel; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CompanyKnowledgeRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CompanyKnowledgeRepository.java
@@ -1,0 +1,11 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.entities.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CompanyKnowledgeRepository extends JpaRepository<CompanyKnowledge, Long> {
+    List<CompanyKnowledge> findByCompany(Company company);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.chrono.chrono.entities.User;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.services.CompanyKnowledgeService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,6 +45,7 @@ public class ChatService {
     private final RestTemplate restTemplate;
     private final RestTemplate longTimeoutRestTemplate; // The special patient RestTemplate
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CompanyKnowledgeService companyKnowledgeService;
     private String knowledgeBaseContent = "";
     private static final List<String> FALLBACKS = Arrays.asList(
             "Das habe ich leider nicht im Repertoire, aber ich lerne gerne dazu! Versuche es gerne nochmal anders oder schau in die Hilfeseite.",
@@ -56,10 +59,13 @@ public class ChatService {
             "Gute Frage! Im Moment kann ich darauf nicht antworten, aber ich kann dich an einen echten Menschen weiterleiten."
     );
 
-    // Modified constructor to accept both RestTemplates
-    public ChatService(RestTemplate restTemplate, @Qualifier("longTimeoutRestTemplate") RestTemplate longTimeoutRestTemplate) {
+    // Modified constructor to accept both RestTemplates and the knowledge service
+    public ChatService(RestTemplate restTemplate,
+                       @Qualifier("longTimeoutRestTemplate") RestTemplate longTimeoutRestTemplate,
+                       CompanyKnowledgeService companyKnowledgeService) {
         this.restTemplate = restTemplate;
         this.longTimeoutRestTemplate = longTimeoutRestTemplate;
+        this.companyKnowledgeService = companyKnowledgeService;
         loadKnowledgeBaseFromResources();
     }
 
@@ -154,10 +160,12 @@ public class ChatService {
                     ? "Der Benutzer ist eingeloggt mit dem Benutzernamen '" + user.getUsername() + "'."
                     : "Es ist kein Benutzer eingeloggt.";
 
+            String companyKnowledge = getCompanyKnowledgeForUser(user);
             String fullPrompt = "Antworte auf die folgende Frage nur basierend auf dem untenstehenden Kontext. Antworte in der gleichen Sprache wie die Frage.\n\n" +
                     "Benutzerkontext: " + userContext + "\n\n" +
                     "--- KONTEXT ---\n" +
                     this.knowledgeBaseContent +
+                    companyKnowledge +
                     "\n--- FRAGE ---\n" +
                     message;
 
@@ -190,5 +198,23 @@ public class ChatService {
 
     private String getRandomFallback() {
         return FALLBACKS.get(ThreadLocalRandom.current().nextInt(FALLBACKS.size()));
+    }
+
+    private String getCompanyKnowledgeForUser(User user) {
+        if (user == null || user.getCompany() == null) {
+            return "";
+        }
+        boolean isAdmin = user.getRoles().stream()
+                .anyMatch(r -> r.getRoleName().equals("ROLE_ADMIN") || r.getRoleName().equals("ROLE_SUPERADMIN"));
+        List<CompanyKnowledge> docs = companyKnowledgeService.findByCompany(user.getCompany());
+        StringBuilder sb = new StringBuilder();
+        for (CompanyKnowledge d : docs) {
+            if (d.getAccessLevel() == CompanyKnowledge.AccessLevel.ALL || isAdmin) {
+                sb.append("\n\n---\n\n");
+                sb.append(d.getTitle()).append("\n");
+                sb.append(d.getContent());
+            }
+        }
+        return sb.toString();
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/CompanyKnowledgeService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/CompanyKnowledgeService.java
@@ -1,0 +1,28 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.repositories.CompanyKnowledgeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CompanyKnowledgeService {
+
+    @Autowired
+    private CompanyKnowledgeRepository repo;
+
+    public List<CompanyKnowledge> findByCompany(Company company) {
+        return repo.findByCompany(company);
+    }
+
+    public CompanyKnowledge save(CompanyKnowledge doc) {
+        return repo.save(doc);
+    }
+
+    public void delete(Long id) {
+        repo.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- create `CompanyKnowledge` entity and repository
- add service and admin controller for managing company knowledge documents
- extend `ChatService` to include company-specific knowledge per user

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c47549f108325ac7f8b6a0bd550f3