### PR TITLE
Fix modal styling for consistent theme readability

### DIFF
--- a/Chrono-frontend/src/styles/global.css
+++ b/Chrono-frontend/src/styles/global.css
@@ -49,7 +49,20 @@ input, button, textarea, select {
   font: inherit;
   margin: 0;
   border-radius: var(--radius-sm);
-}/* src/styles/global.css -- am Ende hinzufügen */
+}
+
+/* Modal overlay defaults */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--modal-backdrop-color, rgba(0, 0, 0, 0.6));
+  z-index: 1000;
+}
+
+/* src/styles/global.css -- am Ende hinzufügen */
 
 [data-theme="dark"] body {
   --c-text: #e9ecef;

--- a/Chrono-frontend/src/styles/tokens/design-tokens.css
+++ b/Chrono-frontend/src/styles/tokens/design-tokens.css
@@ -31,6 +31,8 @@
   --c-bg: #fff;
   --c-bg-surface: var(--brand-gray-100); /* Für Elemente auf dem BG */
   --c-bg-muted: var(--brand-gray-200);
+  --c-card: var(--c-bg-surface);
+  --modal-backdrop-color: rgba(0, 0, 0, 0.6);
 
   /* Rahmenfarben */
   --c-border: var(--brand-gray-300);
@@ -85,6 +87,8 @@
     --c-bg: #0d1117; /* Dunkler Hintergrund für die Seite */
     --c-bg-surface: #161b22; /* Etwas hellerer Hintergrund für Karten */
     --c-bg-muted: #21262d;
+    --c-card: var(--c-bg-surface);
+    --modal-backdrop-color: rgba(0, 0, 0, 0.6);
 
     /* Rahmenfarben */
     --c-border: #30363d;


### PR DESCRIPTION
## Summary
- define `--c-card` and `--modal-backdrop-color` tokens
- add default modal overlay styling to global CSS to ensure visible popups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ee61968c8325917645f473447bb2