### PR TITLE
fix: ignore missing days for percentage users

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
+++ b/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
@@ -318,8 +318,10 @@ export function getDetailedGlobalProblemIndicators(
 
         if (isPotentiallyWorkDay && !vacationToday && !sickToday) {
             if (!summary || summary.entries.length === 0) {
-                indicators.missingEntriesCount++;
-                indicators.problematicDays.push({ dateIso: isoDate, type: 'missing' });
+                if (!userConfig.isPercentage) {
+                    indicators.missingEntriesCount++;
+                    indicators.problematicDays.push({ dateIso: isoDate, type: 'missing' });
+                }
             } else {
                 if (summary.primaryTimes.isOpen) {
                     indicators.incompleteDaysCount++;


### PR DESCRIPTION
## Summary
- avoid flagging missing days as problems for percentage users in the admin week overview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899edf61e508325822127b6a8ee2998