### PR TITLE
Add proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+Copyright (c) 2024 Christopher Siefert
+Alle Rechte vorbehalten.
+
+Dieser Code darf weder ganz noch teilweise genutzt, kopiert, verändert oder verbreitet werden ohne vorherige schriftliche Genehmigung durch den Autor.
+
+DER CODE WIRD OHNE MÄNGELGEWÄHR UND OHNE JEDE AUSDRÜCKLICHE ODER KONKLUDENTE GARANTIE BEREITGESTELLT. DIE NUTZUNG ERFOLGT AUF EIGENE GEFAHR.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ Der Endpunkt sollte JSON im Format `{ "prompt": "Nachricht" }` akzeptieren und m
 
 Im Frontend befindet sich auf jeder Seite unten rechts ein ausklappbarer Chat-Button. Darüber lassen sich Fragen direkt an den lokalen Chatbot stellen.
 
+
+## Lizenz
+
+Copyright (c) 2024 Christopher Siefert. Alle Rechte vorbehalten.
+
+Der gesamte Code dieses Projekts ist proprietär. Eine Nutzung, Vervielfältigung, Veränderung oder Weitergabe ist ohne vorherige schriftliche Genehmigung von Christopher Siefert nicht gestattet. Weitere Informationen stehen in der [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- add proprietary LICENSE for Christopher Siefert
- document license requirements in README

## Testing
- `npm test`
- `./mvnw test` (failed: Non-resolvable parent POM, network unreachable)


------
https://chatgpt.com/codex/tasks/task_e_688dfb7c8c788325825037d4ba4e7357