### PR TITLE
Fix admin correction decision modal props

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
@@ -254,13 +254,12 @@ function AdminCorrectionsList({ t, allCorrections, onApprove, onDeny }) {
             {/* Modal ---------------------------------------------------------------*/}
             {modalOpen && (
                 <CorrectionDecisionModal
-                    isOpen={modalOpen}
+                    visible={modalOpen}
                     mode={modalMode}
-                    adminComment={adminComment}
-                    onAdminCommentChange={setAdminComment}
+                    comment={adminComment}
+                    setComment={setAdminComment}
                     onClose={() => setModalOpen(false)}
                     onSubmit={submitDecision}
-                    t={t}
                 />
             )}
         </section>


### PR DESCRIPTION
## Summary
- Align `CorrectionDecisionModal` props with expected names so approval/denial buttons open the modal

## Testing
- `npm test` *(fails: vitest not found, pcsclite build error)*

------
https://chatgpt.com/codex/tasks/task_e_689ba95b117c83259eb81ecf831417b1