### PR TITLE
Add print option for schedule with week selection

### DIFF
--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -31,6 +31,7 @@ import AdminPayslipsPage from "./pages/AdminPayslipsPage.jsx";
 import AdminSchedulePlannerPage from "./pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx";
 // NEU: Import der Seite für Schichtregeln
 import AdminShiftRulesPage from "./pages/AdminSchedulePlanner/AdminScheduleRulesPage.jsx";
+import PrintSchedule from "./pages/AdminSchedulePlanner/PrintSchedule.jsx";
 import AdminKnowledgePage from "./pages/AdminKnowledge/AdminKnowledgePage.jsx";
 import CompanyManagementPage from "./pages/CompanyManagementPage.jsx";
 import TimeTrackingImport from "./TimeTrackingImport.jsx";
@@ -80,6 +81,7 @@ function App() {
                         <Route path="/admin/company" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanyManagementPage /></PrivateRoute>} />
                         <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN", "ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
                         <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />
+                        <Route path="/admin/print-schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><PrintSchedule /></PrivateRoute>} />
 
                         <Route path="/admin/knowledge" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminKnowledgePage /></PrivateRoute>} />
                         <Route path="/admin/company-settings" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanySettingsPage /></PrivateRoute>} />

--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { create } from 'zustand';
 import { startOfWeek, addDays, formatISO, format, isSameDay, differenceInDays } from 'date-fns';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Navbar from '../../components/Navbar';
 import api from '../../utils/api';
 import '../../styles/AdminSchedulePlannerPageScooped.css';
@@ -264,6 +264,7 @@ const AdminSchedulePlannerPage = () => {
   const weekStart = usePlannerStore(state => state.weekStart);
   const copiedWeek = usePlannerStore(state => state.copiedWeek);
   const setCopiedWeek = usePlannerStore(state => state.setCopiedWeek);
+  const navigate = useNavigate();
 
   const queryClient = useQueryClient();
 
@@ -403,6 +404,13 @@ const AdminSchedulePlannerPage = () => {
     copyWeekMutation.mutate(newEntries);
   };
 
+  const handlePrintSchedule = () => {
+    const weeks = parseInt(prompt(t('schedulePlanner.printWeeksPrompt', 'Wie viele Wochen möchten Sie drucken?'), '1'), 10);
+    if (!weeks || weeks < 1) return;
+    const start = formatISO(weekStart, { representation: 'date' });
+    navigate(`/admin/print-schedule?start=${start}&weeks=${weeks}`);
+  };
+
   return (
       <>
         <Navbar />
@@ -411,10 +419,16 @@ const AdminSchedulePlannerPage = () => {
             <div className="planner-main">
               <div className="planner-header">
                 <h2 className="cmp-title">Dienstplan</h2>
-                <Link to="/admin/shift-rules" className="button-settings">
-                  <span role="img" aria-label="settings">⚙️</span>
-                  Schicht-Einstellungen
-                </Link>
+                <div className="header-actions">
+                  <Link to="/admin/shift-rules" className="button-settings">
+                    <span role="img" aria-label="settings">⚙️</span>
+                    Schicht-Einstellungen
+                  </Link>
+                  <button onClick={handlePrintSchedule} className="button-print">
+                    <span role="img" aria-label="print">🖨️</span>
+                    Drucken
+                  </button>
+                </div>
               </div>
               <WeekNavigator
                   onAutoFill={handleAutoFill}

--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/PrintSchedule.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/PrintSchedule.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { addDays, format, formatISO, startOfWeek } from 'date-fns';
+import api from '../../utils/api';
+import { useTranslation } from '../../context/LanguageContext';
+import '../../styles/AdminSchedulePlannerPageScooped.css';
+import '../../styles/PrintSchedule.css';
+
+const days = ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'];
+
+function useQueryParams() {
+  return new URLSearchParams(useLocation().search);
+}
+
+const fetchUsers = async () => {
+  const { data } = await api.get('/api/admin/users');
+  return Array.isArray(data) ? data : [];
+};
+
+const fetchScheduleRules = async () => {
+  const { data } = await api.get('/api/admin/shift-definitions');
+  return Array.isArray(data) ? data : [];
+};
+
+const fetchScheduleRange = async (startDate, endDate) => {
+  const start = formatISO(startDate, { representation: 'date' });
+  const end = formatISO(endDate, { representation: 'date' });
+  const { data } = await api.get('/api/admin/schedule', { params: { start, end } });
+  const map = {};
+  (Array.isArray(data) ? data : []).forEach(e => {
+    const dayKey = formatISO(new Date(e.date), { representation: 'date' });
+    if (!map[dayKey]) {
+      map[dayKey] = [];
+    }
+    if (e.userId) {
+      map[dayKey].push({ userId: e.userId, id: e.id, shift: e.shift });
+    }
+  });
+  return map;
+};
+
+export default function PrintSchedule() {
+  const { t } = useTranslation();
+  const query = useQueryParams();
+  const startParam = query.get('start');
+  const weeks = parseInt(query.get('weeks') || '1', 10);
+  const startDate = startOfWeek(new Date(startParam), { weekStartsOn: 1 });
+  const endDate = addDays(startDate, weeks * 7 - 1);
+
+  const { data: users = [] } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
+  const { data: shifts = [] } = useQuery({ queryKey: ['scheduleRules'], queryFn: fetchScheduleRules });
+  const { data: scheduleMap = {} } = useQuery({ queryKey: ['printSchedule', startParam, weeks], queryFn: () => fetchScheduleRange(startDate, endDate) });
+
+  const weekStarts = Array.from({ length: weeks }, (_, i) => addDays(startDate, i * 7));
+
+  return (
+    <div className="schedule-planner-page schedule-print-page scoped-dashboard">
+      <div className="btnRow">
+        <button onClick={() => window.print()}>{t('printReport.printButton', 'Drucken')}</button>
+      </div>
+      {weekStarts.map(weekStart => {
+        const weekLabel = `${t('schedulePlanner.weekShort', 'KW')} ${format(weekStart, 'w')} / ${format(weekStart, 'yyyy')}`;
+        const dateKeys = days.map((_, i) => formatISO(addDays(weekStart, i), { representation: 'date' }));
+        return (
+          <div key={weekStart.toISOString()} className="print-week">
+            <h2 className="cmp-title">{weekLabel}</h2>
+            <table className="schedule-table">
+              <thead>
+                <tr>{days.map(d => <th key={d}>{d}</th>)}</tr>
+              </thead>
+              <tbody>
+                <tr>
+                  {dateKeys.map(dateKey => (
+                    <td key={dateKey} className="day-cell">
+                      <div className="day-header">
+                        <span className="day-date">{format(new Date(dateKey), 'd.')}</span>
+                      </div>
+                      <div className="day-content-shifts">
+                        {shifts.filter(s => s.isActive).map(({ shiftKey, label, startTime, endTime }) => {
+                          const entries = (scheduleMap[dateKey] || []).filter(e => e.shift === shiftKey);
+                          return (
+                            <div key={shiftKey} className="shift-slot">
+                              <div className="shift-label">
+                                <span>{label}</span>
+                                <span className="shift-time">{startTime} - {endTime}</span>
+                              </div>
+                              <div className="shift-content">
+                                {entries.length > 0 ? (
+                                  entries.map(entry => {
+                                    const user = users.find(u => u.id === entry.userId);
+                                    if (!user) return null;
+                                    return (
+                                      <div key={entry.id} className="assigned-user" style={{ backgroundColor: user.color || 'var(--ud-c-primary)' }}>
+                                        <span>{user.firstName} {user.lastName}</span>
+                                      </div>
+                                    );
+                                  })
+                                ) : (
+                                  <div className="empty-shift-slot">-</div>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
+++ b/Chrono-frontend/src/styles/AdminSchedulePlannerPageScooped.css
@@ -235,6 +235,33 @@
   transition: all 0.2s ease;
 }
 
+.planner-header .header-actions {
+  display: flex;
+  gap: var(--ud-gap-sm);
+}
+
+.planner-header .button-print {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: transparent;
+  color: var(--ud-c-primary-text);
+  border: 1px solid var(--ud-c-border);
+  padding: 0.6rem 1.2rem;
+  font-weight: 500;
+  border-radius: var(--ud-radius-md);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.planner-header .button-print:hover {
+  background-color: var(--ud-c-primary-light-bg);
+  border-color: var(--ud-c-primary);
+  color: var(--ud-c-primary);
+  transform: translateY(-1px);
+  box-shadow: var(--ud-shadow-interactive);
+}
+
 .planner-header .button-settings:hover {
   background-color: var(--ud-c-primary-light-bg);
   border-color: var(--ud-c-primary);

--- a/Chrono-frontend/src/styles/PrintSchedule.css
+++ b/Chrono-frontend/src/styles/PrintSchedule.css
@@ -1,0 +1,22 @@
+.schedule-print-page .btnRow {
+  margin-bottom: var(--ud-gap-lg);
+}
+
+.schedule-print-page .btnRow button {
+  background: var(--ud-c-primary);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--ud-radius-md);
+  cursor: pointer;
+}
+
+.print-week {
+  margin-bottom: var(--ud-gap-lg);
+}
+
+@media print {
+  .schedule-print-page .btnRow {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add print button to schedule planner enabling week range selection
- implement dedicated PrintSchedule page using existing dashboard styling
- wire new route and styles for printable schedules

## Testing
- `npm install --ignore-scripts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a23ac56088325998b5dcbf7362576