### PR TITLE
Fix project dropdown on dashboards

### DIFF
--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -178,7 +178,8 @@ const assignCustomerForDay = async (isoDate, customerId) => {
     }, [fetchCurrentUser]);
 
     useEffect(() => {
-        if (currentUser?.customerTrackingEnabled) {
+        const trackingEnabled = userProfile?.customerTrackingEnabled ?? currentUser?.customerTrackingEnabled;
+        if (trackingEnabled) {
             fetchCustomers();
             api.get('/api/customers/recent')
                 .then(res => setRecentCustomers(Array.isArray(res.data) ? res.data : []))
@@ -190,7 +191,7 @@ const assignCustomerForDay = async (isoDate, customerId) => {
             setRecentCustomers([]);
             setProjects([]);
         }
-    }, [currentUser, fetchCustomers]);
+    }, [userProfile, currentUser, fetchCustomers]);
 
     useEffect(() => {
         if (selectedProjectId) {


### PR DESCRIPTION
## Summary
- load project list in hourly dashboards when customer tracking is enabled for either user profile or current user

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: fatal error: winscard.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894c3f4a9748325b6744fde0df6f8dd