### PR TITLE
Adjust admin dashboard request cards layout

### DIFF
--- a/Chrono-frontend/src/styles/AdminDashboardScoped.css
+++ b/Chrono-frontend/src/styles/AdminDashboardScoped.css
@@ -488,7 +488,7 @@
 
 @media (min-width: 1024px) {
   .admin-dashboard.scoped-dashboard .dashboard-secondary-grid {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .admin-dashboard.scoped-dashboard .dashboard-secondary-grid > :first-child {
     grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
- force the admin dashboard secondary grid to use two columns on wide screens
- ensure the vacation and correction sections expand to wider tiles while keeping the action stream full width

## Testing
- npm run test *(fails: vitest missing before dependencies install, dependency install blocked by pcsclite native build)*

------
https://chatgpt.com/codex/tasks/task_e_68d19d304abc8325966ade0ddfd1b27e