### PR TITLE
Fix project analytics to include task-linked punches

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TimeTrackingEntryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/TimeTrackingEntryRepository.java
@@ -51,22 +51,14 @@ public interface TimeTrackingEntryRepository extends JpaRepository<TimeTrackingE
             LocalDateTime endDateTime
     );
 
-    @Query("SELECT t.project.id, SUM(COALESCE(t.durationMinutes, 0)) FROM TimeTrackingEntry t " +
-            "WHERE t.project IS NOT NULL AND t.project.customer.company.id = :companyId " +
-            "AND t.durationMinutes IS NOT NULL AND t.entryTimestamp >= :start AND t.entryTimestamp < :end " +
-            "GROUP BY t.project.id")
-    List<Object[]> sumDurationByProject(@Param("companyId") Long companyId,
-                                         @Param("start") LocalDateTime start,
-                                         @Param("end") LocalDateTime end);
-
-    @Query("SELECT t.project.id, SUM(COALESCE(t.durationMinutes, 0)) FROM TimeTrackingEntry t " +
-            "WHERE t.project IS NOT NULL AND t.task IS NOT NULL AND t.task.billable = TRUE " +
-            "AND t.project.customer.company.id = :companyId " +
-            "AND t.durationMinutes IS NOT NULL AND t.entryTimestamp >= :start AND t.entryTimestamp < :end " +
-            "GROUP BY t.project.id")
-    List<Object[]> sumBillableDurationByProject(@Param("companyId") Long companyId,
-                                                @Param("start") LocalDateTime start,
-                                                @Param("end") LocalDateTime end);
+    @Query("SELECT t FROM TimeTrackingEntry t " +
+            "WHERE t.user.company.id = :companyId " +
+            "AND t.entryTimestamp >= :start AND t.entryTimestamp < :end " +
+            "ORDER BY t.user.id, t.entryTimestamp ASC")
+    List<TimeTrackingEntry> findByCompanyIdAndEntryTimestampBetween(
+            @Param("companyId") Long companyId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 
     List<TimeTrackingEntry> findByProjectIdInAndEntryTimestampBetween(List<Long> projectIds,
                                                                      LocalDateTime startDateTime,

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/ReportServiceIntegrationTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/ReportServiceIntegrationTest.java
@@ -1,0 +1,177 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.ProjectHierarchyNodeDTO;
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.Customer;
+import com.chrono.chrono.entities.Project;
+import com.chrono.chrono.entities.Task;
+import com.chrono.chrono.entities.TimeTrackingEntry;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.repositories.CustomerRepository;
+import com.chrono.chrono.repositories.ProjectRepository;
+import com.chrono.chrono.repositories.TaskRepository;
+import com.chrono.chrono.repositories.TimeTrackingEntryRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.show-sql=false"
+})
+@Transactional
+class ReportServiceIntegrationTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TimeTrackingEntryRepository timeTrackingEntryRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Test
+    void projectAnalyticsIncludesTrackedMinutesFromPunches() {
+        Company company = new Company();
+        company.setName("TestCo");
+        company.setCustomerTrackingEnabled(true);
+        company = companyRepository.save(company);
+
+        Customer customer = new Customer();
+        customer.setName("Customer");
+        customer.setCompany(company);
+        customer = customerRepository.save(customer);
+
+        Project project = new Project();
+        project.setName("Project A");
+        project.setCustomer(customer);
+        project.setBudgetMinutes(600);
+        project = projectRepository.save(project);
+
+        User user = new User();
+        user.setUsername("alice");
+        user.setPassword("secret");
+        user.setCountry("DE");
+        user.setPersonnelNumber("PN-1");
+        user.setCompany(company);
+        user = userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2024, 1, 10, 8, 0);
+        LocalDateTime endTime = startTime.plusHours(8);
+
+        TimeTrackingEntry startEntry = new TimeTrackingEntry(user, customer, project, startTime,
+                TimeTrackingEntry.PunchType.START, TimeTrackingEntry.PunchSource.MANUAL_PUNCH);
+        timeTrackingEntryRepository.save(startEntry);
+
+        TimeTrackingEntry endEntry = new TimeTrackingEntry(user, customer, project, endTime,
+                TimeTrackingEntry.PunchType.ENDE, TimeTrackingEntry.PunchSource.MANUAL_PUNCH);
+        endEntry.setDurationMinutes(480);
+        timeTrackingEntryRepository.save(endEntry);
+
+        List<ProjectHierarchyNodeDTO> analytics = reportService.getProjectAnalytics(
+                company.getId(),
+                LocalDate.of(2024, 1, 10),
+                LocalDate.of(2024, 1, 10)
+        );
+
+        assertThat(analytics)
+                .hasSize(1)
+                .first()
+                .satisfies(node -> {
+                    assertThat(node.getId()).isEqualTo(project.getId());
+                    assertThat(node.getTotalMinutes()).isEqualTo(480L);
+                    assertThat(node.getUtilization()).isNotNull();
+                });
+    }
+
+    @Test
+    void projectAnalyticsCountsEntriesAssignedViaTaskProject() {
+        Company company = new Company();
+        company.setName("TaskCo");
+        company.setCustomerTrackingEnabled(true);
+        company = companyRepository.save(company);
+
+        Customer customer = new Customer();
+        customer.setName("Customer");
+        customer.setCompany(company);
+        customer = customerRepository.save(customer);
+
+        Project project = new Project();
+        project.setName("Project B");
+        project.setCustomer(customer);
+        project.setBudgetMinutes(300);
+        project = projectRepository.save(project);
+
+        Task task = new Task();
+        task.setName("Implementation");
+        task.setProject(project);
+        task.setBillable(true);
+        task = taskRepository.save(task);
+
+        User user = new User();
+        user.setUsername("bob");
+        user.setPassword("secret");
+        user.setCountry("DE");
+        user.setPersonnelNumber("PN-2");
+        user.setCompany(company);
+        user = userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2024, 2, 5, 9, 0);
+        LocalDateTime endTime = startTime.plusMinutes(90);
+
+        TimeTrackingEntry startEntry = new TimeTrackingEntry(user, customer, null, startTime,
+                TimeTrackingEntry.PunchType.START, TimeTrackingEntry.PunchSource.MANUAL_PUNCH);
+        startEntry.setTask(task);
+        timeTrackingEntryRepository.save(startEntry);
+
+        TimeTrackingEntry endEntry = new TimeTrackingEntry(user, customer, null, endTime,
+                TimeTrackingEntry.PunchType.ENDE, TimeTrackingEntry.PunchSource.MANUAL_PUNCH);
+        endEntry.setTask(task);
+        endEntry.setDurationMinutes(90);
+        timeTrackingEntryRepository.save(endEntry);
+
+        List<ProjectHierarchyNodeDTO> analytics = reportService.getProjectAnalytics(
+                company.getId(),
+                LocalDate.of(2024, 2, 5),
+                LocalDate.of(2024, 2, 5)
+        );
+
+        assertThat(analytics)
+                .hasSize(1)
+                .first()
+                .satisfies(node -> {
+                    assertThat(node.getId()).isEqualTo(project.getId());
+                    assertThat(node.getTotalMinutes()).isEqualTo(90L);
+                    assertThat(node.getBillableMinutes()).isEqualTo(90L);
+                });
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure project analytics resolve the project from associated tasks when the entry itself has no direct project reference
- add an integration test that covers punches where only the task carries the project relationship

## Testing
- `mvn test` *(fails: cannot resolve spring-boot-starter-parent 3.4.2 due to offline Maven Central access)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f62f6220832588fa661d102ca59c