### PR TITLE
Fix missing new-entry option for hourly users

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -569,7 +569,9 @@ const AdminWeekSection = ({
                                                                     </div>
                                                                 );
                                                             } else if (!dailySummary || !dailySummary.entries || dailySummary.entries.length === 0) {
-                                                                let showNewEntryButton = expectedMinsToday > 0 || (userData.userConfig.isPercentage && (d.getDay() >= 1 && d.getDay() <= (userData.userConfig.expectedWorkDays || 5) )); // Zeige Button, wenn Soll oder potenzieller Arbeitstag für %
+                                                                let showNewEntryButton = expectedMinsToday > 0
+                                                                    || (userData.userConfig.isPercentage && (d.getDay() >= 1 && d.getDay() <= (userData.userConfig.expectedWorkDays || 5)))
+                                                                    || (userData.userConfig.isHourly && (d.getDay() >= 1 && d.getDay() <= 5)); // Zeige Button, wenn Soll oder potenzieller Arbeitstag für % oder Stundenlohn
                                                                 // Check against scheduleEffectiveDate
                                                                 const effectiveDate = userData.userConfig.scheduleEffectiveDate ? parseISO(userData.userConfig.scheduleEffectiveDate) : null;
                                                                 if (effectiveDate && d < effectiveDate) {


### PR DESCRIPTION
## Summary
- show "Neuer Eintrag" button for hourly users on workdays in admin week view

## Testing
- `npm test`
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898c0879a748325a906e6cdba6e50a0