### PR TITLE
Switch frontend router to BrowserRouter

### DIFF
--- a/Chrono-frontend/src/main.jsx
+++ b/Chrono-frontend/src/main.jsx
@@ -1,7 +1,7 @@
 // src/main.jsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
 import { NotificationProvider } from "./context/NotificationContext";
@@ -13,7 +13,7 @@ import "./styles/global.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-    <HashRouter>
+    <BrowserRouter>
         {/* LanguageProvider muss die Provider umschließen, die useTranslation() verwenden */}
         <LanguageProvider>
             <AuthProvider>
@@ -30,5 +30,5 @@ root.render(
                 </CustomerProvider>
             </AuthProvider>
         </LanguageProvider>
-    </HashRouter>
+    </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- replace the frontend HashRouter with BrowserRouter so routes no longer include a hash fragment

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc655c3af88325bbfe4142dc30e80e