### PR TITLE
Fetch original timestamps for correction requests

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CorrectionRequestRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/CorrectionRequestRepository.java
@@ -17,8 +17,11 @@ public interface CorrectionRequestRepository extends JpaRepository<CorrectionReq
 
     List<CorrectionRequest> findByUser(User user);
 
-    @Query("SELECT cr FROM CorrectionRequest cr JOIN FETCH cr.user u WHERE u.company.id = :companyId")
+    @Query("SELECT cr FROM CorrectionRequest cr LEFT JOIN FETCH cr.user u LEFT JOIN FETCH cr.targetEntry WHERE u.company.id = :companyId")
     List<CorrectionRequest> findAllByCompanyId(@Param("companyId") Long companyId);
+
+    @Query("SELECT cr FROM CorrectionRequest cr LEFT JOIN FETCH cr.user u LEFT JOIN FETCH cr.targetEntry")
+    List<CorrectionRequest> findAllWithDetails();
     @Query("SELECT cr FROM CorrectionRequest cr LEFT JOIN FETCH cr.user u LEFT JOIN FETCH cr.targetEntry WHERE u.username = :username ORDER BY cr.requestDate DESC")
     List<CorrectionRequest> findByUserWithDetails(@Param("username") String username);
     List<CorrectionRequest> findByUserAndDesiredTimestampBetweenAndApprovedIsFalseAndDeniedIsFalse(User user, LocalDateTime start, LocalDateTime end);

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/CorrectionRequestService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/CorrectionRequestService.java
@@ -183,12 +183,12 @@ public class CorrectionRequestService {
     }
 
     public List<CorrectionRequest> getAllRequests() {
-        // Lädt alle Anfragen, ideal für Super-Admins.
-        return correctionRepo.findAll();
+        // Lädt alle Anfragen, inklusive Originalzeiten und Benutzer, ideal für Super-Admins.
+        return correctionRepo.findAllWithDetails();
     }
 
     public List<CorrectionRequest> getRequestsByCompany(Long companyId) {
-        // Lädt alle Anfragen für eine spezifische Company-ID.
+        // Lädt alle Anfragen für eine spezifische Company-ID inklusive Originalzeiten.
         return correctionRepo.findAllByCompanyId(companyId);
     }
 

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
@@ -151,17 +151,17 @@ const AdminCorrectionsList = ({
                                                         <div className="request-detail" key={req.id}>
                                                             {req.originalTimestamp ? (
                                                                 <span>
-                                                                    <s className="original-time">
+                                                                    {t('correction.oldTime', 'Alt')}: <s className="original-time">
                                                                         {formatTime(req.originalTimestamp)} {req.originalPunchType}
                                                                     </s>{' '}
                                                                     &rarr;{' '}
-                                                                    <strong className="desired-time">
+                                                                    {t('correction.newTime', 'Neu')}: <strong className="desired-time">
                                                                         {formatTime(req.desiredTimestamp)} {req.desiredPunchType}
                                                                     </strong>
                                                                 </span>
                                                             ) : (
                                                                 <strong className="desired-time">
-                                                                    Neu: {formatTime(req.desiredTimestamp)} {req.desiredPunchType}
+                                                                    {t('correction.newTime', 'Neu')}: {formatTime(req.desiredTimestamp)} {req.desiredPunchType}
                                                                 </strong>
                                                             )}
                                                         </div>
@@ -218,7 +218,20 @@ const AdminCorrectionsList = ({
 
 AdminCorrectionsList.propTypes = {
     t: PropTypes.func.isRequired,
-    allCorrections: PropTypes.array.isRequired,
+    allCorrections: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            username: PropTypes.string.isRequired,
+            requestDate: PropTypes.string.isRequired,
+            reason: PropTypes.string.isRequired,
+            desiredTimestamp: PropTypes.string.isRequired,
+            desiredPunchType: PropTypes.string.isRequired,
+            originalTimestamp: PropTypes.string,
+            originalPunchType: PropTypes.string,
+            approved: PropTypes.bool,
+            denied: PropTypes.bool,
+        })
+    ).isRequired,
     onApprove: PropTypes.func.isRequired,
     onDeny: PropTypes.func.isRequired,
 };

--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -1871,11 +1871,20 @@
   padding-bottom: 10px;
 }
 
+
 .correction-request-list
   .correction-item
   .correction-details
   .original-time {
-  color: var(--ad-c-text-muted);
+  color: var(--c-muted);
+}
+
+.correction-request-list
+  .correction-item
+  .correction-details
+  .desired-time {
+  color: var(--c-text);
+  font-weight: 600;
 }
 
 .correction-request-list .correction-item .reason-text {


### PR DESCRIPTION
## Summary
- explicitly label old and requested times in admin correction requests
- type correction data to include original and desired timestamps
- style old vs new times for clear presentation

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: pcsclite build error: fatal error: winscard.h: No such file or directory)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68931e7db6c883258e789a3cfc8631a5