### PR TITLE
Add print option to schedule planner

### DIFF
--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -635,6 +635,7 @@ const translations = {
             prevWeek: "Vorherige Woche",
             nextWeek: "Nächste Woche",
             copyWeeks: "Kopieren",
+            print: "Drucken",
             weekShort: "KW",
             userOnVacation: "Dieser Mitarbeiter ist an diesem Tag im Urlaub"
 
@@ -1361,6 +1362,7 @@ const translations = {
             prevWeek: "Prev Week",
             nextWeek: "Next Week",
             copyWeeks: "Copy",
+            print: "Print",
             weekShort: "Week",
             userOnVacation: "This employee is on vacation on this day"
 

--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -99,6 +99,7 @@ const WeekNavigator = ({ onAutoFill, onCopyWeek, onPasteWeek }) => {
         </div>
         <div className="tools-group">
           <input type="date" value={format(weekStart, 'yyyy-MM-dd')} onChange={(e) => setWeekStart(new Date(e.target.value))} />
+          <button onClick={() => window.print()} className="button-print">{t('schedulePlanner.print', 'Drucken')}</button>
           <button onClick={onCopyWeek} className="button-copy">Woche kopieren</button>
           {copiedWeek && <button onClick={onPasteWeek} className="button-paste">Einfügen</button>}
           <button onClick={onAutoFill} className="button-autofill">Automatisch auffüllen</button>

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
@@ -338,14 +338,16 @@
 }
 
 .week-controls .button-copy,
-.week-controls .button-paste {
+.week-controls .button-paste,
+.week-controls .button-print {
   color: var(--ud-c-primary-text);
   background-color: transparent;
   border: 1px solid var(--ud-c-primary);
   transition: all 0.2s ease;
 }
 
-.week-controls .button-copy:hover {
+.week-controls .button-copy:hover,
+.week-controls .button-print:hover {
   background-color: var(--ud-c-primary-light-bg);
   transform: translateY(-1px);
 }
@@ -378,4 +380,11 @@
   .schedule-table th, .schedule-table td { min-width: 200px; }
   .week-controls { flex-direction: column; align-items: stretch; }
   .week-controls .navigation-group, .week-controls .tools-group { justify-content: space-between; width: 100%; }
+}
+
+@media print {
+  .week-controls,
+  .planner-sidebar {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add `Drucken` button to schedule planner to launch browser print dialog
- support translations for new print action
- style print button and hide controls in print view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a214283d0832594d25e53c41bd00d