### PR TITLE
Allow moving existing schedule entries

### DIFF
--- a/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
+++ b/Chrono-frontend/src/pages/AdminSchedulePlanner/AdminSchedulePlannerPage.jsx
@@ -26,10 +26,12 @@ const fetchVacations = async () => {
 const usePlannerStore = create((set) => ({
   weekStart: startOfWeek(new Date(), { weekStartsOn: 1 }),
   dragUser: null,
+  dragEntry: null,
   copiedWeek: null,
   setWeekStart: (date) => set({ weekStart: startOfWeek(date, { weekStartsOn: 1 }) }),
   changeWeek: (offset) => set((state) => ({ weekStart: addDays(state.weekStart, offset * 7) })),
-  setDragUser: (user) => set({ dragUser: user }),
+  setDragUser: (user, entry = null) => set({ dragUser: user, dragEntry: entry }),
+  clearDrag: () => set({ dragUser: null, dragEntry: null }),
   setCopiedWeek: (schedule) => set({ copiedWeek: schedule }),
 }));
 
@@ -110,13 +112,15 @@ const WeekNavigator = ({ onAutoFill, onCopyWeek, onPasteWeek }) => {
 const UserList = () => {
   const { t } = useTranslation();
   const { data: users = [], isLoading: isLoadingUsers } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
-  const { dragUser, setDragUser } = usePlannerStore();
+  const dragUser = usePlannerStore(state => state.dragUser);
+  const setDragUser = usePlannerStore(state => state.setDragUser);
+  const clearDrag = usePlannerStore(state => state.clearDrag);
   return (
       <div className="planner-sidebar">
         <h3>{t('schedulePlanner.availableUsers', 'Mitarbeiter')}</h3>
         <div className="user-list">
           {isLoadingUsers ? <p>Lade...</p> : users.map(u => (
-              <div key={u.id} className={`user-list-item ${dragUser?.id === u.id ? 'dragging' : ''}`} draggable onDragStart={() => setDragUser(u)} onDragEnd={() => setDragUser(null)}>
+              <div key={u.id} className={`user-list-item ${dragUser?.id === u.id ? 'dragging' : ''}`} draggable onDragStart={() => setDragUser(u)} onDragEnd={() => clearDrag()}>
                 {u.firstName} {u.lastName}
               </div>
           ))}
@@ -128,14 +132,18 @@ const UserList = () => {
 const ScheduleTable = ({ schedule, holidays, vacationMap }) => {
   const { data: users = [] } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
   const { data: shifts = [], isLoading: isLoadingShifts } = useQuery({ queryKey: ['scheduleRules'], queryFn: fetchScheduleRules });
-  const { weekStart, dragUser, setDragUser } = usePlannerStore();
+  const weekStart = usePlannerStore(state => state.weekStart);
+  const weekKey = formatISO(weekStart, { representation: 'date' });
+  const dragUser = usePlannerStore(state => state.dragUser);
+  const dragEntry = usePlannerStore(state => state.dragEntry);
+  const clearDrag = usePlannerStore(state => state.clearDrag);
   const { notify } = useNotification(); // NEU
   const { t } = useTranslation();
   const [hoveredCell, setHoveredCell] = React.useState(null);
   const queryClient = useQueryClient();
   const mutationOptions = {
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedule', weekStart] });
+      queryClient.invalidateQueries({ queryKey: ['schedule', weekKey] });
     },
     onError: (err) => {
       const message = err?.response?.data?.message || err?.response?.data || err.message;
@@ -151,7 +159,7 @@ const ScheduleTable = ({ schedule, holidays, vacationMap }) => {
 
     const vacForUser = vacationMap?.[dragUser.username]?.[dateKey];
     if (vacForUser) { // Verhindert das Ablegen, wenn der User im Urlaub ist
-      setDragUser(null);
+      clearDrag();
       return;
     }
 
@@ -161,15 +169,31 @@ const ScheduleTable = ({ schedule, holidays, vacationMap }) => {
     const expectedHours = getExpectedHoursForDate(dragUser, dateKey);
     if (expectedHours <= 0) {
       notify(t('schedulePlanner.userDayOff', 'Der Nutzer hat an diesem Tag frei'));
-      setDragUser(null);
+      clearDrag();
       return;
     }
 
     if (!userAlreadyInShift) {
-      saveMutation.mutate({ userId: dragUser.id, date: dateKey, shift: shiftKey });
+      const payload = { userId: dragUser.id, date: dateKey, shift: shiftKey };
+      if (dragEntry?.id) {
+        payload.id = dragEntry.id;
+        // optimistic UI update
+        queryClient.setQueryData(['schedule', weekKey], old => {
+          const newSchedule = { ...(old || {}) };
+          if (dragEntry.date) {
+            const from = (newSchedule[dragEntry.date] || []).filter(e => e.id !== dragEntry.id);
+            newSchedule[dragEntry.date] = from;
+          }
+          const to = (newSchedule[dateKey] || []).filter(e => e.id !== dragEntry.id);
+          to.push({ ...dragEntry, date: dateKey, shift: shiftKey });
+          newSchedule[dateKey] = to;
+          return newSchedule;
+        });
+      }
+      saveMutation.mutate(payload);
     }
 
-    setDragUser(null);
+    clearDrag();
   };
 
   const clearEntry = (entryId) => {
@@ -231,7 +255,14 @@ const ScheduleTable = ({ schedule, holidays, vacationMap }) => {
                                       const user = users.find(u => u.id === entry.userId);
                                       if (!user) return null;
                                       return (
-                                          <div key={entry.id} className="assigned-user" style={{ backgroundColor: user.color || 'var(--ud-c-primary)' }}>
+                                          <div
+                                              key={entry.id}
+                                              className="assigned-user"
+                                              style={{ backgroundColor: user.color || 'var(--ud-c-primary)' }}
+                                              draggable
+                                              onDragStart={() => setDragUser(user, entry)}
+                                              onDragEnd={() => clearDrag()}
+                                          >
                                             <span>{user.firstName} {user.lastName}</span>
                                             <button className="clear-cell-btn" onClick={() => clearEntry(entry.id)}>×</button>
                                           </div>
@@ -265,11 +296,12 @@ const AdminSchedulePlannerPage = () => {
   const copiedWeek = usePlannerStore(state => state.copiedWeek);
   const setCopiedWeek = usePlannerStore(state => state.setCopiedWeek);
   const navigate = useNavigate();
+  const weekKey = formatISO(weekStart, { representation: 'date' });
 
   const queryClient = useQueryClient();
 
   const { data: schedule, isLoading } = useQuery({
-    queryKey: ['schedule', weekStart],
+    queryKey: ['schedule', weekKey],
     queryFn: () => fetchSchedule(weekStart),
     initialData: {},
   });
@@ -313,7 +345,7 @@ const AdminSchedulePlannerPage = () => {
   const autoFillMutation = useMutation({
     mutationFn: autoFillSchedule,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedule', weekStart] });
+      queryClient.invalidateQueries({ queryKey: ['schedule', weekKey] });
     },
     onError: (err) => alert(`Fehler beim automatischen Füllen: ${err.response?.data?.message || err.message}`),
   });
@@ -321,7 +353,7 @@ const AdminSchedulePlannerPage = () => {
   const copyWeekMutation = useMutation({
     mutationFn: copyScheduleRequest,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedule', weekStart] });
+      queryClient.invalidateQueries({ queryKey: ['schedule', weekKey] });
       alert("Woche erfolgreich eingefügt!");
     },
     onError: (err) => alert(`Fehler beim Einfügen der Woche: ${err.response?.data?.message || err.message}`),


### PR DESCRIPTION
## Summary
- use a stable week key for schedule queries so cache invalidation works reliably
- optimistically update the schedule cache when dragging an assignment so moved entries show up in the new day immediately

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent)*
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba8de859083259c84ae8f0ca5cd8e