### PR TITLE
Highlight pending admin requests in collapsed sections

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
@@ -132,9 +132,10 @@ function AdminCorrectionsList({ t, allCorrections, onApprove, onDeny }) {
 
     /* ──────────────────────────────────── render */
     const scrollable = sortedRows.length > 25;
+    const hasPending = allCorrections.some(c => !c.approved && !c.denied);
 
     return (
-        <section className="correction-section content-section">
+        <section className={`correction-section content-section${(!isExpanded && hasPending) ? ' has-pending' : ''}`}>
             {/* Header ----------------------------------------------------------------*/}
             <div
                 className="section-header"

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
@@ -76,9 +76,11 @@ const AdminVacationRequests = ({
 
     const sortedVacations = [...filteredVacations].sort((a, b) => b.id - a.id);
 
+    const hasPending = allVacations.some(v => !v.approved && !v.denied);
+
     return (
         <div className="admin-dashboard scoped-dashboard"> {/* Stellt sicher, dass CSS-Variablen verfügbar sind */}
-            <section className="vacation-section content-section"> {/* Allgemeine Klasse für Sektionen */}
+            <section className={`vacation-section content-section${(!isExpanded && hasPending) ? ' has-pending' : ''}`}> {/* Allgemeine Klasse für Sektionen */}
                 <div
                     className="section-header"
                     onClick={toggleExpansion}

--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -272,6 +272,18 @@
   border-bottom: 1px solid var(--c-line);
   padding-bottom: var(--u-gap-sm);
 }
+.admin-dashboard.scoped-dashboard section.content-section.has-pending .section-header {
+  background-color: var(--stat-pending-bg);
+  animation: pendingGlow 2s ease-in-out infinite;
+}
+@keyframes pendingGlow {
+  0%, 100% {
+    box-shadow: 0 0 0 0 var(--stat-pending-bg);
+  }
+  50% {
+    box-shadow: 0 0 10px 2px var(--stat-pending-bg);
+  }
+}
 .admin-dashboard.scoped-dashboard
   section.content-section
   .section-header


### PR DESCRIPTION
## Summary
- Glow collapsed vacation and correction request sections when pending items exist
- Add animated highlight style for pending section headers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: missing winscard.h for pcsclite dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689baeeaa8a883259afc9a537ba7cad5