### PR TITLE
feat: add error boundary

### DIFF
--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -39,6 +39,7 @@ import Impressum from "./pages/Impressum.jsx";
 
 // Hilfs-Komponenten
 import PrivateRoute from "./components/PrivateRoute.jsx";
+import ErrorBoundary from "./components/ErrorBoundary.jsx";
 
 const queryClient = new QueryClient();
 
@@ -48,51 +49,53 @@ function App() {
 
     return (
         <QueryClientProvider client={queryClient}>
-            <div className="App">
-                <Routes>
-                    {/* Öffentliche Routen */}
-                    <Route path="/" element={<LandingPage />} />
-                    <Route path="/login" element={<Login />} />
-                    <Route path="/register" element={<Registration />} />
-                    <Route path="/agb" element={<AGB />} />
-                    <Route path="/impressum" element={<Impressum />} />
+            <ErrorBoundary>
+                <div className="App">
+                    <Routes>
+                        {/* Öffentliche Routen */}
+                        <Route path="/" element={<LandingPage />} />
+                        <Route path="/login" element={<Login />} />
+                        <Route path="/register" element={<Registration />} />
+                        <Route path="/agb" element={<AGB />} />
+                        <Route path="/impressum" element={<Impressum />} />
 
-                    {/* Geschützte Benutzer-Routen */}
-                    <Route path="/dashboard" element={<PrivateRoute><UserDashboard /></PrivateRoute>} />
-                    <Route path="/percentage-punch" element={<PrivateRoute><PercentagePunch /></PrivateRoute>} />
-                    <Route path="/personal-data" element={<PrivateRoute><PersonalDataPage /></PrivateRoute>} />
+                        {/* Geschützte Benutzer-Routen */}
+                        <Route path="/dashboard" element={<PrivateRoute><UserDashboard /></PrivateRoute>} />
+                        <Route path="/percentage-punch" element={<PrivateRoute><PercentagePunch /></PrivateRoute>} />
+                        <Route path="/personal-data" element={<PrivateRoute><PersonalDataPage /></PrivateRoute>} />
 
-                    {/* Admin-Routen */}
-                    <Route path="/admin/dashboard" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminDashboard /></PrivateRoute>} />
-                    <Route path="/admin/users" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminUserManagementPage /></PrivateRoute>} />
-                    <Route path="/admin/change-password" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminChangePassword /></PrivateRoute>} />
-                    <Route path="/admin/customers" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminCustomersPage /></PrivateRoute>} />
-                    <Route path="/admin/projects" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectsPage /></PrivateRoute>} />
-                    <Route path="/admin/company" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanyManagementPage /></PrivateRoute>} />
-                    <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN","ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
-                    <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />
+                        {/* Admin-Routen */}
+                        <Route path="/admin/dashboard" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminDashboard /></PrivateRoute>} />
+                        <Route path="/admin/users" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminUserManagementPage /></PrivateRoute>} />
+                        <Route path="/admin/change-password" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminChangePassword /></PrivateRoute>} />
+                        <Route path="/admin/customers" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminCustomersPage /></PrivateRoute>} />
+                        <Route path="/admin/projects" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectsPage /></PrivateRoute>} />
+                        <Route path="/admin/company" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanyManagementPage /></PrivateRoute>} />
+                        <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN", "ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
+                        <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />
 
-                    <Route path="/admin/knowledge" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminKnowledgePage /></PrivateRoute>} />
+                        <Route path="/admin/knowledge" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminKnowledgePage /></PrivateRoute>} />
 
-                    {/* NEU: Route für die Schicht-Einstellungsseite */}
-                    <Route
-                        path="/admin/shift-rules"
-                        element={
-                            <PrivateRoute requiredRole="ROLE_ADMIN">
-                                <AdminShiftRulesPage />
-                            </PrivateRoute>
-                        }
-                    />
+                        {/* NEU: Route für die Schicht-Einstellungsseite */}
+                        <Route
+                            path="/admin/shift-rules"
+                            element={
+                                <PrivateRoute requiredRole="ROLE_ADMIN">
+                                    <AdminShiftRulesPage />
+                                </PrivateRoute>
+                            }
+                        />
 
-                    <Route path="/admin/import-times" element={<PrivateRoute requiredRole="ROLE_ADMIN"><TimeTrackingImport /></PrivateRoute>} />
-                    <Route path="/whats-new" element={<PrivateRoute><WhatsNewPage /></PrivateRoute>} />
-                    <Route path="/print-report" element={<PrintReport />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                </Routes>
+                        <Route path="/admin/import-times" element={<PrivateRoute requiredRole="ROLE_ADMIN"><TimeTrackingImport /></PrivateRoute>} />
+                        <Route path="/whats-new" element={<PrivateRoute><WhatsNewPage /></PrivateRoute>} />
+                        <Route path="/print-report" element={<PrintReport />} />
+                        <Route path="*" element={<Navigate to="/" replace />} />
+                    </Routes>
 
-                {/* NEU: Fügt den Chatbot (via ActionButtons) auf allen Seiten für eingeloggte User hinzu */}
-                {authToken && <ActionButtons />}
-            </div>
+                    {/* NEU: Fügt den Chatbot (via ActionButtons) auf allen Seiten für eingeloggte User hinzu */}
+                    {authToken && <ActionButtons />}
+                </div>
+            </ErrorBoundary>
         </QueryClientProvider>
     );
 }

--- a/Chrono-frontend/src/components/ErrorBoundary.jsx
+++ b/Chrono-frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error, info) {
+        console.error("Error caught by ErrorBoundary:", error, info);
+    }
+
+    handleReload = () => {
+        window.location.reload();
+    };
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div role="alert" style={{ padding: "2rem", textAlign: "center" }}>
+                    <p>Es ist ein unerwarteter Fehler aufgetreten.</p>
+                    <button type="button" onClick={this.handleReload}>Neu laden</button>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/Chrono-frontend/src/components/__tests__/ErrorBoundary.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/ErrorBoundary.test.jsx
@@ -1,0 +1,48 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import ErrorBoundary from "../ErrorBoundary.jsx";
+
+function ThrowError() {
+    throw new Error("Test error");
+}
+
+describe("ErrorBoundary", () => {
+    let consoleErrorSpy;
+
+    beforeEach(() => {
+        consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it("renders fallback UI and reloads on button click", async () => {
+        const reloadMock = vi.fn();
+        const originalLocation = window.location;
+        Object.defineProperty(window, "location", {
+            writable: true,
+            value: { ...originalLocation, reload: reloadMock },
+        });
+
+        render(
+            <ErrorBoundary>
+                <ThrowError />
+            </ErrorBoundary>
+        );
+
+        expect(
+            screen.getByText(/unerwarteter Fehler aufgetreten/i)
+        ).toBeInTheDocument();
+        const button = screen.getByRole("button", { name: /neu laden/i });
+        expect(button).toBeInTheDocument();
+
+        await userEvent.click(button);
+        expect(reloadMock).toHaveBeenCalled();
+
+        Object.defineProperty(window, "location", { value: originalLocation });
+    });
+});

--- a/Chrono-frontend/src/test/setup.js
+++ b/Chrono-frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary with reload fallback
- wrap App routes in new ErrorBoundary
- test ErrorBoundary behavior with Vitest and setup file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df5bb8710832580c6908fbe0aa2d7