### PR TITLE
Restore overtime balance on payslip deletion

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/PayrollService.java
@@ -221,6 +221,15 @@ public class PayrollService {
         if (ps.isApproved()) {
             throw new IllegalStateException("Cannot delete approved payslip");
         }
+        if (ps.isPayoutOvertime() && ps.getOvertimeHours() != null && ps.getOvertimeHours() > 0) {
+            User user = ps.getUser();
+            int minutesToRestore = (int) Math.round(ps.getOvertimeHours() * 60);
+            int currentBalance = user.getTrackingBalanceInMinutes() != null
+                    ? user.getTrackingBalanceInMinutes()
+                    : 0;
+            user.setTrackingBalanceInMinutes(currentBalance + minutesToRestore);
+            userRepository.save(user);
+        }
         payslipAuditRepository.deleteByPayslip(ps);
         payslipRepository.delete(ps);
     }


### PR DESCRIPTION
## Summary
- reinstate a user's overtime balance when a payslip with overtime payout is deleted

## Testing
- `./mvnw -q test` *(fails: Network is unreachable and parent POM could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689bbac4b9d483259d6a592cf0549384