### PR TITLE
Redirect to dashboards after login

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -113,7 +113,7 @@ const Navbar = () => {
                             {currentUser && (<>
                                 {/* Rollenspezifische Links */}
                                 {currentUser.roles?.includes('ROLE_SUPERADMIN') ? (
-                                    <li><Link to="/superadmin/companies">{t('navbar.companyManagement', 'Firmen')}</Link></li>
+                                    <li><Link to="/admin/company">{t('navbar.companyManagement', 'Firmen')}</Link></li>
                                 ) : currentUser.roles?.includes('ROLE_ADMIN') ? (
                                     <>
                                         <li><Link to="/admin/dashboard">{t('navbar.adminStart', 'Admin‑Start')}</Link></li>

--- a/Chrono-frontend/src/components/__tests__/Login.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/Login.test.jsx
@@ -44,6 +44,6 @@ describe('Login', () => {
         await userEvent.click(screen.getByRole('button', { name: /Login/i }));
 
         expect(loginMock).toHaveBeenCalledWith('alice', 'secret');
-        expect(mockNavigate).toHaveBeenCalledWith('/user', { replace: true });
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
     });
 });

--- a/Chrono-frontend/src/pages/Login.jsx
+++ b/Chrono-frontend/src/pages/Login.jsx
@@ -91,7 +91,6 @@ const Login = () => {
         const user = res.user || {}; // Fallback auf leeres Objekt, falls res.user undefiniert ist
         const roles = user.roles || [];
         const isPercentageUser = user.isPercentage || false;
-        const isHourlyUser = user.isHourly || false; // NEU: Direkte Prüfung
 
         /* optional redirect */
         const next = new URLSearchParams(location.search).get('next');
@@ -99,15 +98,13 @@ const Login = () => {
         if (next) {
             navigate(next, { replace: true });
         } else if (roles.includes('ROLE_SUPERADMIN')) {
-            navigate('/superadmin/companies', { replace: true });
+            navigate('/admin/company', { replace: true });
         } else if (roles.includes('ROLE_ADMIN')) {
-            navigate('/admin', { replace: true });
+            navigate('/admin/dashboard', { replace: true });
         } else if (isPercentageUser) {
             navigate('/percentage-punch', { replace: true });
-        } else if (isHourlyUser) { // NEU: Explizite Weiterleitung für Stundenlöhner
-            navigate('/user', { replace: true }); // Das UserDashboard rendert dann das HourlyDashboard
-        } else { // Standard-Benutzer
-            navigate('/user', { replace: true });
+        } else {
+            navigate('/dashboard', { replace: true });
         }
     };
 


### PR DESCRIPTION
## Summary
- Redirect users to role-specific dashboards after login
- Point super-admin navbar link to existing company management route
- Adjust login unit test for new dashboard path

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed9b9f788325955b17b3aaa2b8e6