### PR TITLE
Add overtime information to admin time report

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -321,6 +321,8 @@ const AdminDashboard = () => {
 
         const userDetails = users.find(u => u.username === printUser);
         const userNameDisplay = userDetails ? `${userDetails.firstName} ${userDetails.lastName} (${printUser})` : printUser;
+        const balanceRecord = weeklyBalances.find(b => b.username === printUser);
+        const overtimeStr = minutesToHHMM(balanceRecord?.trackingBalance || 0);
 
         const doc = new jsPDF("p", "mm", "a4");
         const pageMargin = 15;
@@ -339,6 +341,8 @@ const AdminDashboard = () => {
         doc.text(`für ${userNameDisplay}`, pageWidth / 2, yPos, { align: "center" });
         yPos += 6;
         doc.text(`Zeitraum: ${formatDate(new Date(printUserStartDate))} - ${formatDate(new Date(printUserEndDate))}`, pageWidth / 2, yPos, { align: "center" });
+        yPos += 6;
+        doc.text(`${t('overtimeBalance', 'Überstundensaldo')}: ${overtimeStr}`, pageWidth / 2, yPos, { align: "center" });
         yPos += 15;
 
         const totalWork = sortedSummaries.reduce((sum, day) => sum + day.workedMinutes, 0);


### PR DESCRIPTION
## Summary
- show user's current overtime balance when printing time reports from admin dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbd7ef49c8325ab83249adf4bd20c