### PR TITLE
Improve authentication error handling

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ErrorResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.chrono.chrono.dto;
+
+public class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/exceptions/GlobalExceptionHandler.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/exceptions/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.chrono.chrono.exceptions;
 
+import com.chrono.chrono.dto.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,26 +16,32 @@ public class GlobalExceptionHandler {
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<String> handleUserNotFound(UserNotFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
         // Logge die Exception intern – ohne sensible Details an den Client zu geben
         logger.error("User not found: {}", ex.getMessage());
         // Gib dem Client eine generische Fehlermeldung zurück
-        return new ResponseEntity<>("Benutzer wurde nicht gefunden.", HttpStatus.NOT_FOUND);
+        return new ResponseEntity<>(new ErrorResponse("Benutzer wurde nicht gefunden."), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentials(InvalidCredentialsException ex) {
+        logger.warn("Invalid login attempt: {}", ex.getMessage());
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.UNAUTHORIZED);
     }
 
     // Spezieller Handler für zu große Datei-Uploads
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<String> handleMaxSize(MaxUploadSizeExceededException ex) {
+    public ResponseEntity<ErrorResponse> handleMaxSize(MaxUploadSizeExceededException ex) {
         logger.error("Dateiupload zu groß", ex);
-        return new ResponseEntity<>("Datei ist zu groß.", HttpStatus.PAYLOAD_TOO_LARGE);
+        return new ResponseEntity<>(new ErrorResponse("Datei ist zu groß."), HttpStatus.PAYLOAD_TOO_LARGE);
     }
 
     // Weitere spezifische Exception-Handler können hier hinzugefügt werden
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleGenericException(Exception ex) {
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
         // Logge den Fehler inklusive Stacktrace intern, aber gebe nur eine generische Nachricht an den Client weiter
         logger.error("Ein unerwarteter Fehler ist aufgetreten.", ex);
-        return new ResponseEntity<>("Ein unerwarteter Fehler ist aufgetreten.", HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(new ErrorResponse("Ein unerwarteter Fehler ist aufgetreten."), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/exceptions/InvalidCredentialsException.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/exceptions/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package com.chrono.chrono.exceptions;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/AuthService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/AuthService.java
@@ -2,6 +2,7 @@ package com.chrono.chrono.services;
 
 import com.chrono.chrono.dto.AuthRequest;
 import com.chrono.chrono.dto.AuthResponse;
+import com.chrono.chrono.exceptions.InvalidCredentialsException;
 import com.chrono.chrono.entities.Role;
 import com.chrono.chrono.entities.User;
 import com.chrono.chrono.repositories.RoleRepository;
@@ -37,12 +38,14 @@ public class AuthService {
     @Autowired
     private DemoDataService demoDataService;
 
+    private static final String INVALID_CREDENTIALS_MESSAGE = "Benutzername oder Passwort ist falsch.";
+
     public AuthResponse login(AuthRequest request) {
         User user = userRepository.findByUsername(request.getUsername())
-                .orElseThrow(() -> new RuntimeException("User not found!"));
+                .orElseThrow(() -> new InvalidCredentialsException(INVALID_CREDENTIALS_MESSAGE));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new RuntimeException("Invalid credentials");
+            throw new InvalidCredentialsException(INVALID_CREDENTIALS_MESSAGE);
         }
 
         // Token (mit user-Daten gehasht) generieren

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/AuthServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/AuthServiceTest.java
@@ -4,6 +4,7 @@ import com.chrono.chrono.dto.AuthRequest;
 import com.chrono.chrono.dto.AuthResponse;
 import com.chrono.chrono.entities.User;
 import com.chrono.chrono.entities.Role;
+import com.chrono.chrono.exceptions.InvalidCredentialsException;
 import com.chrono.chrono.repositories.RoleRepository;
 import com.chrono.chrono.repositories.UserRepository;
 import com.chrono.chrono.utils.JwtUtil;
@@ -68,7 +69,8 @@ class AuthServiceTest {
         when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
 
-        assertThrows(RuntimeException.class, () -> authService.login(request));
+        InvalidCredentialsException ex = assertThrows(InvalidCredentialsException.class, () -> authService.login(request));
+        assertEquals("Benutzername oder Passwort ist falsch.", ex.getMessage());
         verify(passwordEncoder).matches("wrong", "encoded");
     }
 
@@ -77,7 +79,8 @@ class AuthServiceTest {
         AuthRequest request = new AuthRequest("unknown", "pass");
         when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> authService.login(request));
+        InvalidCredentialsException ex = assertThrows(InvalidCredentialsException.class, () -> authService.login(request));
+        assertEquals("Benutzername oder Passwort ist falsch.", ex.getMessage());
         verify(userRepository).findByUsername("unknown");
     }
 


### PR DESCRIPTION
## Summary
- return structured JSON error bodies from the global exception handler, including a dedicated response for invalid credentials
- surface clearer login failures by throwing an `InvalidCredentialsException` with a localized message
- adjust authentication service unit tests to expect the new exception type and message

## Testing
- ./mvnw test *(fails: cannot download Maven parent POM because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfbbe3e7c8325b07ff87ce52f8898