### PR TITLE
feat: tailor navbar per dashboard

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -119,6 +119,7 @@ const Navbar = () => {
     const isPercentage = !!currentUser?.isPercentage;
 
     const userInitial = currentUser?.username?.[0]?.toUpperCase() || 'U';
+    const onAdminRoute = location.pathname.startsWith('/admin');
 
     return (
         <div className={styles['scoped-navbar']}>
@@ -145,11 +146,11 @@ const Navbar = () => {
                         <>
                             {currentUser && (
                                 <>
-                                    {isSuperAdmin && (
+                                    {isSuperAdmin && onAdminRoute && (
                                         <li><Link to="/admin/company">{t('navbar.companyManagement','Firmen')}</Link></li>
                                     )}
 
-                                    {isAdmin ? (
+                                    {isAdmin && onAdminRoute ? (
                                         <li className={`${styles.dropdown} ${openAdmin ? styles.open : ''}`} ref={adminRef}>
                                             <button
                                                 className={styles['dropdown-trigger']}

--- a/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
@@ -53,4 +53,22 @@ describe('Navbar', () => {
         expect(logoutMock).toHaveBeenCalled();
     });
 
+    it('shows user navigation for admin on user dashboard', () => {
+        renderNavbar(
+            { authToken: 'token', currentUser: { username: 'Admin', roles: ['ROLE_ADMIN'] }, logout: vi.fn() },
+            '/dashboard'
+        );
+        expect(screen.getByText(/Mein Dashboard/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Admin-Start/i)).toBeNull();
+    });
+
+    it('shows admin navigation for admin on admin dashboard', () => {
+        renderNavbar(
+            { authToken: 'token', currentUser: { username: 'Admin', roles: ['ROLE_ADMIN'], customerTrackingEnabled: true }, logout: vi.fn() },
+            '/admin/dashboard'
+        );
+        expect(screen.getAllByRole('button', { name: /Admin/i })[0]).toBeInTheDocument();
+        expect(screen.queryByText(/Mein Dashboard/i)).toBeNull();
+    });
+
 });


### PR DESCRIPTION
## Summary
- show admin links only on admin routes
- fall back to user links on user dashboard for admin accounts
- test navbar routing behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac7da0d4fc8325b8b5a5cc7189fd48