### PR TITLE
Ensure admin dashboards handle missing trackable users

### DIFF
--- a/Chrono-frontend/src/pages/AdminAnalytics/AdminAnalyticsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminAnalytics/AdminAnalyticsPage.jsx
@@ -10,6 +10,7 @@ import {
     formatLocalDateYMD,
     calculateWeeklyExpectedMinutes,
     minutesToHHMM,
+    selectTrackableUsers,
 } from '../AdminDashboard/adminDashboardUtils';
 import { Line, Bar, Doughnut } from 'react-chartjs-2';
 import {
@@ -57,7 +58,7 @@ const AdminAnalyticsPage = () => {
     const [selectedUsernames, setSelectedUsernames] = useState([]);
 
     const trackableUsers = useMemo(
-        () => (Array.isArray(users) ? users.filter(user => user?.includeInTimeTracking !== false) : []),
+        () => selectTrackableUsers(users),
         [users]
     );
 

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -24,6 +24,7 @@ import {
     minutesToHHMM,
     formatDate,
     processEntriesForReport,
+    selectTrackableUsers,
 } from './adminDashboardUtils';
 
 const AdminDashboard = () => {
@@ -52,16 +53,21 @@ const AdminDashboard = () => {
     const [weeklyBalances, setWeeklyBalances] = useState([]);
     const defaultExpectedHours = 8.5;
 
+    const trackableUsers = useMemo(
+        () => selectTrackableUsers(users),
+        [users]
+    );
+
     const trackableUsernames = useMemo(() => {
-        if (!Array.isArray(users) || users.length === 0) {
+        if (!Array.isArray(trackableUsers) || trackableUsers.length === 0) {
             return new Set();
         }
         return new Set(
-            users
-                .filter(user => user?.includeInTimeTracking !== false && user?.username)
-                .map(user => user.username)
+            trackableUsers
+                .map(user => user?.username)
+                .filter(Boolean)
         );
-    }, [users]);
+    }, [trackableUsers]);
 
     const filteredWeeklyBalances = useMemo(() => {
         if (!Array.isArray(weeklyBalances) || weeklyBalances.length === 0) {

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboardKpis.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboardKpis.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
-import { minutesToHHMM } from './adminDashboardUtils';
+import { minutesToHHMM, selectTrackableUsers } from './adminDashboardUtils';
 
 const AdminDashboardKpis = ({
     t,
@@ -16,7 +16,7 @@ const AdminDashboardKpis = ({
     onOpenAnalytics,
 }) => {
     const trackableUsers = useMemo(
-        () => (Array.isArray(users) ? users.filter(user => user?.includeInTimeTracking !== false) : []),
+        () => selectTrackableUsers(users),
         [users]
     );
 

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminWeekSection.jsx
@@ -28,6 +28,7 @@ import {
     getDetailedGlobalProblemIndicators,
     getMondayOfWeek,
     addDays,
+    selectTrackableUsers,
 } from "./adminDashboardUtils"; // Ensure this path is correct
 import {parseISO} from "date-fns"; // Make sure date-fns is installed
 import { sortEntries } from '../../utils/timeUtils';
@@ -373,7 +374,7 @@ const AdminWeekSection = forwardRef(({
     const [monthSortConfig, setMonthSortConfig] = useState({ key: 'username', direction: 'ascending' });
 
     const trackableUsers = useMemo(
-        () => (Array.isArray(users) ? users.filter(user => user?.includeInTimeTracking !== false) : []),
+        () => selectTrackableUsers(users),
         [users]
     );
 

--- a/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
+++ b/Chrono-frontend/src/pages/AdminDashboard/adminDashboardUtils.js
@@ -11,6 +11,20 @@ export function getMondayOfWeek(date) {
     copy.setHours(0, 0, 0, 0);
     return copy;
 }
+
+export const selectTrackableUsers = (users) => {
+    if (!Array.isArray(users)) {
+        return [];
+    }
+
+    const filtered = users.filter(user => user?.includeInTimeTracking !== false);
+
+    if (filtered.length > 0) {
+        return filtered;
+    }
+
+    return users.filter(user => user && user.username);
+};
 export const processEntriesForReport = (entries) => {
     const blocks = { work: [], break: [] };
     if (!entries || entries.length === 0) return blocks;


### PR DESCRIPTION
## Summary
- add a shared helper that selects trackable users with a graceful fallback when everyone is filtered out
- reuse the helper across the admin dashboard, weekly section, KPI widget, and analytics page so users still appear if includeInTimeTracking is unset or false everywhere

## Testing
- `npm test` *(fails: vitest missing because native pcsclite dependency cannot be built in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a82164cc8325a14b4c65d8565b07