### PR TITLE
Add admin knowledge management page

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminKnowledgeController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminKnowledgeController.java
@@ -1,0 +1,64 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.CompanyKnowledgeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/knowledge")
+@PreAuthorize("hasRole('ADMIN') or hasRole('SUPERADMIN')")
+public class AdminKnowledgeController {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CompanyRepository companyRepository;
+    @Autowired
+    private CompanyKnowledgeService knowledgeService;
+
+    private Company getCompany(Principal principal) {
+        User admin = userRepository.findByUsername(principal.getName()).orElse(null);
+        if (admin == null) return null;
+        if (admin.getCompany() == null) {
+            return null;
+        }
+        return companyRepository.findById(admin.getCompany().getId()).orElse(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CompanyKnowledge>> list(Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        return ResponseEntity.ok(knowledgeService.findByCompany(c));
+    }
+
+    @PostMapping
+    public ResponseEntity<CompanyKnowledge> create(@RequestBody CompanyKnowledge doc,
+                                                   Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        doc.setCompany(c);
+        return ResponseEntity.ok(knowledgeService.save(doc));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Principal principal) {
+        Company c = getCompany(principal);
+        if (c == null) return ResponseEntity.badRequest().build();
+        List<CompanyKnowledge> docs = knowledgeService.findByCompany(c);
+        boolean belongs = docs.stream().anyMatch(d -> d.getId().equals(id));
+        if (!belongs) return ResponseEntity.status(403).build();
+        knowledgeService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/CompanyKnowledge.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/CompanyKnowledge.java
@@ -1,0 +1,51 @@
+package com.chrono.chrono.entities;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "company_knowledge")
+public class CompanyKnowledge {
+
+    public enum AccessLevel {
+        ALL,
+        ADMIN_ONLY
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AccessLevel accessLevel = AccessLevel.ALL;
+
+    public CompanyKnowledge() {}
+
+    public CompanyKnowledge(Company company, String title, String content, AccessLevel level) {
+        this.company = company;
+        this.title = title;
+        this.content = content;
+        this.accessLevel = level;
+    }
+
+    public Long getId() { return id; }
+    public Company getCompany() { return company; }
+    public void setCompany(Company company) { this.company = company; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public AccessLevel getAccessLevel() { return accessLevel; }
+    public void setAccessLevel(AccessLevel accessLevel) { this.accessLevel = accessLevel; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CompanyKnowledgeRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CompanyKnowledgeRepository.java
@@ -1,0 +1,11 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.entities.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CompanyKnowledgeRepository extends JpaRepository<CompanyKnowledge, Long> {
+    List<CompanyKnowledge> findByCompany(Company company);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ChatService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.chrono.chrono.entities.User;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.services.CompanyKnowledgeService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,6 +45,7 @@ public class ChatService {
     private final RestTemplate restTemplate;
     private final RestTemplate longTimeoutRestTemplate; // The special patient RestTemplate
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CompanyKnowledgeService companyKnowledgeService;
     private String knowledgeBaseContent = "";
     private static final List<String> FALLBACKS = Arrays.asList(
             "Das habe ich leider nicht im Repertoire, aber ich lerne gerne dazu! Versuche es gerne nochmal anders oder schau in die Hilfeseite.",
@@ -56,10 +59,13 @@ public class ChatService {
             "Gute Frage! Im Moment kann ich darauf nicht antworten, aber ich kann dich an einen echten Menschen weiterleiten."
     );
 
-    // Modified constructor to accept both RestTemplates
-    public ChatService(RestTemplate restTemplate, @Qualifier("longTimeoutRestTemplate") RestTemplate longTimeoutRestTemplate) {
+    // Modified constructor to accept both RestTemplates and the knowledge service
+    public ChatService(RestTemplate restTemplate,
+                       @Qualifier("longTimeoutRestTemplate") RestTemplate longTimeoutRestTemplate,
+                       CompanyKnowledgeService companyKnowledgeService) {
         this.restTemplate = restTemplate;
         this.longTimeoutRestTemplate = longTimeoutRestTemplate;
+        this.companyKnowledgeService = companyKnowledgeService;
         loadKnowledgeBaseFromResources();
     }
 
@@ -154,10 +160,12 @@ public class ChatService {
                     ? "Der Benutzer ist eingeloggt mit dem Benutzernamen '" + user.getUsername() + "'."
                     : "Es ist kein Benutzer eingeloggt.";
 
+            String companyKnowledge = getCompanyKnowledgeForUser(user);
             String fullPrompt = "Antworte auf die folgende Frage nur basierend auf dem untenstehenden Kontext. Antworte in der gleichen Sprache wie die Frage.\n\n" +
                     "Benutzerkontext: " + userContext + "\n\n" +
                     "--- KONTEXT ---\n" +
                     this.knowledgeBaseContent +
+                    companyKnowledge +
                     "\n--- FRAGE ---\n" +
                     message;
 
@@ -190,5 +198,23 @@ public class ChatService {
 
     private String getRandomFallback() {
         return FALLBACKS.get(ThreadLocalRandom.current().nextInt(FALLBACKS.size()));
+    }
+
+    private String getCompanyKnowledgeForUser(User user) {
+        if (user == null || user.getCompany() == null) {
+            return "";
+        }
+        boolean isAdmin = user.getRoles().stream()
+                .anyMatch(r -> r.getRoleName().equals("ROLE_ADMIN") || r.getRoleName().equals("ROLE_SUPERADMIN"));
+        List<CompanyKnowledge> docs = companyKnowledgeService.findByCompany(user.getCompany());
+        StringBuilder sb = new StringBuilder();
+        for (CompanyKnowledge d : docs) {
+            if (d.getAccessLevel() == CompanyKnowledge.AccessLevel.ALL || isAdmin) {
+                sb.append("\n\n---\n\n");
+                sb.append(d.getTitle()).append("\n");
+                sb.append(d.getContent());
+            }
+        }
+        return sb.toString();
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/CompanyKnowledgeService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/CompanyKnowledgeService.java
@@ -1,0 +1,28 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.CompanyKnowledge;
+import com.chrono.chrono.repositories.CompanyKnowledgeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CompanyKnowledgeService {
+
+    @Autowired
+    private CompanyKnowledgeRepository repo;
+
+    public List<CompanyKnowledge> findByCompany(Company company) {
+        return repo.findByCompany(company);
+    }
+
+    public CompanyKnowledge save(CompanyKnowledge doc) {
+        return repo.save(doc);
+    }
+
+    public void delete(Long id) {
+        repo.deleteById(id);
+    }
+}

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -29,6 +29,7 @@ import AdminPayslipsPage from "./pages/AdminPayslipsPage.jsx";
 import AdminSchedulePlannerPage from "./pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx";
 // NEU: Import der Seite für Schichtregeln
 import AdminShiftRulesPage from "./pages/AdminSchedulePlanner/AdminScheduleRulesPage.jsx";
+import AdminKnowledgePage from "./pages/AdminKnowledge/AdminKnowledgePage.jsx";
 import CompanyManagementPage from "./pages/CompanyManagementPage.jsx";
 import TimeTrackingImport from "./TimeTrackingImport.jsx";
 import PrintReport from "./pages/PrintReport.jsx";
@@ -70,6 +71,8 @@ function App() {
                     <Route path="/admin/company" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanyManagementPage /></PrivateRoute>} />
                     <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN","ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
                     <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />
+
+                    <Route path="/admin/knowledge" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminKnowledgePage /></PrivateRoute>} />
 
                     {/* NEU: Route für die Schicht-Einstellungsseite */}
                     <Route

--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -126,6 +126,7 @@ const Navbar = () => {
                                         )}
                                         <li><Link to="/admin/payslips">{t('navbar.payslips', 'Abrechnungen')}</Link></li>
                                         <li><Link to="/admin/schedule">{t('navbar.schedulePlanner', 'Dienstplan')}</Link></li>
+                                        <li><Link to="/admin/knowledge">{t('navbar.knowledge', 'Dokumente')}</Link></li>
                                         <li><Link to="/admin/change-password">{t('admin.changePasswordTitle', 'Passwort ändern')}</Link></li>
                                     </>
                                 ) : (

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -225,6 +225,7 @@ const translations = {
             companyManagement: "Firmen",
             payslips: "Abrechnungen",
             schedulePlanner: "Dienstplan",
+            knowledge: "Dokumente",
             payments: "Zahlungen",
             myDashboard: "Mein Dashboard",
             chatbot: "Chatbot",
@@ -622,6 +623,21 @@ const translations = {
             userOnVacation: "Dieser Mitarbeiter ist an diesem Tag im Urlaub"
 
         },
+        knowledge: {
+            managementTitle: "Wissensdokumente",
+            createTitle: "Neues Dokument",
+            titleLabel: "Titel",
+            contentLabel: "Inhalt",
+            accessLabel: "Zugriff",
+            accessAll: "Alle",
+            accessAdmin: "Nur Admins",
+            listTitle: "Dokumente",
+            createSuccess: "Dokument gespeichert",
+            createError: "Fehler beim Speichern",
+            deleteConfirm: "Dokument wirklich löschen?",
+            deleteError: "Fehler beim Löschen",
+            noDocs: "Keine Dokumente"
+        },
         quickStart: {
             title: "Quick Start",
             profile: "Profil ausfüllen",
@@ -924,6 +940,7 @@ const translations = {
             companyManagement: "Companies",
             payslips: "Payslips",
             schedulePlanner: "Schedule",
+            knowledge: "Documents",
             payments: "Payments",
             myDashboard: "My Dashboard",
             chatbot: "Chatbot",
@@ -1315,6 +1332,21 @@ const translations = {
             weekShort: "Week",
             userOnVacation: "This employee is on vacation on this day"
 
+        },
+        knowledge: {
+            managementTitle: "Knowledge Documents",
+            createTitle: "New Document",
+            titleLabel: "Title",
+            contentLabel: "Content",
+            accessLabel: "Access",
+            accessAll: "All",
+            accessAdmin: "Admins only",
+            listTitle: "Documents",
+            createSuccess: "Document saved",
+            createError: "Error while saving",
+            deleteConfirm: "Delete this document?",
+            deleteError: "Error while deleting",
+            noDocs: "No documents"
         },
         quickStart: {
             title: "Quick Start",

--- a/Chrono-frontend/src/pages/AdminKnowledge/AdminKnowledgePage.jsx
+++ b/Chrono-frontend/src/pages/AdminKnowledge/AdminKnowledgePage.jsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import Navbar from '../../components/Navbar';
+import { useNotification } from '../../context/NotificationContext';
+import { useTranslation } from '../../context/LanguageContext';
+import api from '../../utils/api';
+import '../../styles/AdminKnowledgePageScoped.css';
+
+const AdminKnowledgePage = () => {
+  const { notify } = useNotification();
+  const { t } = useTranslation();
+
+  const [docs, setDocs] = useState([]);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [access, setAccess] = useState('ALL');
+
+  const fetchDocs = () => {
+    api.get('/api/admin/knowledge').then(res => {
+      setDocs(Array.isArray(res.data) ? res.data : []);
+    });
+  };
+
+  useEffect(() => {
+    fetchDocs();
+  }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    if (!title.trim() || !content.trim()) return;
+    try {
+      await api.post('/api/admin/knowledge', {
+        title: title.trim(),
+        content: content.trim(),
+        accessLevel: access
+      });
+      setTitle('');
+      setContent('');
+      notify(t('knowledge.createSuccess', 'Gespeichert'), 'success');
+      fetchDocs();
+    } catch (err) {
+      console.error('Error creating document', err);
+      notify(t('knowledge.createError', 'Fehler beim Speichern'), 'error');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm(t('knowledge.deleteConfirm', 'Wirklich löschen?'))) return;
+    try {
+      await api.delete(`/api/admin/knowledge/${id}`);
+      fetchDocs();
+    } catch (err) {
+      console.error('Error deleting document', err);
+      notify(t('knowledge.deleteError', 'Fehler beim Löschen'), 'error');
+    }
+  };
+
+  return (
+    <>
+      <Navbar />
+      <div className="admin-knowledge-page scoped-dashboard">
+        <header className="dashboard-header">
+          <h1>{t('knowledge.managementTitle', 'Wissensdokumente')}</h1>
+        </header>
+
+        <section className="content-section">
+          <h3 className="section-title">{t('knowledge.createTitle', 'Neues Dokument')}</h3>
+          <form onSubmit={handleCreate} className="create-form">
+            <input
+              type="text"
+              placeholder={t('knowledge.titleLabel', 'Titel')}
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              required
+            />
+            <select value={access} onChange={e => setAccess(e.target.value)}>
+              <option value="ALL">{t('knowledge.accessAll', 'Alle')}</option>
+              <option value="ADMIN_ONLY">{t('knowledge.accessAdmin', 'Nur Admins')}</option>
+            </select>
+            <button type="submit" className="button-primary">{t('save', 'Speichern')}</button>
+          </form>
+          <textarea
+            className="content-input"
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            placeholder={t('knowledge.contentLabel', 'Inhalt')}
+            rows="6"
+          />
+        </section>
+
+        <section className="content-section">
+          <h3 className="section-title">{t('knowledge.listTitle', 'Dokumente')}</h3>
+          <div className="item-list-container">
+            <ul className="item-list">
+              {docs.map(d => (
+                <li key={d.id} className="list-item">
+                  <div className="item-details">
+                    <span className="item-name">{d.title}</span>
+                    <span className="item-meta">
+                      {d.accessLevel === 'ADMIN_ONLY' ? t('knowledge.accessAdmin', 'Nur Admins') : t('knowledge.accessAll', 'Alle')}
+                    </span>
+                  </div>
+                  <div className="item-actions">
+                    <button onClick={() => handleDelete(d.id)} className="button-danger">{t('delete', 'Löschen')}</button>
+                  </div>
+                </li>
+              ))}
+              {docs.length === 0 && (
+                <li className="list-item">{t('knowledge.noDocs', 'Keine Dokumente')}</li>
+              )}
+            </ul>
+          </div>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default AdminKnowledgePage;

--- a/Chrono-frontend/src/styles/AdminKnowledgePageScoped.css
+++ b/Chrono-frontend/src/styles/AdminKnowledgePageScoped.css
@@ -1,0 +1,69 @@
+/* =========================================================================
+   AdminKnowledgePageScoped.css
+   Scope: .admin-knowledge-page.scoped-dashboard
+   ========================================================================= */
+
+.admin-knowledge-page.scoped-dashboard {
+  --ud-c-bg: #f8f9fa;
+  --ud-c-card: #ffffff;
+  --ud-c-surface: #e9ecef;
+  --ud-c-border: #dee2e6;
+  --ud-c-line: #e2e8f0;
+  --ud-c-text: #212529;
+  --ud-c-text-muted: #6c757d;
+  --ud-c-primary: #007bff;
+  --ud-c-danger: #dc3545;
+  --ud-shadow-card: 0 10px 30px rgba(0, 0, 0, 0.07);
+  --ud-radius-md: 12px;
+  --ud-gap-md: 1.25rem;
+}
+
+[data-theme="dark"] .admin-knowledge-page.scoped-dashboard {
+  --ud-c-bg: #0e101c;
+  --ud-c-card: #1c1e2e;
+  --ud-c-surface: #232539;
+  --ud-c-border: #3a3f58;
+  --ud-c-line: #2a2d40;
+  --ud-c-text: #e9ecef;
+  --ud-c-text-muted: #adb5bd;
+  --ud-c-primary: #4dabf7;
+  --ud-c-danger: #ff6b6b;
+  --ud-shadow-card: 0 10px 35px rgba(0, 0, 0, 0.25);
+}
+
+.admin-knowledge-page .create-form {
+  display: grid;
+  grid-template-columns: 2fr 1fr auto;
+  gap: var(--ud-gap-md);
+  align-items: center;
+  max-width: 800px;
+  margin-bottom: var(--ud-gap-md);
+}
+
+.admin-knowledge-page textarea.content-input {
+  width: 100%;
+  max-width: 800px;
+  margin-top: var(--ud-gap-md);
+}
+
+.admin-knowledge-page .item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.admin-knowledge-page .list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--ud-gap-md);
+  background: var(--ud-c-card);
+  border: 1px solid var(--ud-c-border);
+  border-radius: var(--ud-radius-md);
+  box-shadow: var(--ud-shadow-card);
+  margin-bottom: var(--ud-gap-md);
+}
+
+.admin-knowledge-page .item-actions button {
+  margin-left: var(--ud-gap-md);
+}


### PR DESCRIPTION
## Summary
- add AdminKnowledgePage with CRUD form
- include link and route for admin knowledge documents
- translate new knowledge strings in LanguageContext

## Testing
- `npm test` *(fails: vitest not found)*
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c47549f108325ac7f8b6a0bd550f3