### PR TITLE
Fix analytics user filter to respect exclusions

### DIFF
--- a/Chrono-frontend/src/pages/AdminAnalytics/AdminAnalyticsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminAnalytics/AdminAnalyticsPage.jsx
@@ -104,11 +104,11 @@ const AdminAnalyticsPage = () => {
 
     const selectableUsers = useMemo(
         () =>
-            users
+            trackableUsers
                 .filter(user => !user.isHourly && user?.username)
                 .slice()
                 .sort((a, b) => (a.username || '').localeCompare(b.username || '', undefined, { sensitivity: 'base' })),
-        [users],
+        [trackableUsers],
     );
 
     const selectableUsernames = useMemo(() => selectableUsers.map(user => user.username), [selectableUsers]);


### PR DESCRIPTION
## Summary
- update the admin analytics user selector to only include users that remain in time tracking overviews

## Testing
- npm ci *(fails: pcsclite build requires winscard.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19862aa888325b39d50e91d96d328