### PR TITLE
feat: add project budget and reporting

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ProjectController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ProjectController.java
@@ -79,6 +79,7 @@ public class ProjectController {
 
         existing.setName(projectDetails.getName());
         existing.setCustomer(customer);
+        existing.setBudgetMinutes(projectDetails.getBudgetMinutes());
         Project saved = projectService.save(existing);
 
         return ResponseEntity.ok(saved);

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
@@ -1,5 +1,6 @@
 package com.chrono.chrono.controller;
 
+import com.chrono.chrono.dto.ProjectReportDTO;
 import com.chrono.chrono.services.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -14,6 +15,20 @@ public class ReportController {
 
     @Autowired
     private ReportService reportService;
+
+    @GetMapping("/project/{projectId}")
+    public ResponseEntity<ProjectReportDTO> projectReport(
+            @PathVariable Long projectId,
+            @RequestParam String startDate,
+            @RequestParam String endDate
+    ) {
+        ProjectReportDTO dto = reportService.generateProjectReport(
+                projectId,
+                LocalDate.parse(startDate),
+                LocalDate.parse(endDate)
+        );
+        return ResponseEntity.ok(dto);
+    }
 
     @GetMapping("/timesheet/pdf")
     public ResponseEntity<byte[]> downloadPdf(

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/TaskController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/TaskController.java
@@ -1,0 +1,21 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.entities.Task;
+import com.chrono.chrono.services.TaskService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    @Autowired
+    private TaskService taskService;
+
+    @GetMapping
+    public List<Task> getTasks(@RequestParam(value = "projectId", required = false) Long projectId) {
+        return taskService.getTasks(projectId);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ProjectReportDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ProjectReportDTO.java
@@ -1,0 +1,43 @@
+package com.chrono.chrono.dto;
+
+import java.util.List;
+
+public class ProjectReportDTO {
+    private Long projectId;
+    private String projectName;
+    private Long totalMinutes;
+    private Integer budgetMinutes;
+    private Integer remainingMinutes;
+    private List<TaskReportDTO> tasks;
+
+    public ProjectReportDTO() {}
+
+    public ProjectReportDTO(Long projectId, String projectName, Long totalMinutes, Integer budgetMinutes, List<TaskReportDTO> tasks) {
+        this.projectId = projectId;
+        this.projectName = projectName;
+        this.totalMinutes = totalMinutes;
+        this.budgetMinutes = budgetMinutes;
+        this.tasks = tasks;
+        if (budgetMinutes != null) {
+            this.remainingMinutes = budgetMinutes - totalMinutes.intValue();
+        }
+    }
+
+    public Long getProjectId() { return projectId; }
+    public void setProjectId(Long projectId) { this.projectId = projectId; }
+
+    public String getProjectName() { return projectName; }
+    public void setProjectName(String projectName) { this.projectName = projectName; }
+
+    public Long getTotalMinutes() { return totalMinutes; }
+    public void setTotalMinutes(Long totalMinutes) { this.totalMinutes = totalMinutes; }
+
+    public Integer getBudgetMinutes() { return budgetMinutes; }
+    public void setBudgetMinutes(Integer budgetMinutes) { this.budgetMinutes = budgetMinutes; }
+
+    public Integer getRemainingMinutes() { return remainingMinutes; }
+    public void setRemainingMinutes(Integer remainingMinutes) { this.remainingMinutes = remainingMinutes; }
+
+    public List<TaskReportDTO> getTasks() { return tasks; }
+    public void setTasks(List<TaskReportDTO> tasks) { this.tasks = tasks; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/TaskReportDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/TaskReportDTO.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.dto;
+
+public class TaskReportDTO {
+    private Long taskId;
+    private String taskName;
+    private Long totalMinutes;
+    private Integer budgetMinutes;
+    private Integer remainingMinutes;
+
+    public TaskReportDTO() {}
+
+    public TaskReportDTO(Long taskId, String taskName, Long totalMinutes, Integer budgetMinutes) {
+        this.taskId = taskId;
+        this.taskName = taskName;
+        this.totalMinutes = totalMinutes;
+        this.budgetMinutes = budgetMinutes;
+        if (budgetMinutes != null) {
+            this.remainingMinutes = budgetMinutes - totalMinutes.intValue();
+        }
+    }
+
+    public Long getTaskId() { return taskId; }
+    public void setTaskId(Long taskId) { this.taskId = taskId; }
+
+    public String getTaskName() { return taskName; }
+    public void setTaskName(String taskName) { this.taskName = taskName; }
+
+    public Long getTotalMinutes() { return totalMinutes; }
+    public void setTotalMinutes(Long totalMinutes) { this.totalMinutes = totalMinutes; }
+
+    public Integer getBudgetMinutes() { return budgetMinutes; }
+    public void setBudgetMinutes(Integer budgetMinutes) { this.budgetMinutes = budgetMinutes; }
+
+    public Integer getRemainingMinutes() { return remainingMinutes; }
+    public void setRemainingMinutes(Integer remainingMinutes) { this.remainingMinutes = remainingMinutes; }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/TimeTrackingEntryDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/TimeTrackingEntryDTO.java
@@ -10,19 +10,29 @@ public class TimeTrackingEntryDTO {
     private String customerName;
     private Long projectId;
     private String projectName;
+    private Long taskId;
+    private String taskName;
+    private Integer durationMinutes;
+    private String description;
+    private boolean approved;
     private LocalDateTime entryTimestamp;
     private TimeTrackingEntry.PunchType punchType;
     private TimeTrackingEntry.PunchSource source;
     private boolean correctedByUser;
     private String systemGeneratedNote;
 
-    public TimeTrackingEntryDTO(Long id, String username, Long customerId, String customerName, Long projectId, String projectName, LocalDateTime entryTimestamp, TimeTrackingEntry.PunchType punchType, TimeTrackingEntry.PunchSource source, boolean correctedByUser, String systemGeneratedNote) {
+    public TimeTrackingEntryDTO(Long id, String username, Long customerId, String customerName, Long projectId, String projectName, Long taskId, String taskName, Integer durationMinutes, String description, boolean approved, LocalDateTime entryTimestamp, TimeTrackingEntry.PunchType punchType, TimeTrackingEntry.PunchSource source, boolean correctedByUser, String systemGeneratedNote) {
         this.id = id;
         this.username = username;
         this.customerId = customerId;
         this.customerName = customerName;
         this.projectId = projectId;
         this.projectName = projectName;
+        this.taskId = taskId;
+        this.taskName = taskName;
+        this.durationMinutes = durationMinutes;
+        this.description = description;
+        this.approved = approved;
         this.entryTimestamp = entryTimestamp;
         this.punchType = punchType;
         this.source = source;
@@ -39,6 +49,11 @@ public class TimeTrackingEntryDTO {
             entry.getCustomer() != null ? entry.getCustomer().getName() : null,
             entry.getProject() != null ? entry.getProject().getId() : null,
             entry.getProject() != null ? entry.getProject().getName() : null,
+            entry.getTask() != null ? entry.getTask().getId() : null,
+            entry.getTask() != null ? entry.getTask().getName() : null,
+            entry.getDurationMinutes(),
+            entry.getDescription(),
+            entry.isApproved(),
             entry.getEntryTimestamp(),
             entry.getPunchType(),
             entry.getSource(),
@@ -54,6 +69,11 @@ public class TimeTrackingEntryDTO {
     public String getCustomerName() { return customerName; }
     public Long getProjectId() { return projectId; }
     public String getProjectName() { return projectName; }
+    public Long getTaskId() { return taskId; }
+    public String getTaskName() { return taskName; }
+    public Integer getDurationMinutes() { return durationMinutes; }
+    public String getDescription() { return description; }
+    public boolean isApproved() { return approved; }
     public LocalDateTime getEntryTimestamp() { return entryTimestamp; }
     public TimeTrackingEntry.PunchType getPunchType() { return punchType; }
     public TimeTrackingEntry.PunchSource getSource() { return source; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/Task.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/Task.java
@@ -4,19 +4,22 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "projects")
-public class Project {
+@Table(name = "tasks")
+public class Task {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "customer_id")
+    @JoinColumn(name = "project_id")
     @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-    private Customer customer;
+    private Project project;
 
     @Column(nullable = false)
     private String name;
+
+    @Column
+    private Boolean billable;
 
     @Column(name = "budget_minutes")
     private Integer budgetMinutes;
@@ -24,11 +27,14 @@ public class Project {
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
-    public Customer getCustomer() { return customer; }
-    public void setCustomer(Customer customer) { this.customer = customer; }
+    public Project getProject() { return project; }
+    public void setProject(Project project) { this.project = project; }
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
+
+    public Boolean getBillable() { return billable; }
+    public void setBillable(Boolean billable) { this.billable = billable; }
 
     public Integer getBudgetMinutes() { return budgetMinutes; }
     public void setBudgetMinutes(Integer budgetMinutes) { this.budgetMinutes = budgetMinutes; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/TimeTrackingEntry.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/TimeTrackingEntry.java
@@ -8,6 +8,7 @@ import java.time.LocalTime; // Import für getEntryTime
 
 import com.chrono.chrono.entities.Customer;
 import com.chrono.chrono.entities.Project;
+import com.chrono.chrono.entities.Task;
 
 @Entity
 @Table(name = "time_tracking_entries",
@@ -34,6 +35,10 @@ public class TimeTrackingEntry {
     @JoinColumn(name = "project_id")
     private Project project;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
     @Column(name = "entry_timestamp", nullable = false)
     private LocalDateTime entryTimestamp; // Präziser Zeitstempel für das Ereignis
 
@@ -50,6 +55,15 @@ public class TimeTrackingEntry {
 
     @Column(name = "system_generated_note", length = 255)
     private String systemGeneratedNote; // z.B. "Automatischer Arbeitsende-Stempel"
+
+    @Column(name = "duration_minutes")
+    private Integer durationMinutes;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    @Column(name = "approved", nullable = false)
+    private boolean approved = false;
 
     public enum PunchType {
         START,
@@ -107,6 +121,8 @@ public class TimeTrackingEntry {
     public void setCustomer(Customer customer) { this.customer = customer; }
     public Project getProject() { return project; }
     public void setProject(Project project) { this.project = project; }
+    public Task getTask() { return task; }
+    public void setTask(Task task) { this.task = task; }
     public LocalDateTime getEntryTimestamp() { return entryTimestamp; }
     public void setEntryTimestamp(LocalDateTime entryTimestamp) { this.entryTimestamp = entryTimestamp; }
     public PunchType getPunchType() { return punchType; }
@@ -117,6 +133,12 @@ public class TimeTrackingEntry {
     public void setCorrectedByUser(boolean correctedByUser) { this.correctedByUser = correctedByUser; }
     public String getSystemGeneratedNote() { return systemGeneratedNote; }
     public void setSystemGeneratedNote(String systemGeneratedNote) { this.systemGeneratedNote = systemGeneratedNote; }
+    public Integer getDurationMinutes() { return durationMinutes; }
+    public void setDurationMinutes(Integer durationMinutes) { this.durationMinutes = durationMinutes; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public boolean isApproved() { return approved; }
+    public void setApproved(boolean approved) { this.approved = approved; }
 
     @Transient
     public LocalDate getEntryDate() {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TaskRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TaskRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories;
+
+import com.chrono.chrono.entities.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TaskRepository extends JpaRepository<Task, Long> {
+    List<Task> findByProjectId(Long projectId);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TimeTrackingEntryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TimeTrackingEntryRepository.java
@@ -2,6 +2,7 @@ package com.chrono.chrono.repositories;
 
 import com.chrono.chrono.entities.TimeTrackingEntry;
 import com.chrono.chrono.entities.User;
+import com.chrono.chrono.entities.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -43,4 +44,10 @@ public interface TimeTrackingEntryRepository extends JpaRepository<TimeTrackingE
 
     @Query("SELECT t.customer.id FROM TimeTrackingEntry t WHERE t.user.id = :userId AND t.customer IS NOT NULL GROUP BY t.customer.id ORDER BY MAX(t.entryTimestamp) DESC")
     List<Long> findRecentCustomerIds(@Param("userId") Long userId, org.springframework.data.domain.Pageable pageable);
+
+    List<TimeTrackingEntry> findByProjectAndEntryTimestampBetween(
+            Project project,
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    );
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/TaskService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/TaskService.java
@@ -1,0 +1,21 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.entities.Task;
+import com.chrono.chrono.repositories.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class TaskService {
+    @Autowired
+    private TaskRepository taskRepository;
+
+    public List<Task> getTasks(Long projectId) {
+        if (projectId != null) {
+            return taskRepository.findByProjectId(projectId);
+        }
+        return taskRepository.findAll();
+    }
+}

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -25,6 +25,7 @@ import AdminUserManagementPage from "./pages/AdminUserManagement/AdminUserManage
 import AdminChangePassword from "./pages/AdminChangePassword.jsx";
 import AdminCustomersPage from "./pages/AdminCustomers/AdminCustomersPage.jsx";
 import AdminProjectsPage from "./pages/AdminProjects/AdminProjectsPage.jsx";
+import AdminProjectReportPage from "./pages/AdminProjectReport/AdminProjectReportPage.jsx";
 import AdminPayslipsPage from "./pages/AdminPayslipsPage.jsx";
 import AdminSchedulePlannerPage from "./pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx";
 // NEU: Import der Seite für Schichtregeln
@@ -70,6 +71,7 @@ function App() {
                         <Route path="/admin/change-password" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminChangePassword /></PrivateRoute>} />
                         <Route path="/admin/customers" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminCustomersPage /></PrivateRoute>} />
                         <Route path="/admin/projects" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectsPage /></PrivateRoute>} />
+                        <Route path="/admin/project-report" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectReportPage /></PrivateRoute>} />
                         <Route path="/admin/company" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanyManagementPage /></PrivateRoute>} />
                         <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN", "ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
                         <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />

--- a/Chrono-frontend/src/context/ProjectContext.jsx
+++ b/Chrono-frontend/src/context/ProjectContext.jsx
@@ -22,9 +22,9 @@ export const ProjectProvider = ({ children }) => {
     }
   }, [notify, t]);
 
-  const createProject = useCallback(async (name, customerId) => {
+  const createProject = useCallback(async (name, customerId, budgetMinutes) => {
     try {
-      const res = await api.post('/api/projects', { name: name.trim(), customer: { id: customerId } });
+      const res = await api.post('/api/projects', { name: name.trim(), customer: { id: customerId }, budgetMinutes });
       setProjects(prev => [...prev, res.data]);
       return res.data;
     } catch (err) {
@@ -34,9 +34,9 @@ export const ProjectProvider = ({ children }) => {
     }
   }, [notify, t]);
 
-  const updateProject = useCallback(async (id, name, customerId) => {
+  const updateProject = useCallback(async (id, name, customerId, budgetMinutes) => {
     try {
-      const res = await api.put(`/api/projects/${id}`, { name: name.trim(), customer: { id: customerId } });
+      const res = await api.put(`/api/projects/${id}`, { name: name.trim(), customer: { id: customerId }, budgetMinutes });
       setProjects(prev => prev.map(p => p.id === id ? res.data : p));
       return res.data;
     } catch (err) {

--- a/Chrono-frontend/src/pages/AdminProjectReport/AdminProjectReportPage.jsx
+++ b/Chrono-frontend/src/pages/AdminProjectReport/AdminProjectReportPage.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { useProjects } from '../../context/ProjectContext';
+import { useTranslation } from '../../context/LanguageContext';
+import api from '../../utils/api';
+
+const AdminProjectReportPage = () => {
+  const { projects } = useProjects();
+  const { t } = useTranslation();
+  const [projectId, setProjectId] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [report, setReport] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadReport = async () => {
+    if (!projectId || !startDate || !endDate) return;
+    setLoading(true);
+    try {
+      const res = await api.get(`/api/report/project/${projectId}`, {
+        params: { startDate, endDate }
+      });
+      setReport(res.data);
+    } catch (err) {
+      console.error('Error fetching project report', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const minsToHours = (mins) => mins == null ? '-' : (mins / 60).toFixed(1);
+  const overallPct = report && report.budgetMinutes ? (report.totalMinutes / report.budgetMinutes) * 100 : 0;
+
+  return (
+    <div className="admin-project-report">
+      <h2>{t('projectReport', 'Projekt-Auswertung')}</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <select value={projectId} onChange={e => setProjectId(e.target.value)}>
+          <option value="">{t('selectProject', 'Projekt wählen')}</option>
+          {projects.map(p => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+        <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+        <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+        <button onClick={loadReport} disabled={loading}>{t('generateReport', 'Bericht erstellen')}</button>
+      </div>
+
+      {report && (
+        <div>
+          {report.budgetMinutes != null && (
+            <div style={{ border: '1px solid #ccc', height: '20px', marginBottom: '0.5rem' }}>
+              <div style={{ width: `${Math.min(100, overallPct)}%`, height: '100%', backgroundColor: '#4caf50' }} />
+            </div>
+          )}
+          <p>
+            {t('budget', 'Budget')}: {minsToHours(report.budgetMinutes)} Std. |
+            {t('actual', 'Ist')}: {minsToHours(report.totalMinutes)} Std. |
+            {t('remaining', 'Verbleibend')}: {minsToHours(report.remainingMinutes)} Std.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>{t('task', 'Aufgabe')}</th>
+                <th>{t('budget', 'Budget')}</th>
+                <th>{t('actual', 'Ist')}</th>
+                <th>{t('progress', 'Fortschritt')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {report.tasks && report.tasks.map(task => {
+                const pct = task.budgetMinutes ? (task.totalMinutes / task.budgetMinutes) * 100 : null;
+                return (
+                  <tr key={task.taskId || task.taskName}>
+                    <td>{task.taskName}</td>
+                    <td>{minsToHours(task.budgetMinutes)}</td>
+                    <td>{minsToHours(task.totalMinutes)}</td>
+                    <td>{pct != null ? `${pct.toFixed(1)}%` : '-'}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminProjectReportPage;

--- a/Chrono-frontend/src/pages/AdminProjects/AdminProjectsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminProjects/AdminProjectsPage.jsx
@@ -21,11 +21,13 @@ const AdminProjectsPage = () => {
   // State für das Erstellen-Formular
   const [newName, setNewName] = useState('');
   const [selectedCustomerId, setSelectedCustomerId] = useState('');
+  const [newBudget, setNewBudget] = useState('');
 
   // State für das Bearbeiten-Formular
   const [editingId, setEditingId] = useState(null);
   const [editingName, setEditingName] = useState('');
   const [editingCustomerId, setEditingCustomerId] = useState('');
+  const [editingBudget, setEditingBudget] = useState('');
 
   useEffect(() => {
     if (customers.length > 0 && !selectedCustomerId) {
@@ -41,8 +43,9 @@ const AdminProjectsPage = () => {
       return;
     }
     try {
-      await createProject(newName, selectedCustomerId);
+      await createProject(newName, selectedCustomerId, newBudget ? parseInt(newBudget, 10) : null);
       setNewName('');
+      setNewBudget('');
       notify(t('project.create.success', 'Projekt erfolgreich angelegt!'), 'success');
     } catch (err) {
       notify(t('project.create.error', 'Fehler beim Anlegen des Projekts.'), 'error');
@@ -56,7 +59,7 @@ const AdminProjectsPage = () => {
       return;
     }
     try {
-      await updateProject(editingId, editingName, editingCustomerId);
+      await updateProject(editingId, editingName, editingCustomerId, editingBudget ? parseInt(editingBudget, 10) : null);
       setEditingId(null);
       notify(t('project.update.success', 'Projekt erfolgreich gespeichert!'), 'success');
     } catch (err) {
@@ -78,12 +81,14 @@ const AdminProjectsPage = () => {
     setEditingId(project.id);
     setEditingName(project.name);
     setEditingCustomerId(project.customer?.id || '');
+    setEditingBudget(project.budgetMinutes ?? '');
   };
 
   const cancelEdit = () => {
     setEditingId(null);
     setEditingName('');
     setEditingCustomerId('');
+    setEditingBudget('');
   };
 
   return (
@@ -114,6 +119,12 @@ const AdminProjectsPage = () => {
                     <option key={c.id} value={c.id}>{c.name}</option>
                 ))}
               </select>
+              <input
+                  type="number"
+                  placeholder={t('project.create.budgetPlaceholder', 'Budget (Minuten)')}
+                  value={newBudget}
+                  onChange={(e) => setNewBudget(e.target.value)}
+              />
               <button type="submit" className="button-primary">{t('create', 'Anlegen')}</button>
             </form>
           </section>
@@ -142,6 +153,12 @@ const AdminProjectsPage = () => {
                                   <option key={c.id} value={c.id}>{c.name}</option>
                               ))}
                             </select>
+                            <input
+                                type="number"
+                                placeholder={t('project.edit.budgetPlaceholder', 'Budget (Minuten)')}
+                                value={editingBudget}
+                                onChange={(e) => setEditingBudget(e.target.value)}
+                            />
                             <div className="form-actions">
                               <button type="submit" className="button-primary">{t('save', 'Speichern')}</button>
                               <button type="button" onClick={cancelEdit} className="button-secondary">
@@ -151,10 +168,13 @@ const AdminProjectsPage = () => {
                           </form>
                       ) : (
                           <>
-                            <div className="item-details">
-                              <span className="item-name">{p.name}</span>
+                          <div className="item-details">
+                            <span className="item-name">{p.name}</span>
                               <span className="item-meta">{p.customer?.name || t('project.noCustomer', 'Kein Kunde zugewiesen')}</span>
-                            </div>
+                              {p.budgetMinutes !== undefined && p.budgetMinutes !== null && (
+                                <span className="item-meta">{p.budgetMinutes} {t('project.budget.unit','Min')}</span>
+                              )}
+                          </div>
                             <div className="item-actions">
                               <button onClick={() => startEdit(p)} className="button-secondary">{t('edit', 'Bearbeiten')}</button>
                               <button onClick={() => handleDelete(p.id)} className="button-danger">{t('delete', 'Löschen')}</button>

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -48,6 +48,8 @@ const HourlyDashboard = () => {
     const [projects, setProjects] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
     const [selectedProjectId, setSelectedProjectId] = useState('');
+    const [tasks, setTasks] = useState([]);
+    const [selectedTaskId, setSelectedTaskId] = useState('');
     const [selectedMonday, setSelectedMonday] = useState(getMondayOfWeek(new Date()));
     const [vacationRequests, setVacationRequests] = useState([]);
     const [correctionRequests, setCorrectionRequests] = useState([]);
@@ -73,6 +75,7 @@ const HourlyDashboard = () => {
             const params = { username: currentUser.username, source: 'MANUAL_PUNCH' };
             if (selectedCustomerId) params.customerId = selectedCustomerId;
             if (selectedProjectId) params.projectId = selectedProjectId;
+            if (selectedTaskId) params.taskId = selectedTaskId;
             const response = await api.post('/api/timetracking/punch', null, { params });
             const newEntry = response.data;
             setPunchMessage(`${t("manualPunchMessage", "Erfolgreich gestempelt")} ${currentUser.username} (${t('punchTypes.' + newEntry.punchType, newEntry.punchType)} @ ${formatTime(new Date(newEntry.entryTimestamp))})`);
@@ -188,6 +191,17 @@ const assignCustomerForDay = async (isoDate, customerId) => {
             setProjects([]);
         }
     }, [currentUser, fetchCustomers]);
+
+    useEffect(() => {
+        if (selectedProjectId) {
+            api.get('/api/tasks', { params: { projectId: selectedProjectId } })
+                .then(res => setTasks(Array.isArray(res.data) ? res.data : []))
+                .catch(err => { console.error('Error loading tasks', err); setTasks([]); });
+        } else {
+            setTasks([]);
+            setSelectedTaskId('');
+        }
+    }, [selectedProjectId]);
 
     useEffect(() => {
         if (currentUser) {
@@ -317,10 +331,13 @@ const assignCustomerForDay = async (isoDate, customerId) => {
                 customers={customers}
                 recentCustomers={recentCustomers}
                 projects={projects}
+                tasks={tasks}
                 selectedCustomerId={selectedCustomerId}
                 setSelectedCustomerId={setSelectedCustomerId}
                 selectedProjectId={selectedProjectId}
                 setSelectedProjectId={setSelectedProjectId}
+                selectedTaskId={selectedTaskId}
+                setSelectedTaskId={setSelectedTaskId}
                 assignCustomerForDay={assignCustomerForDay}
                 assignCustomerForRange={assignCustomerForRange}
                 assignProjectForDay={assignProjectForDay}

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -30,10 +30,13 @@ const HourlyWeekOverview = ({
                                 customers,
                                 recentCustomers,
                                 projects,
+                                tasks,
                                 selectedCustomerId,
                                 setSelectedCustomerId,
                                 selectedProjectId,
                                 setSelectedProjectId,
+                                selectedTaskId,
+                                setSelectedTaskId,
                                 assignCustomerForDay,
                                 assignProjectForDay,
                                 // Diese Props müssten vom HourlyDashboard kommen, um Speichern & Benachrichtigungen zu ermöglichen:
@@ -129,6 +132,12 @@ const HourlyWeekOverview = ({
                             <option value="">{t('noProject','Kein Projekt')}</option>
                             {projects.map(p => (
                                 <option key={p.id} value={p.id}>{p.name}</option>
+                            ))}
+                        </select>
+                        <select value={selectedTaskId} onChange={e => setSelectedTaskId(e.target.value)}>
+                            <option value="">{t('noTask','Keine Aufgabe')}</option>
+                            {tasks.map(task => (
+                                <option key={task.id} value={task.id}>{task.name}</option>
                             ))}
                         </select>
                     </>
@@ -316,10 +325,13 @@ HourlyWeekOverview.propTypes = {
     customers: PropTypes.array,
     recentCustomers: PropTypes.array,
     projects: PropTypes.array,
+    tasks: PropTypes.array,
     selectedCustomerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     setSelectedCustomerId: PropTypes.func,
     selectedProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     setSelectedProjectId: PropTypes.func,
+    selectedTaskId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    setSelectedTaskId: PropTypes.func,
     assignCustomerForDay: PropTypes.func,
     assignProjectForDay: PropTypes.func,
     reloadData: PropTypes.func

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -48,6 +48,8 @@ const PercentageDashboard = () => {
     const [projects, setProjects] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
     const [selectedProjectId, setSelectedProjectId] = useState('');
+    const [tasks, setTasks] = useState([]);
+    const [selectedTaskId, setSelectedTaskId] = useState('');
     const [punchMessage, setPunchMessage] = useState('');
     const lastPunchTimeRef = useRef(0);
 
@@ -120,6 +122,17 @@ const PercentageDashboard = () => {
             setProjects([]);
         }
     }, [userProfile, currentUser, fetchCustomers]);
+
+    useEffect(() => {
+        if (selectedProjectId) {
+            api.get('/api/tasks', { params: { projectId: selectedProjectId } })
+                .then(res => setTasks(Array.isArray(res.data) ? res.data : []))
+                .catch(err => { console.error('Error loading tasks', err); setTasks([]); });
+        } else {
+            setTasks([]);
+            setSelectedTaskId('');
+        }
+    }, [selectedProjectId]);
 
     const fetchDataForUser = useCallback(async () => {
         if (!userProfile?.username) return;
@@ -200,6 +213,7 @@ const PercentageDashboard = () => {
             const params = { username: userProfile.username, source: 'MANUAL_PUNCH' };
             if (selectedCustomerId) params.customerId = selectedCustomerId;
             if (selectedProjectId) params.projectId = selectedProjectId;
+            if (selectedTaskId) params.taskId = selectedTaskId;
             const response = await api.post('/api/timetracking/punch', null, { params });
             const newEntry = response.data;
             showPunchMessage(`${t("manualPunchMessage")} ${userProfile.username} (${t('punchTypes.'+newEntry.punchType, newEntry.punchType)} @ ${formatTime(new Date(newEntry.entryTimestamp))})`);
@@ -371,9 +385,12 @@ const PercentageDashboard = () => {
                     customers={customers}
                     recentCustomers={recentCustomers}
                     projects={projects}
+                    tasks={tasks}
                     selectedCustomerId={selectedCustomerId}
                     setSelectedCustomerId={setSelectedCustomerId}
                     selectedProjectId={selectedProjectId}
+                    selectedTaskId={selectedTaskId}
+                    setSelectedTaskId={setSelectedTaskId}
                     vacationRequests={vacationRequests}
                     sickLeaves={sickLeaves}
                     holidaysForUserCanton={holidaysForUserCanton?.data}

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -28,10 +28,13 @@ const PercentageWeekOverview = ({
                                     customers,
                                     recentCustomers,
                                     projects,
+                                    tasks,
                                     selectedCustomerId,
                                     setSelectedCustomerId,
                                     selectedProjectId,
                                     setSelectedProjectId,
+                                    selectedTaskId,
+                                    setSelectedTaskId,
                                     vacationRequests,
                                     sickLeaves,
                                     holidaysForUserCanton,
@@ -73,6 +76,10 @@ const PercentageWeekOverview = ({
                         <select value={selectedProjectId} onChange={e => setSelectedProjectId(e.target.value)}>
                             <option value="">{t('noProject','Kein Projekt')}</option>
                             {projects.map(p => (<option key={p.id} value={p.id}>{p.name}</option>))}
+                        </select>
+                        <select value={selectedTaskId} onChange={e => setSelectedTaskId(e.target.value)}>
+                            <option value="">{t('noTask','Keine Aufgabe')}</option>
+                            {tasks.map(task => (<option key={task.id} value={task.id}>{task.name}</option>))}
                         </select>
                     </div>
                 )}
@@ -216,10 +223,13 @@ PercentageWeekOverview.propTypes = {
     customers: PropTypes.array,
     recentCustomers: PropTypes.array,
     projects: PropTypes.array,
+    tasks: PropTypes.array,
     selectedCustomerId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     setSelectedCustomerId: PropTypes.func,
     selectedProjectId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     setSelectedProjectId: PropTypes.func,
+    selectedTaskId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    setSelectedTaskId: PropTypes.func,
     vacationRequests: PropTypes.array.isRequired,
     sickLeaves: PropTypes.array.isRequired,
     holidaysForUserCanton: PropTypes.object,

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -68,6 +68,8 @@ function UserDashboard() {
     const [projects, setProjects] = useState([]);
     const [selectedCustomerId, setSelectedCustomerId] = useState('');
     const [selectedProjectId, setSelectedProjectId] = useState('');
+    const [tasks, setTasks] = useState([]);
+    const [selectedTaskId, setSelectedTaskId] = useState('');
 
     const [printModalVisible, setPrintModalVisible] = useState(false);
     const [printStartDate, setPrintStartDate] = useState(formatLocalDate(new Date(new Date().getFullYear(), new Date().getMonth(), 1)));
@@ -149,6 +151,17 @@ function UserDashboard() {
         }
     }, [userProfile, currentUser, fetchCustomers]);
 
+    useEffect(() => {
+        if (selectedProjectId) {
+            api.get('/api/tasks', { params: { projectId: selectedProjectId } })
+                .then(res => setTasks(Array.isArray(res.data) ? res.data : []))
+                .catch(err => { console.error('Error loading tasks', err); setTasks([]); });
+        } else {
+            setTasks([]);
+            setSelectedTaskId('');
+        }
+    }, [selectedProjectId]);
+
     const fetchHolidaysForUser = useCallback(async (year, cantonAbbreviation) => {
         const cantonKey = cantonAbbreviation || 'GENERAL';
         if (holidaysForUserCanton.year === year && holidaysForUserCanton.canton === cantonKey) {
@@ -216,6 +229,7 @@ function UserDashboard() {
             const params = { username: userProfile.username, source: 'MANUAL_PUNCH' };
             if (selectedCustomerId) params.customerId = selectedCustomerId;
             if (selectedProjectId) params.projectId = selectedProjectId;
+            if (selectedTaskId) params.taskId = selectedTaskId;
             const response = await api.post('/api/timetracking/punch', null, { params });
             const newEntry = response.data;
             showPunchMessage(`${t("manualPunchMessage")} ${userProfile.username} (${t('punchTypes.' + newEntry.punchType, newEntry.punchType)} @ ${formatTime(new Date(newEntry.entryTimestamp))})`);
@@ -447,6 +461,10 @@ function UserDashboard() {
                                 <select value={selectedProjectId} onChange={e => setSelectedProjectId(e.target.value)}>
                                     <option value="">{t('noProject','Kein Projekt')}</option>
                                     {projects.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+                                </select>
+                                <select value={selectedTaskId} onChange={e => setSelectedTaskId(e.target.value)}>
+                                    <option value="">{t('noTask','Keine Aufgabe')}</option>
+                                    {tasks.map(task => <option key={task.id} value={task.id}>{task.name}</option>)}
                                 </select>
                             </>
                         )}


### PR DESCRIPTION
## Summary
- add budget minutes to projects and tasks
- expose project task summaries via new report endpoint
- allow admins to manage project budgets in UI
- add admin project report page showing budget usage and task breakdown

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central: Network is unreachable)*
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68949c6fd1c88325909870b5e04f95cd