### PR TITLE
Add service unit tests

### DIFF
--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/AuthServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.AuthRequest;
+import com.chrono.chrono.dto.AuthResponse;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.RoleRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.utils.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RoleRepository roleRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void login_returnsToken_whenCredentialsValid() {
+        AuthRequest request = new AuthRequest("john", "pass");
+        User user = new User();
+        user.setUsername("john");
+        user.setPassword("encoded");
+
+        when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("pass", "encoded")).thenReturn(true);
+        when(jwtUtil.generateTokenWithUser(user)).thenReturn("jwt-token");
+
+        AuthResponse response = authService.login(request);
+
+        assertEquals("jwt-token", response.getToken());
+        verify(userRepository).findByUsername("john");
+        verify(passwordEncoder).matches("pass", "encoded");
+        verify(jwtUtil).generateTokenWithUser(user);
+    }
+
+    @Test
+    void login_throwsException_whenPasswordInvalid() {
+        AuthRequest request = new AuthRequest("john", "wrong");
+        User user = new User();
+        user.setUsername("john");
+        user.setPassword("encoded");
+
+        when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
+
+        assertThrows(RuntimeException.class, () -> authService.login(request));
+        verify(passwordEncoder).matches("wrong", "encoded");
+    }
+
+    @Test
+    void login_throwsException_whenUserNotFound() {
+        AuthRequest request = new AuthRequest("unknown", "pass");
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> authService.login(request));
+        verify(userRepository).findByUsername("unknown");
+    }
+}
+

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/WorkScheduleServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/WorkScheduleServiceTest.java
@@ -1,0 +1,119 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.SickLeave;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.entities.VacationRequest;
+import com.chrono.chrono.repositories.SickLeaveRepository;
+import com.chrono.chrono.repositories.UserHolidayOptionRepository;
+import com.chrono.chrono.repositories.UserScheduleRuleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WorkScheduleServiceTest {
+
+    @Mock
+    private HolidayService holidayService;
+
+    @Mock
+    private SickLeaveRepository sickLeaveRepository;
+
+    @Mock
+    private UserHolidayOptionRepository userHolidayOptionRepository;
+
+    @Mock
+    private UserScheduleRuleRepository ruleRepo;
+
+    @InjectMocks
+    private WorkScheduleService workScheduleService;
+
+    private User createStandardUser() {
+        User user = new User();
+        user.setUsername("standard");
+        user.setIsHourly(false);
+        user.setIsPercentage(false);
+        user.setDailyWorkHours(8.0);
+        return user;
+    }
+
+    private User createPercentageUser() {
+        User user = new User();
+        user.setUsername("percent");
+        user.setIsHourly(false);
+        user.setIsPercentage(true);
+        user.setWorkPercentage(50);
+        user.setExpectedWorkDays(5);
+        return user;
+    }
+
+    @Test
+    void computeExpectedWorkMinutes_returnsZero_onHoliday() {
+        User user = createStandardUser();
+        LocalDate date = LocalDate.of(2024, 1, 1);
+        when(holidayService.isHoliday(date, null)).thenReturn(true);
+        when(sickLeaveRepository.findByUser(user)).thenReturn(List.of());
+
+        int minutes = workScheduleService.computeExpectedWorkMinutes(user, date, List.of());
+
+        assertEquals(0, minutes);
+        verify(holidayService).isHoliday(date, null);
+    }
+
+    @Test
+    void computeExpectedWorkMinutes_halfDayVacation_returnsHalfOfDailyMinutes() {
+        User user = createStandardUser();
+        LocalDate date = LocalDate.of(2024, 1, 2);
+        when(holidayService.isHoliday(date, null)).thenReturn(false);
+        when(sickLeaveRepository.findByUser(user)).thenReturn(List.of());
+
+        VacationRequest vr = new VacationRequest();
+        vr.setApproved(true);
+        vr.setHalfDay(true);
+        vr.setStartDate(date);
+        vr.setEndDate(date);
+
+        int minutes = workScheduleService.computeExpectedWorkMinutes(user, date, List.of(vr));
+
+        assertEquals(240, minutes);
+    }
+
+    @Test
+    void computeExpectedWorkMinutes_percentageUser_noAbsence_returnsProportionalMinutes() {
+        User user = createPercentageUser();
+        LocalDate date = LocalDate.of(2024, 1, 3);
+        when(holidayService.isHoliday(date, null)).thenReturn(false);
+        when(sickLeaveRepository.findByUser(user)).thenReturn(List.of());
+
+        int minutes = workScheduleService.computeExpectedWorkMinutes(user, date, List.of());
+
+        assertEquals(255, minutes);
+    }
+
+    @Test
+    void computeExpectedWorkMinutes_percentageUser_halfDaySick_returnsHalfProportionalMinutes() {
+        User user = createPercentageUser();
+        LocalDate date = LocalDate.of(2024, 1, 4);
+        when(holidayService.isHoliday(date, null)).thenReturn(false);
+
+        SickLeave sick = new SickLeave();
+        sick.setStartDate(date);
+        sick.setEndDate(date);
+        sick.setHalfDay(true);
+
+        when(sickLeaveRepository.findByUser(user)).thenReturn(List.of(sick));
+
+        int minutes = workScheduleService.computeExpectedWorkMinutes(user, date, List.of());
+
+        assertEquals(127, minutes);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Mockito-based tests for `AuthService` login paths
- cover holidays, sick leave, vacation, and percent work time in `WorkScheduleService` tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM – Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_688e05a6c8008325bbadb2a0b35247aa