### PR TITLE
feat: add monitoring and logging setup

### DIFF
--- a/Chrono-backend/pom.xml
+++ b/Chrono-backend/pom.xml
@@ -36,6 +36,21 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Monitoring & Logging -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>7.4</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.poi</groupId>

--- a/Chrono-backend/src/main/resources/application.properties
+++ b/Chrono-backend/src/main/resources/application.properties
@@ -39,3 +39,7 @@ spring.servlet.multipart.max-request-size=5MB
 
 # Local LLM endpoint
 llm.base-url=${LLM_BASE_URL:http://localhost:5000}
+
+# Monitoring endpoints
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.prometheus.enabled=true

--- a/Chrono-backend/src/main/resources/logback-spring.xml
+++ b/Chrono-backend/src/main/resources/logback-spring.xml
@@ -10,14 +10,13 @@
         <CacheExpiration>60</CacheExpiration>
     </turboFilter>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-        </encoder>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 
     <logger name="org.hibernate.SQL" level="DEBUG"/>
 
-    <root level="INFO"> <appender-ref ref="STDOUT"/>
+    <root level="INFO">
+        <appender-ref ref="JSON"/>
     </root>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ Im Backend befinden sich unter `com.chrono.chrono` die Pakete `controller`, `ser
 | `Chrono-frontend` | `npm run build`                 | Produktionsbuild des Frontends  |
 | `Chrono-frontend` | `npm run electron`              | Electron-App inklusive Backend  |
 
+## Monitoring & Logging
+
+Das Backend stellt über Spring Boot Actuator Metriken unter `/actuator/prometheus` bereit und gibt Logs im JSON-Format auf `STDOUT` aus.
+
+### Prometheus und Grafana
+
+```bash
+docker network create monitoring
+
+docker run -d --name=prometheus --network=monitoring \
+  -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml \
+  -p 9090:9090 prom/prometheus
+
+docker run -d --name=grafana --network=monitoring \
+  -p 3000:3000 grafana/grafana
+```
+
+Die `prometheus.yml` sollte das Backend unter `http://<server>:8080/actuator/prometheus` scrapen.
+
+### Log-Sammlung (optional)
+
+```bash
+docker run -d --name=loki --network=monitoring -p 3100:3100 grafana/loki
+docker run -d --name=promtail --network=monitoring \
+  -v $(pwd)/promtail-config.yml:/etc/promtail/config.yml grafana/promtail
+```
+
 ## Weiterführendes
 
 Für Code-Qualitätsanalysen liegen `qodana.yaml`‑Dateien in beiden Teilprojekten. Die Einstellungen in `application.properties` geben Hinweise auf benötigte Umgebungsvariablen für die Datenbank- und Mailkonfiguration.


### PR DESCRIPTION
## Summary
- add Spring Boot Actuator, Prometheus registry, and logstash encoder
- expose Prometheus endpoint and enable JSON logging
- document Prometheus/Grafana/Loki setup for monitoring

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e07d5f1348325b5ee683cdb38ab5c