### PR TITLE
Fix supply chain dashboard handling of paginated API responses

### DIFF
--- a/Chrono-frontend/src/pages/SupplyChain/SupplyChainDashboard.jsx
+++ b/Chrono-frontend/src/pages/SupplyChain/SupplyChainDashboard.jsx
@@ -23,9 +23,13 @@ const SupplyChainDashboard = () => {
                     api.get("/api/supply-chain/warehouses"),
                     api.get("/api/supply-chain/stock")
                 ]);
-                setProducts(productRes.data ?? []);
-                setWarehouses(warehouseRes.data ?? []);
-                setStock(stockRes.data ?? []);
+
+                const productData = productRes?.data;
+                const stockData = stockRes?.data;
+
+                setProducts(Array.isArray(productData) ? productData : productData?.content ?? []);
+                setWarehouses(warehouseRes?.data ?? []);
+                setStock(Array.isArray(stockData) ? stockData : stockData?.content ?? []);
             } catch (error) {
                 console.error("Failed to load supply chain data", error);
                 notify(t("supplyChain.loadError", "Supply-Chain-Daten konnten nicht geladen werden."), "error");


### PR DESCRIPTION
## Summary
- normalize supply chain product and stock responses to handle paginated payloads
- keep dashboard metrics resilient when backend returns page data instead of arrays

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68e2f94c469483258b70f64e42f7c0a0