### PR TITLE
Add calendar feed link and public ICS endpoint

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.POST, "/api/apply").permitAll();
                     auth.requestMatchers(HttpMethod.POST, "/api/contact").permitAll();
                     auth.requestMatchers("/api/chat").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/api/report/timesheet/ics-feed/**").permitAll();
 
                     // Admin-Endpunkte
                     auth.requestMatchers("/api/admin/**").hasRole("ADMIN");

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/ReportController.java
@@ -87,4 +87,12 @@ public class ReportController {
 
         return new ResponseEntity<>(ics, headers, HttpStatus.OK);
     }
+
+    @GetMapping("/timesheet/ics-feed/{username}")
+    public ResponseEntity<byte[]> icsFeed(@PathVariable String username) {
+        byte[] ics = reportService.generateIcsFeed(username);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("text/calendar"));
+        return new ResponseEntity<>(ics, headers, HttpStatus.OK);
+    }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ReportService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ReportService.java
@@ -287,4 +287,16 @@ public class ReportService {
         sb.append("END:VCALENDAR\r\n");
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
+
+    /**
+     * Convenience wrapper to generate an iCalendar feed for a user without
+     * specifying a date range. The feed covers a wide time span so that new
+     * entries will appear automatically when subscribed from external calendar
+     * applications.
+     */
+    public byte[] generateIcsFeed(String username) {
+        LocalDate start = LocalDate.now().minusYears(1);
+        LocalDate end = LocalDate.now().plusYears(1);
+        return generateIcs(username, start, end);
+    }
 }

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -72,6 +72,10 @@ const translations = {
             errorUpdating: "Fehler beim Aktualisieren des Profils",
             passwordChanged: "Passwort erfolgreich geändert",
             errorChangingPassword: "Fehler beim Ändern des Passworts",
+            calendarFeed: "Kalender-Feed",
+            calendarFeedInfo: "Nutze diese URL, um deinen Kalender zu abonnieren.",
+            copyLink: "Link kopieren",
+            linkCopied: "Link kopiert",
         },
         // ----------------------------------------------------------------------
         // Company Settings
@@ -805,6 +809,10 @@ const translations = {
             errorUpdating: "Error updating profile",
             passwordChanged: "Password changed successfully",
             errorChangingPassword: "Error changing password",
+            calendarFeed: "Calendar Feed",
+            calendarFeedInfo: "Use this URL to subscribe to your calendar.",
+            copyLink: "Copy link",
+            linkCopied: "Link copied",
         },
         // ----------------------------------------------------------------------
         // Company Settings

--- a/Chrono-frontend/src/pages/PersonalDataPage.jsx
+++ b/Chrono-frontend/src/pages/PersonalDataPage.jsx
@@ -103,6 +103,16 @@ const PersonalDataPage = () => {
         }
     }
 
+    const baseUrl = api.defaults.baseURL.replace(/\/$/, "");
+    const icsUrl = currentUser
+        ? `${baseUrl}/api/report/timesheet/ics-feed/${currentUser.username}`
+        : '';
+
+    function handleCopyLink() {
+        navigator.clipboard.writeText(icsUrl);
+        notify(t("personalData.linkCopied", "Link kopiert"));
+    }
+
     return (
         <div className="personal-data-page scoped-personal-data">
             <Navbar />
@@ -242,12 +252,28 @@ const PersonalDataPage = () => {
                         {t("personalData.saveButton", "Speichern")}
                     </button>
                 </form>
-            </section>
+              </section>
 
-            <section className="password-change-section">
-                <h3>{t("personalData.changePassword", "Passwort ändern")}</h3>
-                <form onSubmit={handlePasswordChange} className="form-password">
-                    <div className="form-group">
+              <section className="calendar-feed-section">
+                  <h3>{t("personalData.calendarFeed", "Kalender-Feed")}</h3>
+                  <p>{t("personalData.calendarFeedInfo", "Nutze diese URL, um deinen Kalender zu abonnieren.")}</p>
+                  <div className="form-group">
+                      <input
+                          type="text"
+                          readOnly
+                          value={icsUrl}
+                          onFocus={(e) => e.target.select()}
+                      />
+                      <button type="button" onClick={handleCopyLink}>
+                          {t("personalData.copyLink", "Link kopieren")}
+                      </button>
+                  </div>
+              </section>
+
+              <section className="password-change-section">
+                  <h3>{t("personalData.changePassword", "Passwort ändern")}</h3>
+                  <form onSubmit={handlePasswordChange} className="form-password">
+                      <div className="form-group">
                         <label>
                             {t("personalData.currentPassword", "Aktuelles Passwort")}:
                         </label>


### PR DESCRIPTION
## Summary
- expose new `/timesheet/ics-feed/{username}` endpoint to serve wide-range iCalendar feeds
- allow unauthenticated access to the calendar feed
- show calendar feed URL with copy button on profile page, including translations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a7868183c8325931d0be8eef718c3