### PR TITLE
Enforce admin module availability from feature toggles

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/UserDTO.java
@@ -2,11 +2,15 @@ package com.chrono.chrono.dto;
 
 import com.chrono.chrono.entities.Role;
 import com.chrono.chrono.entities.User;
+import com.chrono.chrono.utils.RegistrationFeatures;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.ArrayList;
 
 public class UserDTO {
     // ----- Fields -----
@@ -60,10 +64,12 @@ public class UserDTO {
     private Boolean customerTrackingEnabled; // Kept
     private Long lastCustomerId;
     private String lastCustomerName;
+    private Set<String> companyFeatureKeys;
 
     public UserDTO() {
         this.roles = new ArrayList<>();
         this.weeklySchedule = new ArrayList<>();
+        this.companyFeatureKeys = new LinkedHashSet<>(RegistrationFeatures.ALWAYS_AVAILABLE_FEATURES);
     }
 
     // Constructor from User entity
@@ -119,6 +125,10 @@ public class UserDTO {
         this.lastCustomerId = user.getLastCustomer() != null ? user.getLastCustomer().getId() : null;
         this.lastCustomerName = user.getLastCustomer() != null ? user.getLastCustomer().getName() : null;
         this.customerTrackingEnabled = (user.getCompany() != null) ? user.getCompany().getCustomerTrackingEnabled() : null; // Kept
+        this.companyFeatureKeys = new LinkedHashSet<>(RegistrationFeatures.ALWAYS_AVAILABLE_FEATURES);
+        if (user.getCompany() != null) {
+            this.companyFeatureKeys.addAll(RegistrationFeatures.sanitizeOptionalFeatures(user.getCompany().getEnabledFeatures()));
+        }
     }
 
     // All-Args-Constructor
@@ -182,6 +192,7 @@ public class UserDTO {
         this.lastCustomerId = lastCustomerId;
         this.lastCustomerName = lastCustomerName;
         this.customerTrackingEnabled = customerTrackingEnabled; // Kept
+        this.companyFeatureKeys = new LinkedHashSet<>(RegistrationFeatures.ALWAYS_AVAILABLE_FEATURES);
         this.deleted = deleted;
         this.optOut = optOut;
         this.includeInTimeTracking = includeInTimeTracking != null ? includeInTimeTracking : true;
@@ -238,6 +249,7 @@ public class UserDTO {
     public Long getLastCustomerId() { return lastCustomerId; }
     public String getLastCustomerName() { return lastCustomerName; }
     public Boolean getCustomerTrackingEnabled() { return customerTrackingEnabled; } // Kept
+    public Set<String> getCompanyFeatureKeys() { return companyFeatureKeys; }
 
     // ----- Setters -----
     public void setId(Long id) { this.id = id; }
@@ -290,4 +302,9 @@ public class UserDTO {
     public void setLastCustomerId(Long lastCustomerId) { this.lastCustomerId = lastCustomerId; }
     public void setLastCustomerName(String lastCustomerName) { this.lastCustomerName = lastCustomerName; }
     public void setCustomerTrackingEnabled(Boolean customerTrackingEnabled) { this.customerTrackingEnabled = customerTrackingEnabled; } // Kept
+    public void setCompanyFeatureKeys(Set<String> companyFeatureKeys) {
+        this.companyFeatureKeys = companyFeatureKeys != null
+                ? new LinkedHashSet<>(companyFeatureKeys)
+                : new LinkedHashSet<>(RegistrationFeatures.ALWAYS_AVAILABLE_FEATURES);
+    }
 }

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -82,15 +82,114 @@ function App() {
                         <Route path="/admin/dashboard" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminDashboard /></PrivateRoute>} />
                         <Route path="/admin/users" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminUserManagementPage /></PrivateRoute>} />
                         <Route path="/admin/change-password" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminChangePassword /></PrivateRoute>} />
-                        <Route path="/admin/customers" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminCustomersPage /></PrivateRoute>} />
-                        <Route path="/admin/projects" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectsPage /></PrivateRoute>} />
-                        <Route path="/admin/tasks" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminTasksPage /></PrivateRoute>} />
-                        <Route path="/admin/analytics" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminAnalyticsPage /></PrivateRoute>} />
-                        <Route path="/admin/accounting" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminAccountingPage /></PrivateRoute>} />
-                        <Route path="/admin/supply-chain" element={<PrivateRoute requiredRole="ROLE_ADMIN"><SupplyChainDashboard /></PrivateRoute>} />
-                        <Route path="/admin/crm" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CrmDashboard /></PrivateRoute>} />
-                        <Route path="/admin/banking" element={<PrivateRoute requiredRole="ROLE_ADMIN"><BankingOperationsPage /></PrivateRoute>} />
-                        <Route path="/admin/project-report" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminProjectReportPage /></PrivateRoute>} />
+                        <Route
+                            path="/admin/customers"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="projects"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminCustomersPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/projects"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="projects"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminProjectsPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/tasks"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="projects"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminTasksPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/analytics"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="analytics"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminAnalyticsPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/accounting"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="accounting"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminAccountingPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/supply-chain"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="supplyChain"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <SupplyChainDashboard />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/crm"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="crm"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <CrmDashboard />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/banking"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="banking"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <BankingOperationsPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/project-report"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="projects"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminProjectReportPage />
+                                </PrivateRoute>
+                            }
+                        />
                         <Route
                             path="/admin/company"
                             element={
@@ -99,9 +198,42 @@ function App() {
                                 </PrivateRoute>
                             }
                         />
-                        <Route path="/admin/payslips" element={<PrivateRoute requiredRole={["ROLE_ADMIN", "ROLE_PAYROLL_ADMIN"]}><AdminPayslipsPage /></PrivateRoute>} />
-                        <Route path="/admin/schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminSchedulePlannerPage /></PrivateRoute>} />
-                        <Route path="/admin/print-schedule" element={<PrivateRoute requiredRole="ROLE_ADMIN"><PrintSchedule /></PrivateRoute>} />
+                        <Route
+                            path="/admin/payslips"
+                            element={
+                                <PrivateRoute
+                                    requiredRole={["ROLE_ADMIN", "ROLE_PAYROLL_ADMIN"]}
+                                    requiredFeature="payroll"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminPayslipsPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/schedule"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="roster"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <AdminSchedulePlannerPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/print-schedule"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="roster"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <PrintSchedule />
+                                </PrivateRoute>
+                            }
+                        />
 
                         <Route path="/admin/knowledge" element={<PrivateRoute requiredRole="ROLE_ADMIN"><AdminKnowledgePage /></PrivateRoute>} />
                         <Route path="/admin/company-settings" element={<PrivateRoute requiredRole="ROLE_ADMIN"><CompanySettingsPage /></PrivateRoute>} />

--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 /****************************************
  * Navbar.jsx · kompakt mit Dropdowns & Icons (Aug 2025)
  ****************************************/
-import React, { useState, useEffect, useContext, useRef } from 'react';
+import React, { useState, useEffect, useContext, useRef, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { LanguageContext, useTranslation } from '../context/LanguageContext';
@@ -121,6 +121,19 @@ const Navbar = () => {
     const userInitial = currentUser?.username?.[0]?.toUpperCase() || 'U';
     const onAdminRoute = location.pathname.startsWith('/admin');
 
+    const companyFeatureKeys = useMemo(() => {
+        const keys = currentUser?.companyFeatureKeys;
+        if (!keys) return new Set();
+        if (Array.isArray(keys)) return new Set(keys);
+        return new Set(Object.values(keys));
+    }, [currentUser?.companyFeatureKeys]);
+
+    const hasFeature = (featureKey) => {
+        if (!featureKey) return true;
+        if (isSuperAdmin) return true;
+        return companyFeatureKeys.has(featureKey);
+    };
+
     return (
         <div className={styles['scoped-navbar']}>
             <nav className={styles.navbar} aria-label="Hauptnavigation">
@@ -194,31 +207,43 @@ const Navbar = () => {
                                                 <Link to="/admin/users" onClick={() => setOpenAdmin(false)}>
                                                     {t('navbar.userManagement','Benutzerverwaltung')}
                                                 </Link>
-                                                {currentUser.customerTrackingEnabled && (
+                                                {currentUser.customerTrackingEnabled && hasFeature('projects') && (
                                                     <>
                                                         <Link to="/admin/projects" onClick={() => setOpenAdmin(false)}>
                                                             {t('navbar.workManagement','Kunden · Projekte · Aufgaben')}
                                                         </Link>
                                                     </>
                                                 )}
-                                                <Link to="/admin/accounting" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.accounting','Finanzbuchhaltung')}
-                                                </Link>
-                                                <Link to="/admin/supply-chain" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.supplyChain','Supply Chain')}
-                                                </Link>
-                                                <Link to="/admin/crm" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.crm','CRM & Marketing')}
-                                                </Link>
-                                                <Link to="/admin/banking" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.banking','Zahlungsverkehr')}
-                                                </Link>
-                                                <Link to="/admin/payslips" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.payslips','Abrechnungen')}
-                                                </Link>
-                                                <Link to="/admin/schedule" onClick={() => setOpenAdmin(false)}>
-                                                    {t('navbar.schedulePlanner','Dienstplan')}
-                                                </Link>
+                                                {hasFeature('accounting') && (
+                                                    <Link to="/admin/accounting" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.accounting','Finanzbuchhaltung')}
+                                                    </Link>
+                                                )}
+                                                {hasFeature('supplyChain') && (
+                                                    <Link to="/admin/supply-chain" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.supplyChain','Supply Chain')}
+                                                    </Link>
+                                                )}
+                                                {hasFeature('crm') && (
+                                                    <Link to="/admin/crm" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.crm','CRM & Marketing')}
+                                                    </Link>
+                                                )}
+                                                {hasFeature('banking') && (
+                                                    <Link to="/admin/banking" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.banking','Zahlungsverkehr')}
+                                                    </Link>
+                                                )}
+                                                {hasFeature('payroll') && (
+                                                    <Link to="/admin/payslips" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.payslips','Abrechnungen')}
+                                                    </Link>
+                                                )}
+                                                {hasFeature('roster') && (
+                                                    <Link to="/admin/schedule" onClick={() => setOpenAdmin(false)}>
+                                                        {t('navbar.schedulePlanner','Dienstplan')}
+                                                    </Link>
+                                                )}
                                                 <Link to="/admin/knowledge" onClick={() => setOpenAdmin(false)}>
                                                     {t('navbar.knowledge','Firmen KI Wissen')}
                                                 </Link>

--- a/Chrono-frontend/src/components/PrivateRoute.jsx
+++ b/Chrono-frontend/src/components/PrivateRoute.jsx
@@ -8,7 +8,7 @@ import { useAuth } from '../context/AuthContext';
  * - Bei fehlender Auth → Redirect zu /login?next=<uri>
  * - Bei fehlender Berechtigung → Redirect zur Landing-Page
  */
-const PrivateRoute = ({ children, requiredRole }) => {
+const PrivateRoute = ({ children, requiredRole, requiredFeature, redirectTo = '/' }) => {
     const { authToken, currentUser } = useAuth();
     const location = useLocation();
 
@@ -31,6 +31,28 @@ const PrivateRoute = ({ children, requiredRole }) => {
 
         if (!allowed) {
             return <Navigate to="/" replace />;
+        }
+    }
+
+    if (requiredFeature) {
+        const isSuperAdmin = currentUser?.roles?.includes('ROLE_SUPERADMIN');
+        if (!isSuperAdmin) {
+            const featureKeysRaw = currentUser?.companyFeatureKeys;
+            const featureList = Array.isArray(featureKeysRaw)
+                ? featureKeysRaw
+                : featureKeysRaw
+                    ? Object.values(featureKeysRaw)
+                    : [];
+
+            const requiredFeatures = Array.isArray(requiredFeature)
+                ? requiredFeature
+                : [requiredFeature];
+
+            const hasFeature = requiredFeatures.some((featureKey) => featureList.includes(featureKey));
+
+            if (!hasFeature) {
+                return <Navigate to={redirectTo} replace />;
+            }
         }
     }
 

--- a/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
+++ b/Chrono-frontend/src/pages/AdminDashboard/AdminDashboard.jsx
@@ -172,6 +172,21 @@ const AdminDashboard = () => {
         }
     }, []);
 
+    const isSuperAdmin = !!currentUser?.roles?.includes('ROLE_SUPERADMIN');
+
+    const companyFeatureSet = useMemo(() => {
+        const keys = currentUser?.companyFeatureKeys;
+        if (!keys) return new Set();
+        if (Array.isArray(keys)) return new Set(keys);
+        return new Set(Object.values(keys));
+    }, [currentUser?.companyFeatureKeys]);
+
+    const hasFeature = useCallback((featureKey) => {
+        if (!featureKey) return true;
+        if (isSuperAdmin) return true;
+        return companyFeatureSet.has(featureKey);
+    }, [companyFeatureSet, isSuperAdmin]);
+
     const handleOpenAnalytics = useCallback(() => {
         navigate('/admin/analytics');
     }, [navigate]);
@@ -629,7 +644,7 @@ const AdminDashboard = () => {
                 onShowIssueOverview={handleShowIssueOverview}
                 onFocusNegativeBalances={handleFocusNegativeBalances}
                 onFocusOvertimeLeaders={handleFocusPositiveBalances}
-                onOpenAnalytics={handleOpenAnalytics}
+                onOpenAnalytics={hasFeature('analytics') ? handleOpenAnalytics : null}
             />
 
 
@@ -642,27 +657,33 @@ const AdminDashboard = () => {
                 >
                     {t('adminDashboard.importTimeTrackingButton', 'Zeiten importieren')}
                 </Link>
-                <Link
-                    to="/admin/payslips"
-                    className="admin-action-button button-primary"
-                    role="button"
-                >
-                    {t('navbar.payslips', 'Abrechnungen')}
-                </Link>
-                <Link
-                    to="/admin/schedule"
-                    className="admin-action-button button-primary"
-                    role="button"
-                >
-                    {t('navbar.schedulePlanner', 'Dienstplan')}
-                </Link>
-                <Link
-                    to="/admin/analytics"
-                    className="admin-action-button button-secondary admin-analytics-button"
-                    role="button"
-                >
-                    {t('adminDashboard.analyticsButton', 'Analytics anzeigen')}
-                </Link>
+                {hasFeature('payroll') && (
+                    <Link
+                        to="/admin/payslips"
+                        className="admin-action-button button-primary"
+                        role="button"
+                    >
+                        {t('navbar.payslips', 'Abrechnungen')}
+                    </Link>
+                )}
+                {hasFeature('roster') && (
+                    <Link
+                        to="/admin/schedule"
+                        className="admin-action-button button-primary"
+                        role="button"
+                    >
+                        {t('navbar.schedulePlanner', 'Dienstplan')}
+                    </Link>
+                )}
+                {hasFeature('analytics') && (
+                    <Link
+                        to="/admin/analytics"
+                        className="admin-action-button button-secondary admin-analytics-button"
+                        role="button"
+                    >
+                        {t('adminDashboard.analyticsButton', 'Analytics anzeigen')}
+                    </Link>
+                )}
                 <button
                     type="button"
                     onClick={handleDataReloadNeeded}


### PR DESCRIPTION
## Summary
- expose the enabled company feature keys via `UserDTO` so the frontend can determine module availability
- hide admin navigation links and dashboard shortcuts when a feature is disabled for the current company
- guard relevant admin routes with feature checks to stop direct access when the module is turned off

## Testing
- npm run build *(fails: vite not found in PATH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e255a59e8083258b27c510cf96500c