### PR TITLE
Gate registration modules per company

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.POST, "/api/apply").permitAll();
                     auth.requestMatchers(HttpMethod.POST, "/api/contact").permitAll();
                     auth.requestMatchers("/api/chat").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/api/public/**").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/report/timesheet/ics-feed/**").permitAll();
 
                     // Admin-Endpunkte

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/CompanyManagementController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/CompanyManagementController.java
@@ -8,6 +8,7 @@ import com.chrono.chrono.repositories.RoleRepository;
 import com.chrono.chrono.repositories.UserRepository;
 import com.chrono.chrono.services.StripeService;
 import com.stripe.model.PaymentIntent;
+import com.chrono.chrono.utils.RegistrationFeatures;
 // import com.chrono.chrono.utils.PasswordEncoderConfig; // Wird nicht direkt verwendet, PasswordEncoder reicht
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -75,6 +76,7 @@ public class CompanyManagementController {
         company.setNotifyVacation(body.getNotifyVacation());
         company.setNotifyOvertime(body.getNotifyOvertime());
         company.setCustomerTrackingEnabled(body.getCustomerTrackingEnabled());
+        company.setEnabledFeatures(RegistrationFeatures.sanitizeOptionalFeatures(body.getEnabledFeatures()));
         // Weitere Standardwerte für neue Firmen
         company.setPaid(false);
         company.setCanceled(false);
@@ -130,6 +132,7 @@ public class CompanyManagementController {
         company.setNotifyVacation(companyDTO.getNotifyVacation());
         company.setNotifyOvertime(companyDTO.getNotifyOvertime());
         company.setCustomerTrackingEnabled(companyDTO.getCustomerTrackingEnabled());
+        company.setEnabledFeatures(RegistrationFeatures.sanitizeOptionalFeatures(companyDTO.getEnabledFeatures()));
 
         Company saved = companyRepository.save(company);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -168,6 +171,8 @@ public class CompanyManagementController {
                         existingCompany.setNotifyOvertime(companyDTO.getNotifyOvertime());
                     if (companyDTO.getCustomerTrackingEnabled() != null)
                         existingCompany.setCustomerTrackingEnabled(companyDTO.getCustomerTrackingEnabled());
+                    if (companyDTO.getEnabledFeatures() != null)
+                        existingCompany.setEnabledFeatures(RegistrationFeatures.sanitizeOptionalFeatures(companyDTO.getEnabledFeatures()));
                     // Zahlungsstatus sollte über /payment aktualisiert werden, um die Logik getrennt zu halten
                     // existingCompany.setPaid(companyDTO.isPaid());
                     // existingCompany.setPaymentMethod(companyDTO.getPaymentMethod());
@@ -241,6 +246,7 @@ public class CompanyManagementController {
         private Boolean notifyOvertime;
         private Boolean customerTrackingEnabled;
         private String logoPath;
+        private Set<String> enabledFeatures;
 
         public static CompanyDTO fromEntity(Company co) {
             CompanyDTO dto = new CompanyDTO();
@@ -262,6 +268,7 @@ public class CompanyManagementController {
             dto.notifyOvertime = co.getNotifyOvertime();
             dto.customerTrackingEnabled = co.getCustomerTrackingEnabled();
             dto.logoPath = co.getLogoPath();
+            dto.enabledFeatures = RegistrationFeatures.sanitizeOptionalFeatures(co.getEnabledFeatures());
             return dto;
         }
 
@@ -284,6 +291,7 @@ public class CompanyManagementController {
         public Boolean getNotifyOvertime() { return notifyOvertime; }
         public Boolean getCustomerTrackingEnabled() { return customerTrackingEnabled; }
         public String getLogoPath() { return logoPath; }
+        public Set<String> getEnabledFeatures() { return enabledFeatures; }
 
         // Setter (wichtig für @RequestBody)
         public void setId(Long id) { this.id = id; }
@@ -304,6 +312,11 @@ public class CompanyManagementController {
         public void setNotifyOvertime(Boolean notifyOvertime) { this.notifyOvertime = notifyOvertime; }
         public void setCustomerTrackingEnabled(Boolean customerTrackingEnabled) { this.customerTrackingEnabled = customerTrackingEnabled; }
         public void setLogoPath(String logoPath) { this.logoPath = logoPath; }
+        public void setEnabledFeatures(Set<String> enabledFeatures) {
+            this.enabledFeatures = (enabledFeatures != null)
+                    ? RegistrationFeatures.sanitizeOptionalFeatures(enabledFeatures)
+                    : null;
+        }
     }
 
     public static class CreateCompanyWithAdminDTO {
@@ -323,6 +336,7 @@ public class CompanyManagementController {
         private Boolean notifyVacation;
         private Boolean notifyOvertime;
         private Boolean customerTrackingEnabled;
+        private Set<String> enabledFeatures;
 
         // Getter/Setter
         public String getCompanyName() { return companyName; }
@@ -357,6 +371,12 @@ public class CompanyManagementController {
         public void setNotifyOvertime(Boolean notifyOvertime) { this.notifyOvertime = notifyOvertime; }
         public Boolean getCustomerTrackingEnabled() { return customerTrackingEnabled; }
         public void setCustomerTrackingEnabled(Boolean customerTrackingEnabled) { this.customerTrackingEnabled = customerTrackingEnabled; }
+        public Set<String> getEnabledFeatures() { return enabledFeatures; }
+        public void setEnabledFeatures(Set<String> enabledFeatures) {
+            this.enabledFeatures = (enabledFeatures != null)
+                    ? RegistrationFeatures.sanitizeOptionalFeatures(enabledFeatures)
+                    : null;
+        }
     }
 
     public static class PaymentUpdateDTO {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/RegistrationFeatureController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/RegistrationFeatureController.java
@@ -1,0 +1,42 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.utils.RegistrationFeatures;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/public/registration-features")
+public class RegistrationFeatureController {
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @GetMapping
+    public ResponseEntity<?> getRegistrationFeatures(@RequestParam(value = "companyId", required = false) Long companyId) {
+        if (companyId == null) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("enabledFeatures", List.copyOf(RegistrationFeatures.OPTIONAL_FEATURES));
+            return ResponseEntity.ok(response);
+        }
+
+        return companyRepository.findById(companyId)
+                .map(company -> {
+                    Map<String, Object> response = new LinkedHashMap<>();
+                    response.put("enabledFeatures",
+                            List.copyOf(RegistrationFeatures.sanitizeOptionalFeatures(company.getEnabledFeatures())));
+                    return ResponseEntity.ok(response);
+                })
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .<Map<String, Object>>body(Map.of("message", "Company not found")));
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/ApplicationData.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/ApplicationData.java
@@ -26,4 +26,6 @@ public class ApplicationData {
     // Optionales Intensiv-Onboarding
     private Boolean includeOptionalTraining;
     private Double optionalTrainingCost;  // 120.00 CHF, wenn ausgewählt
+
+    private Long companyId; // Superadmin-gesteuerte Freischaltung
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/Company.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/Company.java
@@ -3,6 +3,7 @@ package com.chrono.chrono.entities;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -44,6 +45,11 @@ public class Company {
 
     @Column(name = "customer_tracking_enabled")
     private Boolean customerTrackingEnabled;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "company_enabled_features", joinColumns = @JoinColumn(name = "company_id"))
+    @Column(name = "feature_key")
+    private Set<String> enabledFeatures = new LinkedHashSet<>();
 
     // NEU: Kantonskürzel für Feiertagsberechnung (z.B. "SG", "ZH")
     @Column(name = "canton_abbreviation", length = 2)
@@ -120,6 +126,19 @@ public class Company {
 
     public Boolean getCustomerTrackingEnabled() { return customerTrackingEnabled; }
     public void setCustomerTrackingEnabled(Boolean customerTrackingEnabled) { this.customerTrackingEnabled = customerTrackingEnabled; }
+
+    public Set<String> getEnabledFeatures() {
+        if (enabledFeatures == null) {
+            enabledFeatures = new LinkedHashSet<>();
+        }
+        return enabledFeatures;
+    }
+
+    public void setEnabledFeatures(Set<String> enabledFeatures) {
+        this.enabledFeatures = (enabledFeatures != null)
+                ? new LinkedHashSet<>(enabledFeatures)
+                : new LinkedHashSet<>();
+    }
 
     public String getLogoPath() { return logoPath; }
     public void setLogoPath(String logoPath) { this.logoPath = logoPath; }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/EmailService.java
@@ -40,6 +40,9 @@ public class EmailService {
         } else if (data.getSelectedFeatures() != null) {
             mailText.append("Gewählte Module (Keys): ").append(String.join(", ", data.getSelectedFeatures())).append("\n");
         }
+        if (data.getCompanyId() != null) {
+            mailText.append("Freigeschaltet für Company-ID: ").append(data.getCompanyId()).append("\n");
+        }
 
         if (data.getEmployeeCount() != null) {
             mailText.append("Mitarbeiteranzahl: ").append(data.getEmployeeCount()).append("\n");

--- a/Chrono-backend/src/main/java/com/chrono/chrono/utils/RegistrationFeatures.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/utils/RegistrationFeatures.java
@@ -1,0 +1,45 @@
+package com.chrono.chrono.utils;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class RegistrationFeatures {
+
+    private RegistrationFeatures() {
+    }
+
+    public static final Set<String> ALWAYS_AVAILABLE_FEATURES = Set.of("vacation", "nfc");
+
+    public static final Set<String> OPTIONAL_FEATURES = Set.of(
+            "payroll",
+            "projects",
+            "accounting",
+            "crm",
+            "supplyChain",
+            "banking",
+            "analytics",
+            "signature",
+            "chatbot",
+            "premiumSupport",
+            "roster"
+    );
+
+    public static final Set<String> ALL_FEATURES;
+
+    static {
+        ALL_FEATURES = new LinkedHashSet<>();
+        ALL_FEATURES.addAll(ALWAYS_AVAILABLE_FEATURES);
+        ALL_FEATURES.addAll(OPTIONAL_FEATURES);
+    }
+
+    public static LinkedHashSet<String> sanitizeOptionalFeatures(Collection<String> requestedKeys) {
+        if (requestedKeys == null) {
+            return new LinkedHashSet<>();
+        }
+        return requestedKeys.stream()
+                .filter(OPTIONAL_FEATURES::contains)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/Chrono-frontend/src/constants/registrationFeatures.js
+++ b/Chrono-frontend/src/constants/registrationFeatures.js
@@ -1,0 +1,141 @@
+export const BASE_FEATURE = {
+    key: "base",
+    name: "Zeiterfassung (Basis)",
+    price: 5,
+    priceType: "perEmployee",
+    required: true,
+    description: "Digitale Zeiterfassung für alle Mitarbeiter (Pflichtmodul).",
+    alwaysAvailable: true,
+};
+
+export const FEATURE_CATALOG = [
+    {
+        key: "vacation",
+        name: "Urlaubs- & Abwesenheitsmodul",
+        price: 1,
+        priceType: "perEmployee",
+        required: false,
+        description: "Digitale Urlaubsanträge, Abwesenheitsübersicht, Freigabe-Workflow.",
+        alwaysAvailable: true,
+    },
+    {
+        key: "payroll",
+        name: "Lohnabrechnung",
+        price: 4,
+        priceType: "perEmployee",
+        required: false,
+        description: "Lohnabrechnung (DE & CH), Gehaltsabrechnungen als PDF, Abrechnungsexport.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "projects",
+        name: "Projektzeiten & Kundenverwaltung",
+        price: 1,
+        priceType: "perEmployee",
+        required: false,
+        description: "Erfassen von Projektzeiten und Kunden, Berichte & Auswertungen.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "accounting",
+        name: "Finanzbuchhaltung & Anlagen",
+        price: 2.5,
+        priceType: "perEmployee",
+        required: false,
+        description:
+            "Hauptbuch, Debitoren/Kreditoren, Anlagenverwaltung inkl. automatischer Übergabe aus Payroll & Billing.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "crm",
+        name: "CRM & Opportunity-Management",
+        price: 1.2,
+        priceType: "perEmployee",
+        required: false,
+        description: "Leads, Aktivitäten, Kampagnen und Pipeline-Visualisierung mit Team-Zugriff.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "supplyChain",
+        name: "Supply Chain & Lager",
+        price: 3.5,
+        priceType: "perEmployee",
+        required: false,
+        description: "Artikel-, Lager- und Auftragsverwaltung, Wareneingang/-ausgang, Produktion & Servicefälle.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "banking",
+        name: "Banking & Zahlungsverkehr",
+        price: 89,
+        priceType: "flat",
+        required: false,
+        description: "ISO-20022 pain.001 Export, Zahlungsfreigaben, sichere Nachrichten & Idempotency-Workflows.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "analytics",
+        name: "Reporting & BI-Dashboards",
+        price: 0.8,
+        priceType: "perEmployee",
+        required: false,
+        description: "Drill-down-Kennzahlen, Forecasts und Export in Echtzeit über alle Module.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "signature",
+        name: "Digitale Signaturen & sichere Zustellung",
+        price: 0.6,
+        priceType: "perEmployee",
+        required: false,
+        description: "Elektronische Signatur von Lohnabrechnungen, Verträgen & Rechnungen mit verschlüsselter Zustellung.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "nfc",
+        name: "NFC-Stempeluhr",
+        price: 0.5,
+        priceType: "perEmployee",
+        required: false,
+        description: "Stempeln per NFC-Karte oder Chip am Terminal oder Smartphone.",
+        alwaysAvailable: true,
+    },
+    {
+        key: "chatbot",
+        name: "Integrierter Support-Chatbot",
+        price: 0.5,
+        priceType: "perEmployee",
+        required: false,
+        description: "KI-basierte Hilfe & Erklärungen direkt in der App.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "premiumSupport",
+        name: "Premium-Support (SLA 2h)",
+        price: 129,
+        priceType: "flat",
+        required: false,
+        description: "Telefonischer Premium-Support, dedizierte Success-Manager & priorisierte Umsetzung.",
+        alwaysAvailable: false,
+    },
+    {
+        key: "roster",
+        name: "Dienstplan & Schichtplanung",
+        price: 1.2,
+        priceType: "perEmployee",
+        required: false,
+        description:
+            "Intelligente Schichtplanung mit Drag & Drop, Konflikterkennung, Mitarbeiterwünschen, Urlaubsabgleich und Export als PDF/Excel.",
+        alwaysAvailable: false,
+    },
+];
+
+export const ALWAYS_AVAILABLE_FEATURE_KEYS = FEATURE_CATALOG.filter((feature) => feature.alwaysAvailable).map(
+    (feature) => feature.key
+);
+
+export const TOGGLABLE_FEATURE_KEYS = FEATURE_CATALOG.filter((feature) => !feature.alwaysAvailable).map(
+    (feature) => feature.key
+);
+
+export const ALL_FEATURE_KEYS = FEATURE_CATALOG.map((feature) => feature.key);

--- a/Chrono-frontend/src/styles/CompanyManagementScoped.css
+++ b/Chrono-frontend/src/styles/CompanyManagementScoped.css
@@ -123,6 +123,96 @@
   background: var(--c-primary-dim);
 }
 
+.company-management-page.scoped-company .cmp-feature-box {
+  border: 1px dashed var(--c-border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  background: var(--c-input-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.company-management-page.scoped-company .cmp-feature-box__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.company-management-page.scoped-company .cmp-feature-box__hint {
+  font-size: 0.85rem;
+  color: var(--c-muted);
+}
+
+.company-management-page.scoped-company .cmp-feature-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.company-management-page.scoped-company .cmp-feature-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--c-border);
+  background: var(--c-card);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.company-management-page.scoped-company .cmp-feature-toggle:hover {
+  border-color: var(--c-primary);
+  background: rgba(71, 91, 255, 0.08);
+}
+
+.company-management-page.scoped-company .cmp-feature-toggle input {
+  accent-color: var(--c-primary);
+}
+
+.company-management-page.scoped-company .cmp-modules {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.company-management-page.scoped-company .cmp-modules__label {
+  font-size: 0.85rem;
+  color: var(--c-muted);
+}
+
+.company-management-page.scoped-company .cmp-modules__hint {
+  font-size: 0.75rem;
+  color: var(--c-muted);
+}
+
+.company-management-page.scoped-company .cmp-feature-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.company-management-page.scoped-company .cmp-feature-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(71, 91, 255, 0.15);
+  color: var(--c-primary);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.company-management-page.scoped-company .cmp-feature-chip--empty {
+  background: none;
+  border: 1px dashed var(--c-border);
+  color: var(--c-muted);
+  font-weight: 500;
+}
+
 /* Speziell für das Changelog-Formular, falls nötig */
 .company-management-page.scoped-company .changelog-form-section .form-group {
   display: flex;

--- a/Chrono-frontend/src/styles/RegistrationScoped.css
+++ b/Chrono-frontend/src/styles/RegistrationScoped.css
@@ -143,6 +143,29 @@
   font-weight: 600;
 }
 
+.feature-availability-note {
+  margin: 1.5rem auto 2rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--u-radius);
+  background: var(--c-card);
+  border: 1px dashed var(--c-border-light);
+  font-size: clamp(0.88rem, 1.4vw, 0.95rem);
+  color: var(--c-text-soft);
+  max-width: 840px;
+}
+
+.feature-availability-note .feature-warning {
+  color: #d35400;
+  font-weight: 600;
+}
+
+.feature-availability-note .feature-muted {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--c-muted);
+  font-size: 0.85rem;
+}
+
 /* Abrechnung (Monat/Jahr) Toggle */
 .billing-toggle {
   display: flex;


### PR DESCRIPTION
## Summary
- add a shared registration feature catalogue and filter the registration page to show only company-enabled modules while keeping the base, vacation, and NFC options always available
- extend the SuperAdmin company management forms to toggle optional modules and persist the sanitized selection for each company
- expose a public registration feature endpoint and persist enabled modules on the backend with security updates for the new route

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68def0bc6bf88325b741e96200f0658f