### PR TITLE
Prevent overlapping dashboard headers and highlight project assignments

### DIFF
--- a/Chrono-frontend/src/context/LanguageContext.jsx
+++ b/Chrono-frontend/src/context/LanguageContext.jsx
@@ -538,6 +538,7 @@ const translations = {
         noTask: "Keine Aufgabe",
         assignCustomer: {
             editButton: "Kunden & Zeiten bearbeiten",
+            projectTag: "Projektzeit",
         },
         correction: {
             desiredChange: "Gewünschte Änderung",
@@ -1505,6 +1506,7 @@ const translations = {
         noTask: "No task",
         assignCustomer: {
             editButton: "Edit customers & times",
+            projectTag: "Project time",
         },
         correction: {
             desiredChange: "Desired Change",

--- a/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
+++ b/Chrono-frontend/src/pages/UserDashboard/UserDashboard.jsx
@@ -528,6 +528,21 @@ function UserDashboard() {
                             const sickToday = sickLeaves.find(sl => isoDate >= sl.startDate && isoDate <= sl.endDate);
                             const holidayName = holidaysForUserCanton.data?.[isoDate];
 
+                            const projectNames = Array.from(
+                                new Set(
+                                    (summary?.entries || [])
+                                        .map(entry => entry.projectName || (projects || []).find(p => String(p.id) === String(entry.projectId))?.name || '')
+                                        .filter(Boolean)
+                                )
+                            );
+                            const hasProjects = projectNames.length > 0;
+                            const showProjectBadge = isCustomerTrackingEnabled && hasProjects;
+                            const projectBadgeBaseLabel = t('assignCustomer.projectTag', 'Projektzeit');
+                            const projectBadgeLabel = projectNames.length === 1
+                                ? projectNames[0]
+                                : `${projectBadgeBaseLabel}${projectNames.length > 1 ? ` (${projectNames.length})` : ''}`;
+                            const projectBadgeTitle = projectNames.join(', ');
+
                             let dayClass = 'week-day-card';
                             if (vacationToday) dayClass += ' vacation-day';
                             if (sickToday) dayClass += ' sick-day';
@@ -549,10 +564,24 @@ function UserDashboard() {
                             return (
                                 <div key={isoDate} className={dayClass}>
                                     <div className="week-day-header day-card-header">
-                                        <h4>{dayName}, {formattedDisplayDate}</h4>
-                                        {holidayName && <div className="day-card-badge holiday-badge">{holidayName}</div>}
-                                        {vacationToday && <div className="day-card-badge vacation-badge">{t('onVacation', 'Im Urlaub')}</div>}
-                                        {sickToday && <div className="day-card-badge sick-badge">{t('sickLeave.sick', 'Krank')}</div>}
+                                        <div className="day-card-header-main">
+                                            <h4>{dayName}, {formattedDisplayDate}</h4>
+                                            {(holidayName || vacationToday || sickToday || showProjectBadge) && (
+                                                <div className="day-card-badges">
+                                                    {holidayName && <span className="day-card-badge holiday-badge">{holidayName}</span>}
+                                                    {vacationToday && <span className="day-card-badge vacation-badge">{t('onVacation', 'Im Urlaub')}</span>}
+                                                    {sickToday && <span className="day-card-badge sick-badge">{t('sickLeave.sick', 'Krank')}</span>}
+                                                    {showProjectBadge && (
+                                                        <span
+                                                            className="day-card-badge project-badge"
+                                                            title={projectBadgeTitle || undefined}
+                                                        >
+                                                            {projectBadgeLabel}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
                                         {isCustomerTrackingEnabled && summary && summary.entries?.length > 0 && (
                                             <div className="day-card-actions">
                                                 <button

--- a/Chrono-frontend/src/styles/HourlyDashboardScoped.css
+++ b/Chrono-frontend/src/styles/HourlyDashboardScoped.css
@@ -280,13 +280,42 @@
 .hourly-dashboard.scoped-dashboard .week-day-card:hover { border-color: color-mix(in srgb, var(--ud-c-primary) 50%, var(--ud-c-border)); transform: translateY(-4px); box-shadow: var(--ud-shadow-hover); }
 
 .hourly-dashboard.scoped-dashboard .day-card-header,
-.hourly-dashboard.scoped-dashboard .week-day-header { margin-bottom:.6rem; display:flex; align-items:center; justify-content:space-between; gap:.6rem; }
+.hourly-dashboard.scoped-dashboard .week-day-header {
+    margin-bottom:.6rem;
+    display:flex;
+    flex-wrap:wrap;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:.75rem;
+}
 .hourly-dashboard.scoped-dashboard .day-card-header h3,
 .hourly-dashboard.scoped-dashboard .week-day-header h4 { margin:0; font-size: var(--ud-fz-lg); font-weight: 720; }
 
+.hourly-dashboard.scoped-dashboard .day-card-header-main { display:flex; flex-direction:column; gap:.35rem; flex:1 1 60%; min-width:0; }
+.hourly-dashboard.scoped-dashboard .day-card-badges { display:flex; flex-wrap:wrap; gap:.4rem; }
+.hourly-dashboard.scoped-dashboard .day-card-actions { display:flex; flex:0 0 auto; }
+.hourly-dashboard.scoped-dashboard .day-card-actions .button-primary-outline { white-space:nowrap; }
+
 /* Badges / Indicators */
-.hourly-dashboard.scoped-dashboard .day-card-badge { position:absolute; top:10px; right:10px; font-size:.75rem; padding:.28rem .55rem; border-radius:999px; border:1px solid currentColor; opacity:.96; backdrop-filter: blur(4px); }
+.hourly-dashboard.scoped-dashboard .day-card-badge {
+    position:relative;
+    top:auto;
+    right:auto;
+    font-size:.75rem;
+    padding:.28rem .55rem;
+    border-radius:999px;
+    border:1px solid currentColor;
+    opacity:.96;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    white-space:nowrap;
+    max-width:100%;
+    overflow:hidden;
+    text-overflow:ellipsis;
+}
 .hourly-dashboard.scoped-dashboard .vacation-badge { background: color-mix(in srgb, var(--ud-c-primary) 12%, transparent); color: var(--ud-c-primary); }
+.hourly-dashboard.scoped-dashboard .project-badge { background: color-mix(in srgb, var(--ud-c-success) 16%, transparent); color: var(--ud-c-success); }
+[data-theme="dark"] .hourly-dashboard.scoped-dashboard .project-badge { background: color-mix(in srgb, var(--ud-c-success) 34%, transparent); }
 .hourly-dashboard.scoped-dashboard .vacation-indicator { background: color-mix(in srgb, var(--ud-c-primary) 8%, transparent); color: var(--ud-c-primary); padding:.2rem .5rem; border-radius: 999px; display:inline-block; }
 
 /* Entry list */

--- a/Chrono-frontend/src/styles/PercentageDashboardScoped.css
+++ b/Chrono-frontend/src/styles/PercentageDashboardScoped.css
@@ -260,9 +260,20 @@
 .percentage-dashboard.scoped-dashboard .week-day-card:hover { border-color: color-mix(in srgb, var(--ud-c-primary) 50%, var(--ud-c-border)); transform: translateY(-4px); box-shadow: var(--ud-shadow-hover); }
 
 .percentage-dashboard.scoped-dashboard .day-card-header,
-.percentage-dashboard.scoped-dashboard .week-day-header { margin-bottom:.6rem; display:flex; align-items:center; justify-content:space-between; gap:.6rem; }
+.percentage-dashboard.scoped-dashboard .week-day-header {
+    margin-bottom:.6rem;
+    display:flex;
+    flex-wrap:wrap;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:.75rem;
+}
 .percentage-dashboard.scoped-dashboard .day-card-header h3,
 .percentage-dashboard.scoped-dashboard .week-day-header h4 { margin:0; font-size: var(--ud-fz-lg); font-weight: 720; }
+.percentage-dashboard.scoped-dashboard .day-card-header-main { display:flex; flex-direction:column; gap:.35rem; flex:1 1 60%; min-width:0; }
+.percentage-dashboard.scoped-dashboard .day-card-badges { display:flex; flex-wrap:wrap; gap:.4rem; }
+.percentage-dashboard.scoped-dashboard .day-card-actions { display:flex; flex:0 0 auto; }
+.percentage-dashboard.scoped-dashboard .day-card-actions .button-primary-outline { white-space:nowrap; }
 
 /* Entry list */
 .percentage-dashboard.scoped-dashboard .time-entry-list { list-style:none; margin:.55rem 0 0 0; padding:0; font-size: var(--ud-fz-sm); }
@@ -289,10 +300,27 @@
 .percentage-dashboard.scoped-dashboard .note-buttons { display:flex; gap:.5rem; }
 
 /* Day badges */
-.day-card-badge { position:absolute; top:10px; right:10px; font-size:.75rem; padding:.28rem .55rem; border-radius:999px; border:1px solid currentColor; opacity:.96; backdrop-filter: blur(4px); }
+.day-card-badge {
+    position:relative;
+    top:auto;
+    right:auto;
+    font-size:.75rem;
+    padding:.28rem .55rem;
+    border-radius:999px;
+    border:1px solid currentColor;
+    opacity:.96;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    white-space:nowrap;
+    max-width:100%;
+    overflow:hidden;
+    text-overflow:ellipsis;
+}
 .holiday-indicator { background: color-mix(in srgb, var(--ud-c-warn) 12%, transparent); color: var(--ud-c-warn); }
 .vacation-indicator { background: color-mix(in srgb, var(--ud-c-primary) 12%, transparent); color: var(--ud-c-primary); }
 .sick-leave-indicator { background: color-mix(in srgb, var(--ud-c-error) 12%, transparent); color: var(--ud-c-error); }
+.project-badge { background: color-mix(in srgb, var(--ud-c-success) 16%, transparent); color: var(--ud-c-success); }
+[data-theme="dark"] .project-badge { background: color-mix(in srgb, var(--ud-c-success) 34%, transparent); }
 
 /* Correction actions row */
 .percentage-dashboard.scoped-dashboard .correction-button-row { margin-top:auto; padding-top:.7rem; border-top:1px solid var(--ud-c-line); display:grid; gap:.5rem; }

--- a/Chrono-frontend/src/styles/UserDashboardScoped.css
+++ b/Chrono-frontend/src/styles/UserDashboardScoped.css
@@ -272,14 +272,43 @@
 .user-dashboard.scoped-dashboard .week-day-card::before { content:""; position:absolute; inset:0; background: radial-gradient(400px 160px at 10% 0%, rgba(var(--ud-c-primary-rgb),.05), transparent 60%); pointer-events:none; }
 .user-dashboard.scoped-dashboard .week-day-card:hover { border-color: color-mix(in srgb, var(--ud-c-primary) 50%, var(--ud-c-border)); transform: translateY(-4px); box-shadow: var(--ud-shadow-hover); }
 
-.user-dashboard.scoped-dashboard .week-day-header { margin-bottom:.6rem; display:flex; align-items:center; justify-content:space-between; gap:.6rem; }
+.user-dashboard.scoped-dashboard .week-day-header {
+    margin-bottom:.6rem;
+    display:flex;
+    flex-wrap:wrap;
+    align-items:flex-start;
+    justify-content:space-between;
+    gap:.75rem;
+}
 .user-dashboard.scoped-dashboard .week-day-header h4 { margin:0; font-size: var(--ud-fz-lg); font-weight: 720; }
 
+.user-dashboard.scoped-dashboard .day-card-header-main { display:flex; flex-direction:column; gap:.35rem; flex:1 1 60%; min-width:0; }
+.user-dashboard.scoped-dashboard .day-card-badges { display:flex; flex-wrap:wrap; gap:.4rem; }
+.user-dashboard.scoped-dashboard .day-card-actions { display:flex; flex:0 0 auto; }
+.user-dashboard.scoped-dashboard .day-card-actions .button-primary-outline { white-space:nowrap; }
+
 /* Status badges */
-.user-dashboard.scoped-dashboard .day-card-badge { position:absolute; top:10px; right:10px; font-size:.75rem; padding:.28rem .55rem; border-radius:999px; border:1px solid currentColor; opacity:.96; backdrop-filter: blur(4px); }
+.user-dashboard.scoped-dashboard .day-card-badge {
+    position:relative;
+    top:auto;
+    right:auto;
+    font-size:.75rem;
+    padding:.28rem .55rem;
+    border-radius:999px;
+    border:1px solid currentColor;
+    opacity:.96;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    white-space:nowrap;
+    max-width:100%;
+    overflow:hidden;
+    text-overflow:ellipsis;
+}
 .user-dashboard.scoped-dashboard .holiday-badge { background: color-mix(in srgb, var(--ud-c-warn) 12%, transparent); color: var(--ud-c-warn); }
 .user-dashboard.scoped-dashboard .vacation-badge { background: color-mix(in srgb, var(--ud-c-primary) 12%, transparent); color: var(--ud-c-primary); }
 .user-dashboard.scoped-dashboard .sick-badge { background: color-mix(in srgb, var(--ud-c-error) 12%, transparent); color: var(--ud-c-error); }
+.user-dashboard.scoped-dashboard .project-badge { background: color-mix(in srgb, var(--ud-c-success) 16%, transparent); color: var(--ud-c-success); }
+[data-theme="dark"] .user-dashboard.scoped-dashboard .project-badge { background: color-mix(in srgb, var(--ud-c-success) 34%, transparent); }
 
 /* Day highlighting */
 .user-dashboard.scoped-dashboard .holiday-day { background: color-mix(in srgb, var(--ud-c-warn) 6%, var(--ud-c-card)); }


### PR DESCRIPTION
## Summary
- restructure day card headers in the user, hourly, and percentage dashboards so action buttons no longer overlap status badges and project assignments surface directly on each day
- style the new header badge layout across scoped styles and add translations that label the project indicator consistently
- guard project badge rendering behind the project-tracking flag while collecting unique project names for tooltip context

## Testing
- npm run test *(fails: src/context/__tests__/ProjectContext.test.jsx due to existing module mock error)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f263c7a08325acba1e2f5bf43136