### PR TITLE
fix password change request body

### DIFF
--- a/Chrono-frontend/src/pages/AdminChangePassword.jsx
+++ b/Chrono-frontend/src/pages/AdminChangePassword.jsx
@@ -16,12 +16,10 @@ const AdminChangePassword = () => {
     const handlePasswordChange = async (e) => {
         e.preventDefault();
         try {
-            await api.put('/api/user/change-password', null, {
-                params: {
-                    username: currentUser.username,
-                    currentPassword: passwordData.currentPassword,
-                    newPassword: passwordData.newPassword
-                }
+            await api.put('/api/user/change-password', {
+                username: currentUser.username,
+                currentPassword: passwordData.currentPassword,
+                newPassword: passwordData.newPassword,
             });
             setMessage(t("personalData.passwordChanged", "Passwort erfolgreich geändert"));
             notify(t("personalData.passwordChanged", "Passwort erfolgreich geändert"));

--- a/Chrono-frontend/src/pages/PersonalDataPage.jsx
+++ b/Chrono-frontend/src/pages/PersonalDataPage.jsx
@@ -86,12 +86,10 @@ const PersonalDataPage = () => {
     async function handlePasswordChange(e) {
         e.preventDefault();
         try {
-            await api.put('/api/user/change-password', null, {
-                params: {
-                    username: currentUser.username,
-                    currentPassword: passwordData.currentPassword,
-                    newPassword: passwordData.newPassword,
-                },
+            await api.put('/api/user/change-password', {
+                username: currentUser.username,
+                currentPassword: passwordData.currentPassword,
+                newPassword: passwordData.newPassword,
             });
             setMessage(t("personalData.passwordChanged", "Passwort erfolgreich geändert"));
             notify(t("personalData.passwordChanged", "Passwort erfolgreich geändert"));


### PR DESCRIPTION
## Summary
- Send password change parameters in request body for user and admin views

## Testing
- `npm test` *(fails: vitest not found; npm install fails building @pokusew/pcsclite)*
- `mvn -q test` *(fails: cannot resolve parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a720f4f9d08325ab721660ad722398