### PR TITLE
Refactor AuthController to use constructor injection

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AuthController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AuthController.java
@@ -21,21 +21,24 @@ import org.springframework.web.server.ResponseStatusException;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @Autowired
-    private AuthService authService;
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+    private final UserRepository userRepository;
+    private final UserService userService;
 
     @Autowired
-    private JwtUtil jwtUtil;
-
-    @Autowired
-    private UserDetailsService userDetailsService;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    // ✅ Neu hinzugefügt
-    @Autowired
-    private UserService userService;
+    public AuthController(AuthService authService,
+                          JwtUtil jwtUtil,
+                          UserDetailsService userDetailsService,
+                          UserRepository userRepository,
+                          UserService userService) {
+        this.authService = authService;
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+        this.userRepository = userRepository;
+        this.userService = userService;
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody AuthRequest request) {


### PR DESCRIPTION
## Summary
- replace field injection in AuthController with constructor injection

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_688dfa234be88325ad27391b19df16db