### PR TITLE
Handle nullable company vacation flag

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/VacationRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/VacationRequest.java
@@ -19,8 +19,8 @@ public class VacationRequest {
     private boolean denied;
     private boolean halfDay;
     private boolean usesOvertime;
-    @Column(name = "company_vacation")
-    private boolean companyVacation;
+    @Column(name = "company_vacation", nullable = false)
+    private Boolean companyVacation = false;
 
     @Column(name = "overtime_deduction_minutes") // NEUES FELD
     private Integer overtimeDeductionMinutes; // Nur für usesOvertime = true & prozentuale User
@@ -54,8 +54,8 @@ public class VacationRequest {
     public boolean isUsesOvertime() { return usesOvertime; }
     public void setUsesOvertime(boolean usesOvertime) { this.usesOvertime = usesOvertime; }
 
-    public boolean isCompanyVacation() { return companyVacation; }
-    public void setCompanyVacation(boolean companyVacation) { this.companyVacation = companyVacation; }
+    public boolean isCompanyVacation() { return Boolean.TRUE.equals(companyVacation); }
+    public void setCompanyVacation(Boolean companyVacation) { this.companyVacation = (companyVacation != null && companyVacation); }
 
     public User getUser() { return user; }
     public void setUser(User user) { this.user = user; }

--- a/Chrono-backend/src/main/resources/db/migration/V1__set_company_vacation_not_null.sql
+++ b/Chrono-backend/src/main/resources/db/migration/V1__set_company_vacation_not_null.sql
@@ -1,0 +1,2 @@
+UPDATE vacation_requests SET company_vacation = FALSE WHERE company_vacation IS NULL;
+ALTER TABLE vacation_requests MODIFY company_vacation BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- allow `VacationRequest.companyVacation` to be `null` by using `Boolean`
- ensure null values default to `false` via custom accessor and setter
- add Flyway-style SQL migration to backfill `company_vacation` and enforce NOT NULL

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.4.2 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689b0f11e31483258cf78d6acdea2b67