### PR TITLE
Prevent multiple daily shifts for one user

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminScheduleEntryController.java
@@ -47,7 +47,7 @@ public class AdminScheduleEntryController {
         }
         User user = userOpt.get();
 
-        Optional<ScheduleEntry> existingEntry = entryRepo.findByUserAndDateAndShift(user, dto.getDate(), dto.getShift());
+        Optional<ScheduleEntry> existingEntry = entryRepo.findByUserAndDate(user, dto.getDate());
         if(existingEntry.isPresent()) {
             return ResponseEntity.ok(new ScheduleEntryDTO(existingEntry.get()));
         }
@@ -70,7 +70,7 @@ public class AdminScheduleEntryController {
             if (user == null) {
                 return null;
             }
-            Optional<ScheduleEntry> existing = entryRepo.findByUserAndDateAndShift(user, dto.getDate(), dto.getShift());
+            Optional<ScheduleEntry> existing = entryRepo.findByUserAndDate(user, dto.getDate());
             if (existing.isPresent()) {
                 return null;
             }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/ScheduleEntry.java
@@ -4,7 +4,12 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "schedule_entries")
+@Table(
+        name = "schedule_entries",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "date"})
+        }
+)
 public class ScheduleEntry {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 public interface ScheduleEntryRepository extends JpaRepository<ScheduleEntry, Long> {
     List<ScheduleEntry> findByDateBetween(LocalDate start, LocalDate end);
 
-    // --- NEU: Methode zur Prüfung auf doppelte Einträge ---
-    Optional<ScheduleEntry> findByUserAndDateAndShift(User user, LocalDate date, String shift);
+    // Verhindert doppelte Einträge pro Nutzer und Datum
+    Optional<ScheduleEntry> findByUserAndDate(User user, LocalDate date);
 }


### PR DESCRIPTION
## Summary
- ensure schedule entries are unique per user and date
- check for existing user/day entry before saving or autofilling shifts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f4b79f7c08325a37904c55c5a8942