### PR TITLE
feat: enforce weekly hour limits during schedule creation

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleEntryRepository.java
@@ -12,4 +12,6 @@ public interface ScheduleEntryRepository extends JpaRepository<ScheduleEntry, Lo
 
     // Verhindert doppelte Einträge pro Nutzer und Datum
     Optional<ScheduleEntry> findByUserAndDate(User user, LocalDate date);
+
+    List<ScheduleEntry> findByUserAndDateBetween(User user, LocalDate start, LocalDate end);
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleRuleRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/ScheduleRuleRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ScheduleRuleRepository extends JpaRepository<ScheduleRule, Long> {
     List<ScheduleRule> findByIsActiveTrueOrderByStartTime();
+
+    java.util.Optional<ScheduleRule> findByShiftKey(String shiftKey);
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/WorkScheduleService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/WorkScheduleService.java
@@ -211,8 +211,19 @@ public class WorkScheduleService {
 
         int netExpectedMinutes = Math.max(0, expectedWeeklyMinutesTotal - absenceMinutesToDeduct);
         logger.debug("User: {}, Week starting: {}, Base Expected ({}%): {}min, Total Absence Deduction (Vacation+Sick+Holiday): {}min, Net Expected: {}min",
-                user.getUsername(), startOfWeek, user.getWorkPercentage(),expectedWeeklyMinutesTotal, absenceMinutesToDeduct, netExpectedMinutes);
+                user.getUsername(), startOfWeek, user.getWorkPercentage(), expectedWeeklyMinutesTotal, absenceMinutesToDeduct, netExpectedMinutes);
         return netExpectedMinutes;
+    }
+
+    public int getExpectedWeeklyMinutes(User user, LocalDate dateInWeek) {
+        LocalDate startOfWeek = dateInWeek.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        int total = 0;
+        for (int i = 0; i < 7; i++) {
+            LocalDate d = startOfWeek.plusDays(i);
+            double hours = getExpectedWorkHours(user, d);
+            total += (int) Math.round(hours * 60);
+        }
+        return total;
     }
 
 


### PR DESCRIPTION
## Summary
- calculate expected weekly work minutes for a user
- add repository helpers for schedule lookups
- prevent schedule entries from exceeding weekly hour limits in manual and auto-fill APIs
- skip scheduling when user has a day off or no expected hours and exclude vacation days during auto-fill
- warn administrators when assigning a shift on a day the user is off

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2)*
- `npm test --silent` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4e4dd2988325ba6213b48a86d7d5