### PR TITLE
Fix admin dashboard link for admin users

### DIFF
--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -224,7 +224,7 @@ const Navbar = () => {
                                     ) : (
                                         <>
                                             <li>
-                                                <Link to={isPercentage ? "/percentage-punch" : "/dashboard"}>
+                                                <Link to={(isAdmin || isSuperAdmin) ? "/admin/dashboard" : isPercentage ? "/percentage-punch" : "/dashboard"}>
                                                     {t('navbar.myDashboard','Mein Dashboard')}
                                                 </Link>
                                             </li>

--- a/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
+++ b/Chrono-frontend/src/components/__tests__/Navbar.test.jsx
@@ -58,7 +58,9 @@ describe('Navbar', () => {
             { authToken: 'token', currentUser: { username: 'Admin', roles: ['ROLE_ADMIN'] }, logout: vi.fn() },
             '/dashboard'
         );
-        expect(screen.getByText(/Mein Dashboard/i)).toBeInTheDocument();
+        const dashboardLink = screen.getByRole('link', { name: /Mein Dashboard/i });
+        expect(dashboardLink).toBeInTheDocument();
+        expect(dashboardLink).toHaveAttribute('href', '/admin/dashboard');
         expect(screen.queryByText(/Admin-Start/i)).toBeNull();
     });
 


### PR DESCRIPTION
## Summary
- ensure "Mein Dashboard" links to admin dashboard when admin logged in
- test navbar routing for admins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c591c4fb048325b288893f4a4f8b3a