### PR TITLE
Adjust admin dashboard request lists layout

### DIFF
--- a/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminCorrectionsList.jsx
@@ -137,7 +137,7 @@ function AdminCorrectionsList({ t, allCorrections, onApprove, onDeny, openSignal
     }, [groupedRows, sortConfig]);
 
     /* ──────────────────────────────────── render */
-    const scrollable = sortedRows.length > 25;
+    const requiresScroll = sortedRows.length >= 10;
     const hasPending = allCorrections.some(c => !c.approved && !c.denied);
 
     return (
@@ -188,10 +188,7 @@ function AdminCorrectionsList({ t, allCorrections, onApprove, onDeny, openSignal
                     {sortedRows.length === 0 ? (
                         <p>{t("adminCorrections.noRequestsFound", "Keine Anträge gefunden.")}</p>
                     ) : (
-                        <div
-                            className="table-wrapper"
-                            style={{ maxHeight: scrollable ? "70vh" : "none", overflowY: scrollable ? "auto" : "visible" }}
-                        >
+                        <div className={`table-wrapper${requiresScroll ? ' scroll-limited' : ''}`}>
                             <table className="corrections-table">
                                 <thead>
                                 <tr>

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminVacationRequests.jsx
@@ -84,6 +84,7 @@ const AdminVacationRequests = ({
     const sortedVacations = [...filteredVacations].sort((a, b) => b.id - a.id);
 
     const hasPending = allVacations.some(v => !v.approved && !v.denied);
+    const isScrollable = sortedVacations.length >= 10;
 
     return (
         <> {/* Stellt sicher, dass CSS-Variablen verfügbar sind */}
@@ -115,7 +116,7 @@ const AdminVacationRequests = ({
                         {sortedVacations.length === 0 ? (
                             <p>{t('adminDashboard.noVacationRequests', 'Keine Urlaubsanträge gefunden.')}</p>
                         ) : (
-                            <div className="vacation-requests-container" style={{ maxHeight: sortedVacations.length > 20 ? '70vh' : 'none' }}>
+                            <div className={`vacation-requests-container${isScrollable ? ' scroll-limited' : ''}`}>
                             <ul className="item-list vacation-request-list">
                                 {sortedVacations.map((v) => {
                                     const status = v.approved

--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -39,6 +39,10 @@
   --u-dur: 0.26s;
   --u-ease: cubic-bezier(0.4, 0.2, 0.2, 1);
 
+  --ad-scroll-visible-items: 10;
+  --ad-scroll-row-height: 4.75rem;
+  --ad-scroll-area-height: calc(var(--ad-scroll-visible-items) * var(--ad-scroll-row-height));
+
   background: var(--c-bg);
   color: var(--c-text);
   font-family: "Poppins", system-ui, sans-serif;
@@ -484,7 +488,7 @@
 
 @media (min-width: 1024px) {
   .admin-dashboard.scoped-dashboard .dashboard-secondary-grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
   }
   .admin-dashboard.scoped-dashboard .dashboard-secondary-grid > :first-child {
     grid-column: 1 / -1;
@@ -2700,21 +2704,29 @@
 
 /* Tabellen-Container (für Scrolling) */
 .corrections-list-container {
-  overflow-y: auto;
-  max-height: 70vh; /* Scrollbar erscheint bei mehr als ca. 10-12 Einträgen */
   border: 1px solid var(--ad-c-border);
   border-radius: var(--ad-radius-lg);
   box-shadow: var(--ad-shadow-sm);
   background-color: var(--ad-c-bg-card);
 }
 
-.vacation-requests-container {
+.corrections-list-container.scroll-limited {
   overflow-y: auto;
-  max-height: 70vh;
+  max-height: min(70vh, var(--ad-scroll-area-height));
+  scrollbar-gutter: stable;
+}
+
+.vacation-requests-container {
   border: 1px solid var(--ad-c-border);
   border-radius: var(--ad-radius-lg);
   box-shadow: var(--ad-shadow-sm);
   background-color: var(--ad-c-bg-card);
+}
+
+.vacation-requests-container.scroll-limited {
+  overflow-y: auto;
+  max-height: min(70vh, var(--ad-scroll-area-height));
+  scrollbar-gutter: stable;
 }
 .vacation-request-list .vacation-item {
   display: flex;
@@ -2872,10 +2884,14 @@
 
 /* ---------- 1) Container ------------------------------------------------- */
 .admin-dashboard.scoped-dashboard .correction-section .table-wrapper {
-    max-height: 70vh;
-    overflow-y: auto;
     border: 1px solid var(--c-border);
     border-radius: var(--u-radius-sm);
+}
+
+.admin-dashboard.scoped-dashboard .correction-section .table-wrapper.scroll-limited {
+    max-height: min(70vh, var(--ad-scroll-area-height));
+    overflow-y: auto;
+    scrollbar-gutter: stable;
 }
 
 /* ---------- 2) Tabelle --------------------------------------------------- */


### PR DESCRIPTION
## Summary
- widen the admin dashboard secondary grid so the vacation and correction panels can use more horizontal space
- add configurable scroll limits for request panels and reuse them for both vacation and correction tables
- update the vacation and correction request components to toggle the scroll container once 10 or more entries are shown

## Testing
- npm install *(fails: pcsclite native build requires winscard.h in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b241f048325a0eed3c3d5e8c22a