### PR TITLE
fix: require admin approval for vacation requests

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/VacationService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/VacationService.java
@@ -88,14 +88,9 @@ public class VacationService {
         vr.setHalfDay(halfDay); //
         vr.setUsesOvertime(usesOvertime); //
 
-        // Auto approve if enough remaining vacation days and no conflicts
-        boolean autoApprove = false;
-        if (!usesOvertime) {
-            double requested = calculateRequestedVacationDays(user, start, end, halfDay);
-            double remaining = calculateRemainingVacationDays(username, start.getYear());
-            autoApprove = requested <= remaining;
-        }
-        vr.setApproved(autoApprove);
+        // User-submitted vacation requests should not be auto-approved.
+        // An admin must explicitly approve or deny the request later.
+        vr.setApproved(false);
 
         if (usesOvertime && Boolean.TRUE.equals(user.getIsPercentage())) { //
             if (overtimeDeductionMinutes != null && overtimeDeductionMinutes > 0) { //


### PR DESCRIPTION
## Summary
- prevent automatic approval of user-submitted vacation requests, requiring admin action

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.chrono:Chrono:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bb1daa42083258e278541c6052fe2