### PR TITLE
Fix legal footer links and add privacy page

### DIFF
--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -39,6 +39,7 @@ import PrintReport from "./pages/PrintReport.jsx";
 import WhatsNewPage from "./pages/WhatsNewPage.jsx";
 import AGB from "./pages/AGB.jsx";
 import Impressum from "./pages/Impressum.jsx";
+import Datenschutz from "./pages/Datenschutz.jsx";
 import CompanySettingsPage from "./pages/CompanySettingsPage.jsx";
 import PayslipsPage from "./pages/PayslipsPage.jsx";
 
@@ -62,6 +63,7 @@ function App() {
                         <Route path="/login" element={<Login />} />
                         <Route path="/register" element={<Registration />} />
                         <Route path="/agb" element={<AGB />} />
+                        <Route path="/datenschutz" element={<Datenschutz />} />
                         <Route path="/impressum" element={<Impressum />} />
 
                         {/* Geschützte Benutzer-Routen */}

--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -677,6 +677,10 @@ const translations = {
             copyright: "<strong>Copyright:</strong><br />Sämtliche Inhalte (Texte, Bilder, Grafiken) auf dieser Website sind urheberrechtlich geschützt. Jegliche Nutzung ohne ausdrückliche Zustimmung ist untersagt.",
             stand: "<em>Stand: Mai 2025</em>",
         },
+        privacyPage: {
+            title: "Datenschutz",
+            content: "Hier finden Sie Informationen zum Datenschutz.",
+        },
         agbPage: {
             title: "Allgemeine Geschäftsbedingungen",
             stand: "Stand Mai 2025",
@@ -1409,6 +1413,10 @@ const translations = {
             liability: "<strong>Disclaimer:</strong><br />We assume no liability for the content of external links. The operators of the linked pages are solely responsible for their content.",
             copyright: "<strong>Copyright:</strong><br />All content on this website is protected by copyright. Any use without explicit permission is prohibited.",
             stand: "<em>Updated: May 2025</em>",
+        },
+        privacyPage: {
+            title: "Privacy Policy",
+            content: "Here you can find information about our privacy policy.",
         },
         agbPage: {
             title: "Terms of Service",

--- a/Chrono-frontend/src/pages/Datenschutz.jsx
+++ b/Chrono-frontend/src/pages/Datenschutz.jsx
@@ -1,0 +1,22 @@
+// src/pages/Datenschutz.jsx
+import React from 'react';
+import Navbar from '../components/Navbar';
+import '../styles/LegalPages.css';
+import { useTranslation } from '../context/LanguageContext';
+
+const Datenschutz = () => {
+    const { t } = useTranslation();
+    return (
+        <>
+            <Navbar />
+            <div className="legal-wrapper">
+                <div className="legal-page">
+                    <h1>{t('privacyPage.title')}</h1>
+                    <p>{t('privacyPage.content')}</p>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default Datenschutz;

--- a/Chrono-frontend/src/pages/LandingPage.jsx
+++ b/Chrono-frontend/src/pages/LandingPage.jsx
@@ -153,9 +153,9 @@ const LandingPage = () => {
                 <div className="lp-foot-inner">
                     <span>© {new Date().getFullYear()} Chrono</span>
                     <nav className="lp-foot-links" aria-label="Footer Navigation">
-                        <Link to="/imprint">Impressum</Link>
-                        <Link to="/privacy">Datenschutz</Link>
-                        <Link to="/terms">AGB</Link>
+                        <Link to="/impressum">Impressum</Link>
+                        <Link to="/datenschutz">Datenschutz</Link>
+                        <Link to="/agb">AGB</Link>
                     </nav>
                 </div>
             </footer>


### PR DESCRIPTION
## Summary
- Update landing page footer links to point to the correct legal routes
- Add privacy policy page and translations
- Register new privacy route in the app

## Testing
- `npm test` *(fails: Unable to find element with text /Hallo, Alice/ in Navbar test)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dd1270b88325bce02dadbbeb494b