### PR TITLE
Add current-week buttons to dashboard week views

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -199,6 +199,10 @@ const AdminDashboard = () => {
         }
     }
 
+    function handleCurrentWeek() {
+        setSelectedMonday(getMondayOfWeek(new Date()));
+    }
+
     async function handleApproveVacation(id) {
         try {
             await api.post(`/api/vacation/approve/${id}`);
@@ -472,6 +476,7 @@ const AdminDashboard = () => {
                         handlePrevWeek={handlePrevWeek}
                         handleNextWeek={handleNextWeek}
                         handleWeekJump={handleWeekJump}
+                        handleCurrentWeek={handleCurrentWeek}
                         onFocusProblemWeek={focusWeekForProblem}
                         dailySummariesForWeekSection={dailySummaries}
                         allVacations={allVacations}

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -30,6 +30,7 @@ const AdminWeekSection = ({
                               handlePrevWeek,
                               handleNextWeek,
                               handleWeekJump,
+                              handleCurrentWeek,
                               onFocusProblemWeek,
                               dailySummariesForWeekSection, // This will be DailyTimeSummaryDTO[]
                               allVacations,
@@ -375,6 +376,7 @@ const AdminWeekSection = ({
                             aria-label={t('adminDashboard.jumpToDate', 'Datum auswählen')}
                         />
                         <button onClick={handleNextWeek} aria-label={t('adminDashboard.nextWeek', 'Nächste Woche')}>→</button>
+                        <button onClick={handleCurrentWeek} aria-label={t('adminDashboard.currentWeek', 'Aktuelle Woche')}>{t('currentWeek', 'Aktuelle Woche')}</button>
                     </div>
                 </div>
 
@@ -742,6 +744,7 @@ AdminWeekSection.propTypes = {
     handlePrevWeek: PropTypes.func.isRequired,
     handleNextWeek: PropTypes.func.isRequired,
     handleWeekJump: PropTypes.func.isRequired,
+    handleCurrentWeek: PropTypes.func.isRequired,
     onFocusProblemWeek: PropTypes.func.isRequired,
     dailySummariesForWeekSection: PropTypes.arrayOf(
         PropTypes.shape({ // This should match DailyTimeSummaryDTO

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -82,6 +82,10 @@ const HourlyWeekOverview = ({
         }
     }
 
+    function handleCurrentWeek() {
+        setSelectedMonday(getMondayOfWeek(new Date()));
+    }
+
     const handleNoteSave = async (isoDate, content) => {
         if (!userProfile?.username) return;
         try {
@@ -156,6 +160,7 @@ const HourlyWeekOverview = ({
                     value={formatLocalDate(selectedMonday)}
                 />
                 <button onClick={handleNextWeek} className="button-secondary">{t("nextWeek", "Nächste Woche")} →</button>
+                <button onClick={handleCurrentWeek} className="button-secondary">{t('currentWeek', 'Aktuelle Woche')}</button>
             </div>
             <div className="weekly-monthly-totals">
                 <div className="summary-item">

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -52,9 +52,13 @@ const PercentageWeekOverview = ({
 
     function handleWeekJump(e) {
         const picked = new Date(e.target.value + "T00:00:00");
-        if (!isNaN(picked.getTime())) {
-            setMonday(getMondayOfWeek(picked));
-        }
+       if (!isNaN(picked.getTime())) {
+           setMonday(getMondayOfWeek(picked));
+       }
+    }
+
+    function handleCurrentWeek() {
+        setMonday(getMondayOfWeek(new Date()));
     }
 
     return (
@@ -101,6 +105,7 @@ const PercentageWeekOverview = ({
                 <button onClick={() => setMonday(prev => addDays(prev, 7))} className="button-secondary">
                     {t('nextWeek', "Nächste Woche")} →
                 </button>
+                <button onClick={handleCurrentWeek} className="button-secondary">{t('currentWeek', 'Aktuelle Woche')}</button>
             </div>
 
             <div className="weekly-summary">

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -495,6 +495,9 @@ function UserDashboard() {
                         <button onClick={() => setSelectedMonday(prev => addDays(prev, 7))} className="button-secondary">
                             {t("nextWeek")} →
                         </button>
+                        <button onClick={() => setSelectedMonday(getMondayOfWeek(new Date()))} className="button-secondary">
+                            {t('currentWeek', 'Aktuelle Woche')}
+                        </button>
                     </div>
 
                     <div className="weekly-monthly-totals">


### PR DESCRIPTION
## Summary
- add handler to reset week view to current date
- add "Aktuelle Woche" navigation button on admin and user dashboards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bbfc124288325a4c4422d80b4d56b