### PR TITLE
Ensure time entries display in chronological order

### DIFF
--- a/Chrono-frontend/src/components/CorrectionModal.jsx
+++ b/Chrono-frontend/src/components/CorrectionModal.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ModalOverlay from './ModalOverlay';
 import { formatDate } from '../utils/dateUtils';
-import { formatTime } from '../utils/timeUtils';
+import { formatTime, sortEntries } from '../utils/timeUtils';
 
 const CorrectionModal = ({
                              visible,
@@ -20,7 +20,7 @@ const CorrectionModal = ({
     useEffect(() => {
         if (visible) {
             const initialEntries =
-                dailySummary?.entries?.map((entry) => ({
+                sortEntries(dailySummary?.entries).map((entry) => ({
                     time: formatTime(new Date(entry.entryTimestamp)),
                     type: entry.punchType,
                 })) || [];

--- a/Chrono-frontend/src/components/DayCard.jsx
+++ b/Chrono-frontend/src/components/DayCard.jsx
@@ -5,6 +5,7 @@ import {
   formatTime,
   formatPunchedTimeFromEntry,
   isLateTime,
+  sortEntries,
 } from '../utils/timeUtils';
 
 const DayCard = ({
@@ -22,13 +23,17 @@ const DayCard = ({
   children,
 }) => {
   const correctionDisabled = holidayName || vacationInfo || sickInfo;
+  const sortedEntries = useMemo(
+    () => sortEntries(summary?.entries),
+    [summary]
+  );
 
   const customerRanges = useMemo(() => {
-    if (!summary || !Array.isArray(summary.entries)) return [];
+    if (!sortedEntries || !Array.isArray(sortedEntries)) return [];
     const ranges = [];
     let currentCustomer = null;
     let start = null;
-    summary.entries.forEach(entry => {
+    sortedEntries.forEach(entry => {
       const time = formatTime(entry.entryTimestamp);
       if (entry.punchType === 'START') {
         currentCustomer = entry.customerName || null;
@@ -40,7 +45,7 @@ const DayCard = ({
       }
     });
     return ranges;
-  }, [summary]);
+  }, [sortedEntries]);
 
   const uniqueCustomers = useMemo(() => {
     return Array.from(
@@ -113,7 +118,7 @@ const DayCard = ({
         ) : (
           <>
             <ul className="time-entry-list">
-              {summary.entries.map((entry) => (
+              {sortedEntries.map((entry) => (
                   <li
                       key={entry.id || entry.entryTimestamp}
                       style={{

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -21,6 +21,7 @@ import {
     getMondayOfWeek,
 } from "./adminDashboardUtils"; // Ensure this path is correct
 import {parseISO} from "date-fns"; // Make sure date-fns is installed
+import { sortEntries } from '../../utils/timeUtils';
 
 
 const AdminWeekSection = ({
@@ -570,7 +571,7 @@ const AdminWeekSection = ({
                                                                                 </button>
                                                                             </div>
                                                                             <ul className="time-entry-list-condensed text-xs">
-                                                                                {dailySummary.entries.map(entry => {
+                                                                                {sortEntries(dailySummary.entries).map(entry => {
                                                                                     let typeLabel = entry.punchType;
                                                                                     try {
                                                                                         typeLabel = t(`punchTypes.${entry.punchType}`, entry.punchType);
@@ -650,7 +651,7 @@ const AdminWeekSection = ({
                                                                             </button>
                                                                         </div>
                                                                         <ul className="time-entry-list-condensed text-xs">
-                                                                            {dailySummary.entries.map(entry => {
+                                                                            {sortEntries(dailySummary.entries).map(entry => {
                                                                                 let typeLabel = entry.punchType;
                                                                                 try {
                                                                                     typeLabel = t(`punchTypes.${entry.punchType}`, entry.punchType);

--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -10,7 +10,8 @@ import {
     getMondayOfWeek,
     minutesToHHMM,
     isLateTime,
-    formatPunchedTimeFromEntry
+    formatPunchedTimeFromEntry,
+    sortEntries
 } from './hourDashUtils';
 import '../../styles/HourlyDashboardScoped.css';
 import api from "../../utils/api.js";
@@ -216,7 +217,7 @@ const HourlyWeekOverview = ({
                                     <>
                                         <ul className="time-entry-list">
                                             {/* ... (deine Listeneinträge bleiben unverändert) ... */}
-                                            {summary.entries.map(entry => (
+                                            {sortEntries(summary.entries).map(entry => (
                                                 <li key={entry.id || entry.entryTimestamp} style={{backgroundColor: entry.customerId ? `hsl(${(entry.customerId * 57) % 360}, var(--customer-color-saturation), var(--customer-color-lightness))` : 'transparent'}}>                                                    <span className="entry-label">{t(`punchTypes.${entry.punchType}`, entry.punchType)}:</span>
                                                     <span className={`entry-time ${isLateTime(formatTime(new Date(entry.entryTimestamp))) ? 'late-time' : ''}`}>
                                                         {formatPunchedTimeFromEntry(entry)}

--- a/Chrono-frontend/src/pages/HourlyDashboard/hourDashUtils.js
+++ b/Chrono-frontend/src/pages/HourlyDashboard/hourDashUtils.js
@@ -12,6 +12,7 @@ import {
     minutesToHours,
     formatPunchedTimeFromEntry,
     isLateTime,
+    sortEntries,
 } from '../../utils/timeUtils';
 
 export {
@@ -25,6 +26,7 @@ export {
     minutesToHours,
     formatPunchedTimeFromEntry,
     isLateTime,
+    sortEntries,
 };
 
 // Holt gearbeitete Minuten aus einem DailyTimeSummaryDTO

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageDashboard.jsx
@@ -21,7 +21,8 @@ import {
     minutesToHHMM,
     computeTotalWorkedMinutesInRange,
     expectedDayMinutesForPercentageUser,
-    parseHex16
+    parseHex16,
+    sortEntries
 } from './percentageDashUtils';
 
 import PercentageWeekOverview from './PercentageWeekOverview';
@@ -303,7 +304,7 @@ const PercentageDashboard = () => {
             const workEnd    = primary.lastEndTime ? primary.lastEndTime.substring(0,5) : (primary.isOpen ? t('printReport.open') : "-");
             const breakTimeStr = minutesToHHMM(summary.breakMinutes);
             const totalWorkedStr = minutesToHHMM(summary.workedMinutes);
-            const punches = summary.entries.map(e => `${t('punchTypes.'+e.punchType, e.punchType).substring(0,1)}:${formatTime(e.entryTimestamp)}${e.source === 'SYSTEM_AUTO_END' && !e.correctedByUser ? '(A)' : ''}`).join(' | ');
+            const punches = sortEntries(summary.entries).map(e => `${t('punchTypes.'+e.punchType, e.punchType).substring(0,1)}:${formatTime(e.entryTimestamp)}${e.source === 'SYSTEM_AUTO_END' && !e.correctedByUser ? '(A)' : ''}`).join(' | ');
             return [displayDate, workStart, workEnd, breakTimeStr, totalWorkedStr, punches, summary.dailyNote || ""];
         });
         autoTable(doc, {

--- a/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/PercentageDashboard/PercentageWeekOverview.jsx
@@ -8,7 +8,8 @@ import {
     formatLocalDate,
     minutesToHHMM,
     formatDate,
-    getMondayOfWeek
+    getMondayOfWeek,
+    sortEntries
 } from './percentageDashUtils';
 
 import '../../styles/HourlyDashboardScoped.css'; // Einheitliches Design verwenden
@@ -159,7 +160,7 @@ const PercentageWeekOverview = ({
                                                 <p><strong>{t('breakTime', 'Pause')}:</strong> {minutesToHHMM(summary?.breakMinutes || 0)}</p>
                                             </div>
                                             <ul className="time-entry-list" style={{marginTop: '1rem'}}>
-                                                {(summary?.entries || []).map(entry => (
+                                                {sortEntries(summary?.entries).map(entry => (
                                                     <li key={entry.id || entry.entryTimestamp} style={{backgroundColor: entry.customerId ? `hsl(${(entry.customerId * 57) % 360}, var(--customer-color-saturation), var(--customer-color-lightness))` : 'transparent'}}>
                                                         <span className="entry-label">{t(`punchTypes.${entry.punchType}`, entry.punchType)}:</span>
                                                         <span className="entry-time">{entry.entryTimestamp ? new Date(entry.entryTimestamp).toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' }) : ''}</span>
@@ -180,7 +181,7 @@ const PercentageWeekOverview = ({
                                             <p><strong>{t('breakTime', 'Pause')}:</strong> {minutesToHHMM(summary?.breakMinutes || 0)}</p>
                                         </div>
                                         <ul className="time-entry-list" style={{marginTop: '1rem'}}>
-                                            {(summary?.entries || []).map(entry => (
+                                            {sortEntries(summary?.entries).map(entry => (
                                                 <li key={entry.id || entry.entryTimestamp} style={{backgroundColor: entry.customerId ? `hsl(${(entry.customerId * 57) % 360}, var(--customer-color-saturation), var(--customer-color-lightness))` : 'transparent'}}>
                                                     <span className="entry-label">{t(`punchTypes.${entry.punchType}`, entry.punchType)}:</span>
                                                     <span className="entry-time">{entry.entryTimestamp ? new Date(entry.entryTimestamp).toLocaleTimeString('de-CH', { hour: '2-digit', minute: '2-digit' }) : ''}</span>

--- a/Chrono-frontend/src/pages/PercentageDashboard/percentageDashUtils.js
+++ b/Chrono-frontend/src/pages/PercentageDashboard/percentageDashUtils.js
@@ -12,6 +12,7 @@ import {
     minutesToHours,
     formatPunchedTimeFromEntry,
     isLateTime,
+    sortEntries,
 } from '../../utils/timeUtils';
 
 export {
@@ -25,6 +26,7 @@ export {
     minutesToHours,
     formatPunchedTimeFromEntry,
     isLateTime,
+    sortEntries,
 };
 
 export function getWorkedMinutesFromSummary(dailySummary) {

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -29,6 +29,7 @@ import {
     isLateTime,
     formatPunchedTimeFromEntry,
     parseHex16,
+    sortEntries,
 } from './userDashUtils';
 
 import CorrectionModal from '../../components/CorrectionModal';
@@ -376,7 +377,7 @@ function UserDashboard() {
             const workEnd = primary.lastEndTime ? primary.lastEndTime.substring(0, 5) : (primary.isOpen ? t('printReport.open') : '-');
             const breakTimeStr = minutesToHHMM(summary.breakMinutes);
             const totalWorkedStr = minutesToHHMM(summary.workedMinutes);
-            const punches = summary.entries
+            const punches = sortEntries(summary.entries)
                 .map(e => `${t('punchTypes.' + e.punchType, e.punchType).substring(0,1)}:${formatTime(e.entryTimestamp)}${e.source === 'SYSTEM_AUTO_END' && !e.correctedByUser ? '(A)' : ''}`)
                 .join(' | ');
             return [displayDate, workStart, workEnd, breakTimeStr, totalWorkedStr, punches, summary.dailyNote || ''];
@@ -564,7 +565,7 @@ function UserDashboard() {
                                         ) : (
                                             <>
                                                 <ul className="time-entry-list">
-                                                    {summary?.entries.map(entry => (
+                                                    {sortEntries(summary?.entries).map(entry => (
                                                         <li key={entry.id || entry.entryTimestamp} style={{backgroundColor: entry.customerId ? `hsl(${(entry.customerId * 57) % 360}, var(--customer-color-saturation), var(--customer-color-lightness))` : 'transparent'}}>
                                                             <span className="entry-label">{t(`punchTypes.${entry.punchType}`, entry.punchType)}:</span>
                                                             <span className={`entry-time ${isLateTime(formatTime(new Date(entry.entryTimestamp))) ? 'late-time' : ''}`}>

--- a/Chrono-frontend/src/pages/UserDashboard/userDashUtils.js
+++ b/Chrono-frontend/src/pages/UserDashboard/userDashUtils.js
@@ -11,6 +11,7 @@ import {
     formatPunchedTimeFromEntry,
     minutesToHHMM,
     isLateTime,
+    sortEntries,
 } from '../../utils/timeUtils';
 
 export {
@@ -22,6 +23,7 @@ export {
     formatPunchedTimeFromEntry,
     minutesToHHMM,
     isLateTime,
+    sortEntries,
 };
 
 export function parseHex16(hexString) {

--- a/Chrono-frontend/src/utils/timeUtils.js
+++ b/Chrono-frontend/src/utils/timeUtils.js
@@ -43,3 +43,9 @@ export function isLateTime(timeString) {
         return false;
     }
 }
+
+export function sortEntries(entries) {
+    return [...(entries || [])].sort(
+        (a, b) => new Date(a.entryTimestamp) - new Date(b.entryTimestamp)
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared `sortEntries` helper for chronological ordering
- use `sortEntries` across dashboards and components so punch times always list top‑to‑bottom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bc2346c788325a201ec5bc09f1dbe