### PR TITLE
Fix translation labels for vacation and sick badges

### DIFF
--- a/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
+++ b/Chrono-frontend/src/pages/HourlyDashboard/HourlyWeekOverview.jsx
@@ -196,7 +196,7 @@ const HourlyWeekOverview = ({
                         <div key={isoDate} className={dayClasses}>
                         <div className="week-day-header day-card-header">
                                 <h4>{dayName}, {formattedDisplayDate}</h4>
-                                {vacationToday && <div className="day-card-badge vacation-badge">{t('vacation')}</div>}
+                                {vacationToday && <div className="day-card-badge vacation-badge">{t('onVacation', 'Im Urlaub')}</div>}
 
                                 {summary && summary.entries.length > 0 && (
                                     <div className="day-card-actions">

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -552,8 +552,8 @@ function UserDashboard() {
                                     <div className="week-day-header day-card-header">
                                         <h4>{dayName}, {formattedDisplayDate}</h4>
                                         {holidayName && <div className="day-card-badge holiday-badge">{holidayName}</div>}
-                                        {vacationToday && <div className="day-card-badge vacation-badge">{t('vacation')}</div>}
-                                        {sickToday && <div className="day-card-badge sick-badge">{t('sickLeave')}</div>}
+                                        {vacationToday && <div className="day-card-badge vacation-badge">{t('onVacation', 'Im Urlaub')}</div>}
+                                        {sickToday && <div className="day-card-badge sick-badge">{t('sickLeave.sick', 'Krank')}</div>}
                                     </div>
 
                                     <div className="week-day-content day-card-content">


### PR DESCRIPTION
## Summary
- Use concrete translation keys for vacation and sick-day badges to avoid rendering translation objects
- Show proper labels "Im Urlaub" and "Krank" on dashboards

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: pcsclite build missing winscard.h)*

------
https://chatgpt.com/codex/tasks/task_e_68aa54e87f148325a90971b0436794d2