### PR TITLE
feat: change password request dto and tests

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/UserController.java
@@ -1,9 +1,12 @@
 package com.chrono.chrono.controller;
 
+import com.chrono.chrono.dto.ChangePasswordRequest;
 import com.chrono.chrono.dto.UserDTO;
 import com.chrono.chrono.entities.User;
+import com.chrono.chrono.exceptions.UserNotFoundException;
 import com.chrono.chrono.repositories.UserRepository;
 import com.chrono.chrono.services.UserService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,17 +30,15 @@ public class UserController {
 
     // KORRIGIERT: Voller Pfad für die Passwortänderung, wie vom Frontend aufgerufen.
     @PutMapping("/api/user/change-password")
-    public ResponseEntity<String> changePassword(@RequestParam String username,
-                                                 @RequestParam String currentPassword,
-                                                 @RequestParam String newPassword) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+    public ResponseEntity<String> changePassword(@Valid @RequestBody ChangePasswordRequest request) {
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new UserNotFoundException("User not found: " + request.getUsername()));
 
-        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
             return ResponseEntity.badRequest().body("Current password is incorrect");
         }
 
-        user.setPassword(passwordEncoder.encode(newPassword));
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
         userRepository.save(user);
         return ResponseEntity.ok("Password updated successfully");
     }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ChangePasswordRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ChangePasswordRequest.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.dto;
+
+public class ChangePasswordRequest {
+    private String username;
+    private String currentPassword;
+    private String newPassword;
+
+    public ChangePasswordRequest() {
+    }
+
+    public ChangePasswordRequest(String username, String currentPassword, String newPassword) {
+        this.username = username;
+        this.currentPassword = currentPassword;
+        this.newPassword = newPassword;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getCurrentPassword() {
+        return currentPassword;
+    }
+
+    public void setCurrentPassword(String currentPassword) {
+        this.currentPassword = currentPassword;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/controller/UserControllerTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/controller/UserControllerTest.java
@@ -1,0 +1,59 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.dto.ChangePasswordRequest;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.exceptions.UserNotFoundException;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class UserControllerTest {
+
+    @Test
+    void changePassword_success() {
+        UserService userService = mock(UserService.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        UserController controller = new UserController(userService);
+        ReflectionTestUtils.setField(controller, "userRepository", userRepository);
+        ReflectionTestUtils.setField(controller, "passwordEncoder", passwordEncoder);
+
+        ChangePasswordRequest request = new ChangePasswordRequest("john", "old", "new");
+        User user = new User();
+        user.setUsername("john");
+        user.setPassword("encodedOld");
+        when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("old", "encodedOld")).thenReturn(true);
+        when(passwordEncoder.encode("new")).thenReturn("encodedNew");
+
+        ResponseEntity<String> response = controller.changePassword(request);
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals("Password updated successfully", response.getBody());
+        verify(userRepository).save(user);
+        assertEquals("encodedNew", user.getPassword());
+    }
+
+    @Test
+    void changePassword_userNotFound() {
+        UserService userService = mock(UserService.class);
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        UserController controller = new UserController(userService);
+        ReflectionTestUtils.setField(controller, "userRepository", userRepository);
+        ReflectionTestUtils.setField(controller, "passwordEncoder", passwordEncoder);
+
+        ChangePasswordRequest request = new ChangePasswordRequest("missing", "old", "new");
+        when(userRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> controller.changePassword(request));
+    }
+}


### PR DESCRIPTION
## Summary
- add ChangePasswordRequest DTO
- update UserController changePassword to use ChangePasswordRequest and throw UserNotFoundException
- add unit tests for changePassword success and missing user scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688df5a34c6c8325a7e500541ea5773c