### PR TITLE
Show overtime balance on printed time reports

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/ReportService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/ReportService.java
@@ -210,6 +210,11 @@ public class ReportService {
         long totalMinutes = totalWorkedMinutesOverall % 60;
         document.add(new Paragraph("Gesamte Arbeitszeit im Zeitraum: " + String.format("%d Std. %02d Min.", totalHours, totalMinutes), headerFont));
 
+        int overtimeMinutes = user.getTrackingBalanceInMinutes() != null ? user.getTrackingBalanceInMinutes() : 0;
+        long overtimeHours = overtimeMinutes / 60;
+        long overtimeRemainder = overtimeMinutes % 60;
+        document.add(new Paragraph("Aktueller Überstundensaldo: " + String.format("%d Std. %02d Min.", overtimeHours, overtimeRemainder), headerFont));
+
         document.close();
         return baos.toByteArray();
     }

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyDashboard.jsx
@@ -278,9 +278,11 @@ const assignCustomerForDay = async (isoDate, customerId) => {
             const doc = new jsPDF();
             doc.text(`${t("timeReportFor")} ${userName}`, 14, 15);
             doc.text(`${t("period")}: ${formatDate(printStartDate)} - ${formatDate(printEndDate)}`, 14, 22);
+            const overtimeStr = minutesToHHMM(currentUser.trackingBalanceInMinutes || 0);
+            doc.text(`${t('overtimeBalance')}: ${overtimeStr}`, 14, 28);
 
             autoTable(doc, {
-                startY: 30,
+                startY: 36,
                 head: [[t("date"), t("start"), t("end"), t("worked"), t("pause"), t("overtime")]],
                 body: reportData.map(d => [
                     formatDate(d.date), d.startTime, d.endTime,

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -293,6 +293,8 @@ const PercentageDashboard = () => {
         doc.text(`${t('printReport.title')} ${t('for')} ${userProfile.firstName} ${userProfile.lastName} (${userProfile.username}) - ${userProfile.workPercentage}%`, 14, 15);
         doc.setFontSize(11);
         doc.text(`${t('printReport.periodLabel')}: ${formatDate(printStartDate)} – ${formatDate(printEndDate)}`, 14, 22);
+        const overtimeStr = minutesToHHMM(userProfile.trackingBalanceInMinutes || 0);
+        doc.text(`${t('overtimeBalance')}: ${overtimeStr}`, 14, 28);
 
         const tableBody = summariesToPrint.map(summary => {
             const displayDate = formatDate(summary.date);
@@ -306,7 +308,7 @@ const PercentageDashboard = () => {
         });
         autoTable(doc, {
             head: [[t('printReport.date'), t('printReport.workStart'), t('printReport.workEnd'), t('printReport.pause'), t('printReport.total'), t('printReport.punches'), t('printReport.note')]],
-            body: tableBody, startY: 30, margin: { left: 10, right: 10 }, styles: { fontSize: 7, cellPadding: 1.5, overflow: 'linebreak' },
+            body: tableBody, startY: 36, margin: { left: 10, right: 10 }, styles: { fontSize: 7, cellPadding: 1.5, overflow: 'linebreak' },
             headStyles: { fillColor: [71, 91, 255], textColor: 255, fontStyle: "bold", halign: "center" },
             columnStyles: { 5: { cellWidth: 'auto'}, 6: { cellWidth: 40 } },
             didDrawPage: (dataHooks) => {

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -362,6 +362,12 @@ function UserDashboard() {
             14,
             22
         );
+        const overtimeStr = minutesToHHMM(userProfile.trackingBalanceInMinutes || 0);
+        doc.text(
+            `${t('overtimeBalance')}: ${overtimeStr}`,
+            14,
+            28
+        );
 
         const tableBody = summariesToPrint.map(summary => {
             const displayDate = formatDate(summary.date);
@@ -387,7 +393,7 @@ function UserDashboard() {
                 t('printReport.note'),
             ]],
             body: tableBody,
-            startY: 30,
+            startY: 36,
             margin: { left: 10, right: 10 },
             styles: { fontSize: 7, cellPadding: 1.5, overflow: 'linebreak' },
             headStyles: { fillColor: [71, 91, 255], textColor: 255, fontStyle: 'bold', halign: 'center' },


### PR DESCRIPTION
## Summary
- display users' overtime balance when generating timesheet PDFs in the backend
- include current overtime in all frontend time report printouts

## Testing
- `./mvnw test` *(fails: Network is unreachable for Maven dependencies)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb616f0fc8325a66727b39844a1fe