### PR TITLE
feat(admin): add collapsible scrollable requests lists

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
@@ -22,7 +22,7 @@ const AdminCorrectionsList = ({
     // Wird jetzt ein Array von IDs für die Gruppenverarbeitung halten
     const [targetIds, setTargetIds] = useState([]);
     const [adminComment, setAdminComment] = useState("");
-    const [isExpanded, setIsExpanded] = useState(true);
+    const [isExpanded, setIsExpanded] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
     const [searchDate, setSearchDate] = useState('');
 
@@ -84,6 +84,8 @@ const AdminCorrectionsList = ({
         return Array.from(groups.values()).sort((a, b) => b.id - a.id);
     }, [allCorrections, searchTerm, searchDate]);
 
+    const isScrollable = groupedAndFilteredCorrections.length > 20;
+
     return (
         <div className="content-section">
             <header className="section-header" onClick={() => setIsExpanded(!isExpanded)}>
@@ -111,7 +113,7 @@ const AdminCorrectionsList = ({
                             {t('adminDashboard.resetFilters', 'Filter zurücksetzen')}
                         </button>
                     </div>
-                    <div className="corrections-list-container">
+                    <div className="corrections-list-container" style={{ maxHeight: isScrollable ? '70vh' : 'none' }}>
                         <table className="corrections-table">
                             <thead>
                             <tr>
@@ -126,7 +128,7 @@ const AdminCorrectionsList = ({
                             <tbody>
                             {groupedAndFilteredCorrections.length > 0 ? (
                                 groupedAndFilteredCorrections.map(group => (
-                                    <tr key={group.id}>
+                                    <tr key={group.id} className={`status-${group.status.toLowerCase()}`}>
                                         <td data-label={t('adminCorrections.header.user')}>{group.username}</td>
                                         <td data-label={t('adminCorrections.header.date')}>{formatDate(group.requestDate)}</td>
                                         <td data-label={t('adminCorrections.header.request')}>

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
@@ -74,6 +74,8 @@ const AdminVacationRequests = ({
         (formatDate(v.endDate) || '').includes(searchTerm)
     );
 
+    const sortedVacations = [...filteredVacations].sort((a, b) => b.id - a.id);
+
     return (
         <div className="admin-dashboard scoped-dashboard"> {/* Stellt sicher, dass CSS-Variablen verfügbar sind */}
             <section className="vacation-section content-section"> {/* Allgemeine Klasse für Sektionen */}
@@ -101,11 +103,12 @@ const AdminVacationRequests = ({
                             onChange={handleSearch}
                             className="search-input"
                         />
-                        {filteredVacations.length === 0 ? (
+                        {sortedVacations.length === 0 ? (
                             <p>{t('adminDashboard.noVacationRequests', 'Keine Urlaubsanträge gefunden.')}</p>
                         ) : (
+                            <div className="vacation-requests-container" style={{ maxHeight: sortedVacations.length > 20 ? '70vh' : 'none' }}>
                             <ul className="item-list vacation-request-list">
-                                {filteredVacations.map((v) => {
+                                {sortedVacations.map((v) => {
                                     const status = v.approved
                                         ? t('adminDashboard.statusApproved', 'Genehmigt')
                                         : v.denied
@@ -118,7 +121,7 @@ const AdminVacationRequests = ({
                                             : 'status-pending';
 
                                     return (
-                                        <li key={v.id} className="list-item vacation-item">
+                                        <li key={v.id} className={`list-item vacation-item ${statusClass}`}>
                                             <div className="item-info">
                                                 <strong className="username">{v.username || t('adminVacation.unknownUser', 'Unbekannt')}</strong>
                                                 <span>
@@ -159,6 +162,7 @@ const AdminVacationRequests = ({
                                     );
                                 })}
                             </ul>
+                            </div>
                         )}
                     </div>
                 )}

--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -1804,6 +1804,15 @@
   background-color: var(--ad-c-bg-card);
 }
 
+.vacation-requests-container {
+  overflow-y: auto;
+  max-height: 70vh;
+  border: 1px solid var(--ad-c-border);
+  border-radius: var(--ad-radius-lg);
+  box-shadow: var(--ad-shadow-sm);
+  background-color: var(--ad-c-bg-card);
+}
+
 .corrections-table {
   width: 100%;
   border-collapse: collapse;
@@ -1878,6 +1887,33 @@
   background-color: var(--ad-c-danger, #ef4444);
 }
 
+.vacation-request-list .vacation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--ad-c-border);
+}
+
+.vacation-request-list .vacation-item:last-child {
+  border-bottom: none;
+}
+
+.corrections-table tr.status-approved,
+.vacation-request-list .vacation-item.status-approved {
+  border-left: 4px solid var(--ad-c-success);
+}
+
+.corrections-table tr.status-denied,
+.vacation-request-list .vacation-item.status-denied {
+  border-left: 4px solid var(--ad-c-danger);
+}
+
+.corrections-table tr.status-pending,
+.vacation-request-list .vacation-item.status-pending {
+  border-left: 4px solid var(--ad-c-warn);
+}
+
 .corrections-table .action-buttons {
   display: flex;
   gap: 10px;
@@ -1939,6 +1975,11 @@
 }
 
 [data-theme="dark"] .corrections-list-container {
+  border-color: var(--c-border);
+  background-color: var(--c-card);
+}
+
+[data-theme="dark"] .vacation-requests-container {
   border-color: var(--c-border);
   background-color: var(--c-card);
 }


### PR DESCRIPTION
## Summary
- collapse correction and vacation request sections by default
- add scrollable containers and sorting for large request lists
- highlight request status with consistent admin dashboard colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b9149b6083259956245b0340b1e4