### PR TITLE
fix: route payslips

### DIFF
--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -39,6 +39,7 @@ import WhatsNewPage from "./pages/WhatsNewPage.jsx";
 import AGB from "./pages/AGB.jsx";
 import Impressum from "./pages/Impressum.jsx";
 import CompanySettingsPage from "./pages/CompanySettingsPage.jsx";
+import PayslipsPage from "./pages/PayslipsPage.jsx";
 
 // Hilfs-Komponenten
 import PrivateRoute from "./components/PrivateRoute.jsx";
@@ -66,6 +67,7 @@ function App() {
                         <Route path="/dashboard" element={<PrivateRoute><UserDashboard /></PrivateRoute>} />
                         <Route path="/percentage-punch" element={<PrivateRoute><PercentagePunch /></PrivateRoute>} />
                         <Route path="/personal-data" element={<PrivateRoute><PersonalDataPage /></PrivateRoute>} />
+                        <Route path="/payslips" element={<PrivateRoute><PayslipsPage /></PrivateRoute>} />
 
                         {/* Admin-Routen */}
                         <Route path="/admin/dashboard" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminDashboard /></PrivateRoute>} />


### PR DESCRIPTION
## Summary
- expose Payslips page via dedicated route so users can navigate from navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68992a7d51f88325a72b3bbc438cc9b4