### PR TITLE
Display company vacation on all dashboards

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/VacationRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/VacationRequest.java
@@ -19,6 +19,8 @@ public class VacationRequest {
     private boolean denied;
     private boolean halfDay;
     private boolean usesOvertime;
+    @Column(name = "company_vacation")
+    private boolean companyVacation;
 
     @Column(name = "overtime_deduction_minutes") // NEUES FELD
     private Integer overtimeDeductionMinutes; // Nur für usesOvertime = true & prozentuale User
@@ -51,6 +53,9 @@ public class VacationRequest {
 
     public boolean isUsesOvertime() { return usesOvertime; }
     public void setUsesOvertime(boolean usesOvertime) { this.usesOvertime = usesOvertime; }
+
+    public boolean isCompanyVacation() { return companyVacation; }
+    public void setCompanyVacation(boolean companyVacation) { this.companyVacation = companyVacation; }
 
     public User getUser() { return user; }
     public void setUser(User user) { this.user = user; }

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -404,6 +404,7 @@ const translations = {
             unknownUser: "Unbekannt",
             halfDayShort: "½",
             overtimeVacationShort: "ÜS",
+            companyVacationLabel: "Betriebsurlaub",
             endDateLabel: "Enddatum",
             halfDayLabel: "Halbtags Urlaub",
             confirmButton: "Bestätigen",
@@ -1143,6 +1144,7 @@ const translations = {
             unknownUser: "Unknown",
             halfDayShort: "1/2",
             overtimeVacationShort: "OT",
+            companyVacationLabel: "Company vacation",
             delete: {
                 noSelection: "No vacation selected to delete.",
                 success: "Vacation request deleted successfully.",

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -553,7 +553,54 @@ const AdminWeekSection = ({
                                                                 );
                                                             } else if (vacationOnThisDay) {
                                                                 cardClass += ' admin-day-card-vacation';
-                                                                dayCardContent = <p className="vacation-indicator text-xs">🏖️ {t('adminDashboard.onVacation', 'Im Urlaub')}{vacationOnThisDay.halfDay ? ` (${t('adminDashboard.halfDayShort', '½ Tag')})` : ''}{vacationOnThisDay.usesOvertime ? ` (${t('adminDashboard.overtimeVacationShort', 'ÜS')})` : ''}</p>;
+                                                                if (vacationOnThisDay.companyVacation && dailySummary && dailySummary.entries && dailySummary.entries.length > 0) {
+                                                                    dayCardContent = (
+                                                                        <>
+                                                                            <p className="vacation-indicator text-xs">🏖️ {t('adminDashboard.onVacation', 'Im Urlaub')}{vacationOnThisDay.halfDay ? ` (${t('adminDashboard.halfDayShort', '½ Tag')})` : ''}{vacationOnThisDay.usesOvertime ? ` (${t('adminDashboard.overtimeVacationShort', 'ÜS')})` : ''}</p>
+                                                                            <div className="admin-day-card-header justify-between items-start mb-1">
+                                                                                <div className="text-xs">
+                                                                                    {!userData.userConfig.isHourly && <span className="expected-hours">({t('expectedTimeShort', 'Soll')}: {minutesToHHMM(expectedMinsToday)})</span>}
+                                                                                    {!userData.userConfig.isHourly && <span className={`daily-diff ml-1 ${diffMinsToday < 0 ? 'text-red-600' : 'text-green-600'}`}>({t('diffTimeShort', 'Diff')}: {minutesToHHMM(diffMinsToday)})</span>}
+                                                                                    {dailySummary.needsCorrection && <span className="auto-completed-tag ml-1 text-red-600 font-bold" title={t('adminDashboard.needsCorrectionTooltip', 'Automatisch beendet und unkorrigiert')}>KORR?</span>}
+                                                                                </div>
+                                                                                <button className="edit-day-button text-xs py-0.5 px-1 bg-gray-200 hover:bg-gray-300 rounded" onClick={() => openEditModal(userData.username, d, dailySummary)}>
+                                                                                    {t("adminDashboard.editButton", "Bearb.")}
+                                                                                </button>
+                                                                            </div>
+                                                                            <ul className="time-entry-list-condensed text-xs">
+                                                                                {dailySummary.entries.map(entry => {
+                                                                                    let typeLabel = entry.punchType;
+                                                                                    try {
+                                                                                        typeLabel = t(`punchTypes.${entry.punchType}`, entry.punchType);
+                                                                                    } catch (e) { /* Fallback */ }
+
+                                                                                    let sourceIndicator = '';
+                                                                                    if (entry.source === 'SYSTEM_AUTO_END' && !entry.correctedByUser) {
+                                                                                        sourceIndicator = t('adminDashboard.entrySource.autoSuffix', ' (Auto)');
+                                                                                    } else if (entry.source === 'ADMIN_CORRECTION') {
+                                                                                        sourceIndicator = t('adminDashboard.entrySource.adminSuffix', ' (AdmK)');
+                                                                                    } else if (entry.source === 'USER_CORRECTION') {
+                                                                                        sourceIndicator = t('adminDashboard.entrySource.userSuffix', ' (UsrK)');
+                                                                                    } else if (entry.source === 'MANUAL_IMPORT') {
+                                                                                        sourceIndicator = t('adminDashboard.entrySource.importSuffix', ' (Imp)');
+                                                                                    }
+
+                                                                                    return (
+                                                                                        <li key={entry.id || entry.key} className="py-0.5">
+                                                                                            {`${typeLabel}: ${formatTime(entry.entryTimestamp)}${sourceIndicator}`}
+                                                                                        </li>
+                                                                                    );
+                                                                                })}
+                                                                            </ul>
+                                                                            <p className="text-xs mt-1">
+                                                                                <strong>{t('actualTime', 'Ist')}:</strong> {minutesToHHMM(actualMinsToday)} | <strong>{t('breakTime', 'Pause')}:</strong> {minutesToHHMM(dailySummary.breakMinutes)}
+                                                                            </p>
+                                                                            {dailySummary.dailyNote && <p className="text-xs mt-1 italic">📝 {dailySummary.dailyNote}</p>}
+                                                                        </>
+                                                                    );
+                                                                } else {
+                                                                    dayCardContent = <p className="vacation-indicator text-xs">🏖️ {t('adminDashboard.onVacation', 'Im Urlaub')}{vacationOnThisDay.halfDay ? ` (${t('adminDashboard.halfDayShort', '½ Tag')})` : ''}{vacationOnThisDay.usesOvertime ? ` (${t('adminDashboard.overtimeVacationShort', 'ÜS')})` : ''}</p>;
+                                                                }
                                                             } else if (sickOnThisDay) {
                                                                 cardClass += ' admin-day-card-sick';
                                                                 dayCardContent = (

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -343,6 +343,7 @@ const assignCustomerForDay = async (isoDate, customerId) => {
                 assignCustomerForRange={assignCustomerForRange}
                 assignProjectForDay={assignProjectForDay}
                 reloadData={() => fetchWeeklyData(selectedMonday)}
+                vacationRequests={vacationRequests}
             />
 
             <PrintReportModal

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -44,6 +44,7 @@ const HourlyWeekOverview = ({
                                 // notify,
                                 // fetchDataForUser,
                             reloadData,
+                            vacationRequests,
                             }) => {
     const { currentUser } = useAuth();
     const [editingNote, setEditingNote] = useState(null); // Speichert das Datum des Tages, dessen Notiz bearbeitet wird
@@ -179,13 +180,17 @@ const HourlyWeekOverview = ({
                 {weekDates.map((dayObj) => {
                     const isoDate = formatLocalDate(dayObj);
                     const summary = dailySummaries.find(s => s.date === isoDate);
+                    const vacationToday = vacationRequests?.find(v => v.approved && isoDate >= v.startDate && isoDate <= v.endDate);
                     const dayName = dayObj.toLocaleDateString('de-DE', { weekday: 'long' });
                     const formattedDisplayDate = formatDate(dayObj);
 
+                    const dayClasses = `week-day-card day-card ${summary?.needsCorrection ? 'needs-correction-highlight' : ''} ${vacationToday ? 'vacation-day' : ''}`;
+
                     return (
-                        <div key={isoDate} className={`week-day-card day-card ${summary?.needsCorrection ? 'needs-correction-highlight' : ''}`}>
+                        <div key={isoDate} className={dayClasses}>
                         <div className="week-day-header day-card-header">
                                 <h4>{dayName}, {formattedDisplayDate}</h4>
+                                {vacationToday && <div className="day-card-badge vacation-badge">{t('vacation')}</div>}
 
                                 {summary && summary.entries.length > 0 && (
                                     <div className="day-card-actions">
@@ -197,6 +202,9 @@ const HourlyWeekOverview = ({
                             </div>
 
                             <div className="week-day-content day-card-content">
+                                {vacationToday?.companyVacation && (
+                                    <div className="day-card-info vacation-indicator">🏖️ {t('onVacation', 'Im Urlaub')} {vacationToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
+                                )}
                                 {(!summary || summary.entries.length === 0) ? (
                                     <p className="no-entries">{t("noEntries", "Keine Einträge")}</p>
                                 ) : (
@@ -335,7 +343,8 @@ HourlyWeekOverview.propTypes = {
     setSelectedTaskId: PropTypes.func,
     assignCustomerForDay: PropTypes.func,
     assignProjectForDay: PropTypes.func,
-    reloadData: PropTypes.func
+    reloadData: PropTypes.func,
+    vacationRequests: PropTypes.array
 };
 
 export default HourlyWeekOverview;

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -146,7 +146,26 @@ const PercentageWeekOverview = ({
                                 {holidayName ? (
                                     <div className="day-card-info holiday-indicator">🎉 {holidayName}</div>
                                 ) : vacationToday ? (
-                                    <div className="day-card-info vacation-indicator">🏖️ {t('onVacation', 'Im Urlaub')} {vacationToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
+                                    vacationToday.companyVacation ? (
+                                        <>
+                                            <div className="day-card-info vacation-indicator">🏖️ {t('onVacation', 'Im Urlaub')} {vacationToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
+                                            <div className="daily-summary-times">
+                                                <p><strong>{t('actualTime', 'Gearbeitet')}:</strong> {minutesToHHMM(dailyWorkedMins)}</p>
+                                                <p><strong>{t('breakTime', 'Pause')}:</strong> {minutesToHHMM(summary?.breakMinutes || 0)}</p>
+                                            </div>
+                                            <ul className="time-entry-list" style={{marginTop: '1rem'}}>
+                                                {(summary?.entries || []).map(entry => (
+                                                    <li key={entry.id || entry.entryTimestamp} style={{backgroundColor: entry.customerId ? `hsl(${(entry.customerId * 57) % 360}, var(--customer-color-saturation), var(--customer-color-lightness))` : 'transparent'}}>
+                                                        <span className="entry-label">{t(`punchTypes.${entry.punchType}`, entry.punchType)}:</span>
+                                                        <span className="entry-time">{entry.entryTimestamp ? new Date(entry.entryTimestamp).toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' }) : ''}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                            {(summary?.entries || []).length === 0 && <p className='no-entries'>{t('noEntries')}</p>}
+                                        </>
+                                    ) : (
+                                        <div className="day-card-info vacation-indicator">🏖️ {t('onVacation', 'Im Urlaub')} {vacationToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
+                                    )
                                 ) : sickToday ? (
                                     <div className="day-card-info sick-leave-indicator">⚕️ {t('sickLeave.sick', 'Krank')} {sickToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
                                 ) : (

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -525,9 +525,16 @@ function UserDashboard() {
                             if (sickToday) dayClass += ' sick-day';
                             if (holidayName) dayClass += ' holiday-day';
 
-                            const expectedMinsToday = Math.round(getExpectedHoursForDay(
+                            let expectedMinsToday = Math.round(getExpectedHoursForDay(
                                 dayObj, userProfile, defaultExpectedHours, holidaysForUserCanton?.data, vacationRequests, sickLeaves
                             ) * 60);
+                            if (holidayName) {
+                                expectedMinsToday = 0;
+                            } else if (vacationToday) {
+                                expectedMinsToday = vacationToday.halfDay ? expectedMinsToday / 2 : 0;
+                            } else if (sickToday) {
+                                expectedMinsToday = sickToday.halfDay ? expectedMinsToday / 2 : 0;
+                            }
 
                             const dailyDiffMinutes = summary ? summary.workedMinutes - expectedMinsToday : (holidayName || vacationToday || sickToday ? 0 : -expectedMinsToday);
 
@@ -541,6 +548,9 @@ function UserDashboard() {
                                     </div>
 
                                     <div className="week-day-content day-card-content">
+                                        {vacationToday?.companyVacation && (
+                                            <div className="day-card-info vacation-indicator">🏖️ {t('onVacation', 'Im Urlaub')} {vacationToday.halfDay && `(${t('halfDayShort', '½ Tag')})`}</div>
+                                        )}
                                         {(!summary || summary.entries.length === 0) && !vacationToday && !sickToday && !holidayName ? (
                                             <p className="no-entries">{t("noEntries")}</p>
                                         ) : (
@@ -595,6 +605,9 @@ function UserDashboard() {
                                                     )}
                                                 </div>
                                             </>
+                                        )}
+                                        {vacationToday?.companyVacation && (!summary || summary.entries.length === 0) && (
+                                            <p className="no-entries">{t('noEntries')}</p>
                                         )}
                                     </div>
                                     <div className="correction-button-row">


### PR DESCRIPTION
## Summary
- show company vacation days on user and hourly dashboards so stamped hours remain visible
- treat company vacation days as zero expected work time to keep balances from going negative

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b064377608325b877f71fe7dc774d