### PR TITLE
Adjust admin dashboard layout for full-width week view

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -649,62 +649,62 @@ const AdminDashboard = () => {
             </div>
 
             <div className="dashboard-content">
-                <div className="left-column">
-                    <AdminWeekSection
-                        ref={weekSectionRef}
-                        t={t}
-                        weekDates={Array.from({ length: 7 }, (_, i) => addDays(selectedMonday, i))}
-                        selectedMonday={selectedMonday}
-                        handlePrevWeek={handlePrevWeek}
-                        handleNextWeek={handleNextWeek}
-                        handleWeekJump={handleWeekJump}
-                        handleCurrentWeek={handleCurrentWeek}
-                        onFocusProblemWeek={focusWeekForProblem}
-                        dailySummariesForWeekSection={dailySummaries}
-                        allVacations={allVacations}
-                        allSickLeaves={allSickLeaves}
-                        allHolidays={holidaysByCanton}
-                        users={users}
-                        defaultExpectedHours={defaultExpectedHours}
-                        openEditModal={openEditModal}
-                        openPrintUserModal={openPrintUserModal}
-                        rawUserTrackingBalances={weeklyBalances}
-                        openNewEntryModal={openNewEntryModal}
-                        onDataReloadNeeded={handleDataReloadNeeded}
-                        onIssueSummaryChange={handleIssueSummaryUpdate}
-                    />
-                </div>
-                <div className="right-column">
-                    <AdminActionStream
-                        t={t}
-                        allVacations={allVacations}
-                        allCorrections={allCorrections}
-                        onApproveVacation={handleApproveVacation}
-                        onDenyVacation={handleDenyVacation}
-                        onApproveCorrection={handleApproveCorrection}
-                        onDenyCorrection={handleDenyCorrection}
-                        onOpenVacationCenter={handleNavigateToVacations}
-                        onOpenCorrectionCenter={handleNavigateToCorrections}
-                        onFocusUser={handleFocusUserFromTask}
-                    />
-                    <div ref={vacationsSectionRef}>
-                        <AdminVacationRequests
-                        t={t}
-                        allVacations={allVacations}
-                        handleApproveVacation={handleApproveVacation}
-                        handleDenyVacation={handleDenyVacation}
-                        onReloadVacations={handleDataReloadNeeded}
-                        openSignal={vacationOpenSignal}
-                    />
+                <AdminWeekSection
+                    ref={weekSectionRef}
+                    t={t}
+                    weekDates={Array.from({ length: 7 }, (_, i) => addDays(selectedMonday, i))}
+                    selectedMonday={selectedMonday}
+                    handlePrevWeek={handlePrevWeek}
+                    handleNextWeek={handleNextWeek}
+                    handleWeekJump={handleWeekJump}
+                    handleCurrentWeek={handleCurrentWeek}
+                    onFocusProblemWeek={focusWeekForProblem}
+                    dailySummariesForWeekSection={dailySummaries}
+                    allVacations={allVacations}
+                    allSickLeaves={allSickLeaves}
+                    allHolidays={holidaysByCanton}
+                    users={users}
+                    defaultExpectedHours={defaultExpectedHours}
+                    openEditModal={openEditModal}
+                    openPrintUserModal={openPrintUserModal}
+                    rawUserTrackingBalances={weeklyBalances}
+                    openNewEntryModal={openNewEntryModal}
+                    onDataReloadNeeded={handleDataReloadNeeded}
+                    onIssueSummaryChange={handleIssueSummaryUpdate}
+                />
+                <div className="dashboard-secondary-grid">
+                    <div className="secondary-section action-stream-wrapper">
+                        <AdminActionStream
+                            t={t}
+                            allVacations={allVacations}
+                            allCorrections={allCorrections}
+                            onApproveVacation={handleApproveVacation}
+                            onDenyVacation={handleDenyVacation}
+                            onApproveCorrection={handleApproveCorrection}
+                            onDenyCorrection={handleDenyCorrection}
+                            onOpenVacationCenter={handleNavigateToVacations}
+                            onOpenCorrectionCenter={handleNavigateToCorrections}
+                            onFocusUser={handleFocusUserFromTask}
+                        />
                     </div>
-                    <div ref={correctionsSectionRef}>
+                    <div ref={vacationsSectionRef} className="secondary-section">
+                        <AdminVacationRequests
+                            t={t}
+                            allVacations={allVacations}
+                            handleApproveVacation={handleApproveVacation}
+                            handleDenyVacation={handleDenyVacation}
+                            onReloadVacations={handleDataReloadNeeded}
+                            openSignal={vacationOpenSignal}
+                        />
+                    </div>
+                    <div ref={correctionsSectionRef} className="secondary-section">
                         <AdminCorrectionsList
-                        t={t}
-                        allCorrections={allCorrections}
-                        onApprove={handleApproveCorrection}
-                        onDeny={handleDenyCorrection}
-                        openSignal={correctionOpenSignal}
-                    />
+                            t={t}
+                            allCorrections={allCorrections}
+                            onApprove={handleApproveCorrection}
+                            onDeny={handleDenyCorrection}
+                            openSignal={correctionOpenSignal}
+                        />
                     </div>
                 </div>
             </div>

--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -453,31 +453,31 @@
   background-color: color-mix(in srgb, var(--c-error) 20%, transparent);
 }
 
-/* Haupt-Layout: Spalten-Grid */
+/* Haupt-Layout: Wochenansicht über die volle Breite */
 .admin-dashboard.scoped-dashboard .dashboard-content {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--u-gap);
-} /* Standardmäßig 1 Spalte */
-
-@media (min-width: 1024px) {
-  /* Desktop */
-  .admin-dashboard.scoped-dashboard .dashboard-content {
-    grid-template-columns: 2fr 1fr;
-  } /* 2/3 und 1/3 Aufteilung */
-  .admin-dashboard.scoped-dashboard .left-column {
-    /* Nimmt 2 Teile des Grids ein */
-  }
-  .admin-dashboard.scoped-dashboard .right-column {
-    /* Nimmt 1 Teil des Grids ein */
-  }
-}
-
-.admin-dashboard.scoped-dashboard .left-column,
-.admin-dashboard.scoped-dashboard .right-column {
   display: flex;
   flex-direction: column;
   gap: var(--u-gap);
+}
+
+.admin-dashboard.scoped-dashboard .dashboard-secondary-grid {
+  display: grid;
+  gap: var(--u-gap);
+  grid-template-columns: 1fr;
+}
+
+.admin-dashboard.scoped-dashboard .secondary-section {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 1024px) {
+  .admin-dashboard.scoped-dashboard .dashboard-secondary-grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+  .admin-dashboard.scoped-dashboard .dashboard-secondary-grid > :first-child {
+    grid-column: 1 / -1;
+  }
 }
 
 /* Standard-Section-Styling */
@@ -1770,12 +1770,8 @@
 
 /* Generelle Layout-Anpassungen für kleinere Bildschirme */
 @media (max-width: 1024px) {
-  .admin-dashboard.scoped-dashboard .dashboard-content {
+  .admin-dashboard.scoped-dashboard .dashboard-secondary-grid {
     grid-template-columns: 1fr;
-  }
-  .admin-dashboard.scoped-dashboard .left-column,
-  .admin-dashboard.scoped-dashboard .right-column {
-    grid-column: span 1 / span 1;
   }
 }
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- let the admin week section span the full dashboard width instead of sharing space with a right-hand column
- move the action stream and request sections beneath the week view and adjust the layout CSS to use a responsive secondary grid

## Testing
- npm test *(fails: vitest not found because native dependency pcsclite cannot be built without winscard headers)*

------
https://chatgpt.com/codex/tasks/task_e_68cf755801b0832595b80076ed2b5983