### PR TITLE
Fix admin dashboard visibility issues

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminTimeTrackingController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/AdminTimeTrackingController.java
@@ -47,7 +47,6 @@ public class AdminTimeTrackingController {
             logger.warn("Admin {} has no company assigned. Falling back to all active users for time summaries.", principal.getName());
             usersToList = userRepository.findByDeletedFalse();
         }
-        usersToList = usersToList.stream().filter(User::isIncludeInTimeTracking).collect(Collectors.toList());
         List<DailyTimeSummaryDTO> result = usersToList.stream()
                 .flatMap(u -> timeTrackingService.getUserHistory(u.getUsername()).stream())
                 .sorted(Comparator.comparing(DailyTimeSummaryDTO::getUsername).thenComparing(DailyTimeSummaryDTO::getDate).reversed())
@@ -128,7 +127,6 @@ public class AdminTimeTrackingController {
             logger.warn("Admin {} has no company assigned. Falling back to all active users for weekly balances.", principal.getName());
             usersToList = userRepository.findByDeletedFalse();
         }
-        usersToList = usersToList.stream().filter(User::isIncludeInTimeTracking).collect(Collectors.toList());
         if (usersToList.isEmpty()) {
             return ResponseEntity.ok(Collections.emptyList());
         }
@@ -156,7 +154,6 @@ public class AdminTimeTrackingController {
             logger.warn("Admin {} has no company assigned. Falling back to all active users for tracking balances.", principal.getName());
             usersToList = userRepository.findByDeletedFalse();
         }
-        usersToList = usersToList.stream().filter(User::isIncludeInTimeTracking).collect(Collectors.toList());
         if (usersToList.isEmpty()) {
             return ResponseEntity.ok(Collections.emptyList());
         }


### PR DESCRIPTION
## Summary
- ensure admin time-tracking APIs return all users so dashboards always receive complete data
- filter weekly balance data on the admin dashboard and analytics views so only trackable users appear in KPIs and summaries

## Testing
- ./mvnw test *(fails: unable to download parent POM because the Maven Central repository is unreachable in the environment)*
- npm test -- --runInBand *(fails: vitest executable is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a4bb21ac8325a7da95fd575d7a86