### PR TITLE
test: add Navbar and Login tests

### DIFF
--- a/Chrono-frontend/src/components/__tests__/Login.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/Login.test.jsx
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../components/Navbar', () => ({ default: () => <div>Navbar</div> }));
+vi.mock('howler', () => ({ Howl: vi.fn().mockImplementation(() => ({ play: vi.fn() })) }));
+vi.mock('/sounds/stamp.mp3', () => ({ default: '' }), { virtual: true });
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return { ...actual, useNavigate: () => mockNavigate, useLocation: () => ({ search: '' }) };
+});
+
+import { MemoryRouter } from 'react-router-dom';
+import Login from '../../pages/Login.jsx';
+import { AuthContext } from '../../context/AuthContext.jsx';
+import { LanguageProvider } from '../../context/LanguageContext.jsx';
+
+beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('Login', () => {
+    it('submits credentials and navigates after successful login', async () => {
+        const loginMock = vi.fn().mockResolvedValue({ success: true, user: {} });
+        render(
+            <MemoryRouter>
+                <LanguageProvider>
+                    <AuthContext.Provider value={{ login: loginMock }}>
+                        <Login />
+                    </AuthContext.Provider>
+                </LanguageProvider>
+            </MemoryRouter>
+        );
+
+        await userEvent.type(screen.getByLabelText(/Benutzername/i), ' alice ');
+        await userEvent.type(screen.getByLabelText(/Passwort/i), 'secret');
+        await userEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+        expect(loginMock).toHaveBeenCalledWith('alice', 'secret');
+        expect(mockNavigate).toHaveBeenCalledWith('/user', { replace: true });
+    });
+});

--- a/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/api', () => ({ default: { get: vi.fn().mockResolvedValue({ data: null }) } }));
+vi.mock('../ChangelogModal.jsx', () => ({ default: () => null }));
+
+import Navbar from '../Navbar.jsx';
+import { AuthContext } from '../../context/AuthContext.jsx';
+import { LanguageProvider } from '../../context/LanguageContext.jsx';
+import { MemoryRouter } from 'react-router-dom';
+
+const renderNavbar = (authValue, initialRoute = '/') => {
+    return render(
+        <MemoryRouter initialEntries={[initialRoute]}>
+            <LanguageProvider>
+                <AuthContext.Provider value={authValue}>
+                    <Navbar />
+                </AuthContext.Provider>
+            </LanguageProvider>
+        </MemoryRouter>
+    );
+};
+
+describe('Navbar', () => {
+    it('shows login and register links when unauthenticated', () => {
+        renderNavbar({ authToken: null, currentUser: null, logout: vi.fn() }, '/login');
+        expect(screen.getByText(/Login/i)).toBeInTheDocument();
+        expect(screen.getByText(/Registrieren/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Abmelden/i)).toBeNull();
+    });
+
+    it('displays username and triggers logout when authenticated', async () => {
+        const logoutMock = vi.fn();
+        renderNavbar({ authToken: 'token', currentUser: { username: 'Alice', roles: [] }, logout: logoutMock }, '/dashboard');
+        expect(screen.getByText(/Hallo, Alice/)).toBeInTheDocument();
+        const logoutButton = screen.getByRole('button', { name: /Abmelden/i });
+        await userEvent.click(logoutButton);
+        expect(logoutMock).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- add vitest for Navbar auth links and logout behavior
- cover Login form submit and navigation

## Testing
- `cd Chrono-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e05ac2b7c8325a7218e523f1a5e6c