### PR TITLE
Prevent AdminDashboard issue summary update loop

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -68,9 +68,20 @@ const AdminDashboard = () => {
     const correctionsSectionRef = useRef(null);
 
     const handleIssueSummaryUpdate = useCallback((summary) => {
-        if (summary) {
-            setIssueSummary(summary);
+        if (!summary) {
+            return;
         }
+
+        setIssueSummary(prevSummary => {
+            if (!prevSummary) {
+                return summary;
+            }
+
+            const keysToCompare = ['missing', 'incomplete', 'autoCompleted', 'holidayPending', 'totalWithIssue'];
+            const hasChanges = keysToCompare.some(key => (prevSummary[key] || 0) !== (summary[key] || 0));
+
+            return hasChanges ? summary : prevSummary;
+        });
     }, []);
 
     const scrollToRef = useCallback((targetRef) => {


### PR DESCRIPTION
## Summary
- guard the AdminDashboard issue summary handler so it only updates state when the counts actually change

## Testing
- npm run test -- --runInBand *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d162b219d083258a53ed5db88a470c