### PR TITLE
Fix floating chat widget container blocking navigation buttons

### DIFF
--- a/Chrono-frontend/src/styles/FloatingButtons.css
+++ b/Chrono-frontend/src/styles/FloatingButtons.css
@@ -13,4 +13,12 @@
     flex-direction: row;
     align-items: center;
     gap: 12px; /* Abstand zwischen den Buttons */
+
+    /* Verhindert, dass der Container selbst Klicks blockiert */
+    pointer-events: none;
+}
+
+/* Der eigentliche Inhalt darf weiterhin auf Eingaben reagieren */
+.scoped-floating-buttons .chat-widget {
+    pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- prevent the floating action container from intercepting pointer events by default
- allow the chat widget itself to keep reacting to user input so the assistant still works

## Testing
- npm install *(fails: @pokusew/pcsclite native build requires winscard.h on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d040860c6883258b6af29f46e61f02