### PR TITLE
Add accounting, CRM, supply chain, and banking workflows

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/accounting/AccountingController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/accounting/AccountingController.java
@@ -77,6 +77,14 @@ public class AccountingController {
         return ResponseEntity.ok(entries);
     }
 
+    @GetMapping("/assets")
+    public ResponseEntity<List<AssetDTO>> listAssets() {
+        List<AssetDTO> assets = assetManagementService.listAssets().stream()
+                .map(AssetDTO::from)
+                .toList();
+        return ResponseEntity.ok(assets);
+    }
+
     @PostMapping("/journal")
     public ResponseEntity<JournalEntryDTO> createJournalEntry(@RequestBody CreateJournalEntryRequest request) {
         JournalEntry entry = new JournalEntry();
@@ -132,5 +140,21 @@ public class AccountingController {
                 .map(AssetDTO::from)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping("/receivables/{id}/payments")
+    public ResponseEntity<CustomerInvoiceDTO> applyReceivablePayment(@PathVariable Long id,
+                                                                     @RequestBody RecordPaymentRequest request) {
+        var updated = accountsReceivableService.applyPayment(id, request.getAmount(),
+                request.getPaymentDate(), request.getMemo());
+        return ResponseEntity.ok(CustomerInvoiceDTO.from(updated));
+    }
+
+    @PostMapping("/payables/{id}/payments")
+    public ResponseEntity<VendorInvoiceDTO> applyPayablePayment(@PathVariable Long id,
+                                                                @RequestBody RecordPaymentRequest request) {
+        var updated = accountsPayableService.applyPayment(id, request.getAmount(),
+                request.getPaymentDate(), request.getMemo());
+        return ResponseEntity.ok(VendorInvoiceDTO.from(updated));
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/CustomerInvoiceDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/CustomerInvoiceDTO.java
@@ -11,21 +11,28 @@ public class CustomerInvoiceDTO {
     private final String invoiceNumber;
     private final String customerName;
     private final BigDecimal amount;
+    private final BigDecimal amountPaid;
+    private final BigDecimal openAmount;
     private final String currency;
     private final InvoiceStatus status;
     private final LocalDate invoiceDate;
     private final LocalDate dueDate;
+    private final LocalDate lastPaymentDate;
 
     public CustomerInvoiceDTO(Long id, String invoiceNumber, String customerName, BigDecimal amount,
-                              String currency, InvoiceStatus status, LocalDate invoiceDate, LocalDate dueDate) {
+                              BigDecimal amountPaid, BigDecimal openAmount, String currency, InvoiceStatus status,
+                              LocalDate invoiceDate, LocalDate dueDate, LocalDate lastPaymentDate) {
         this.id = id;
         this.invoiceNumber = invoiceNumber;
         this.customerName = customerName;
         this.amount = amount;
+        this.amountPaid = amountPaid;
+        this.openAmount = openAmount;
         this.currency = currency;
         this.status = status;
         this.invoiceDate = invoiceDate;
         this.dueDate = dueDate;
+        this.lastPaymentDate = lastPaymentDate;
     }
 
     public static CustomerInvoiceDTO from(CustomerInvoice invoice) {
@@ -34,10 +41,13 @@ public class CustomerInvoiceDTO {
                 invoice.getInvoiceNumber(),
                 invoice.getCustomerName(),
                 invoice.getAmount(),
+                invoice.getAmountPaid(),
+                invoice.getOpenAmount(),
                 invoice.getCurrency(),
                 invoice.getStatus(),
                 invoice.getInvoiceDate(),
-                invoice.getDueDate());
+                invoice.getDueDate(),
+                invoice.getLastPaymentDate());
     }
 
     public Long getId() {
@@ -56,6 +66,14 @@ public class CustomerInvoiceDTO {
         return amount;
     }
 
+    public BigDecimal getAmountPaid() {
+        return amountPaid;
+    }
+
+    public BigDecimal getOpenAmount() {
+        return openAmount;
+    }
+
     public String getCurrency() {
         return currency;
     }
@@ -70,5 +88,9 @@ public class CustomerInvoiceDTO {
 
     public LocalDate getDueDate() {
         return dueDate;
+    }
+
+    public LocalDate getLastPaymentDate() {
+        return lastPaymentDate;
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/RecordPaymentRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/RecordPaymentRequest.java
@@ -1,0 +1,34 @@
+package com.chrono.chrono.dto.accounting;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class RecordPaymentRequest {
+    private BigDecimal amount;
+    private LocalDate paymentDate;
+    private String memo;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public LocalDate getPaymentDate() {
+        return paymentDate;
+    }
+
+    public void setPaymentDate(LocalDate paymentDate) {
+        this.paymentDate = paymentDate;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/VendorInvoiceDTO.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/accounting/VendorInvoiceDTO.java
@@ -11,21 +11,28 @@ public class VendorInvoiceDTO {
     private final String invoiceNumber;
     private final String vendorName;
     private final BigDecimal amount;
+    private final BigDecimal amountPaid;
+    private final BigDecimal openAmount;
     private final String currency;
     private final InvoiceStatus status;
     private final LocalDate invoiceDate;
     private final LocalDate dueDate;
+    private final LocalDate lastPaymentDate;
 
     public VendorInvoiceDTO(Long id, String invoiceNumber, String vendorName, BigDecimal amount,
-                            String currency, InvoiceStatus status, LocalDate invoiceDate, LocalDate dueDate) {
+                            BigDecimal amountPaid, BigDecimal openAmount, String currency, InvoiceStatus status,
+                            LocalDate invoiceDate, LocalDate dueDate, LocalDate lastPaymentDate) {
         this.id = id;
         this.invoiceNumber = invoiceNumber;
         this.vendorName = vendorName;
         this.amount = amount;
+        this.amountPaid = amountPaid;
+        this.openAmount = openAmount;
         this.currency = currency;
         this.status = status;
         this.invoiceDate = invoiceDate;
         this.dueDate = dueDate;
+        this.lastPaymentDate = lastPaymentDate;
     }
 
     public static VendorInvoiceDTO from(VendorInvoice invoice) {
@@ -34,10 +41,13 @@ public class VendorInvoiceDTO {
                 invoice.getInvoiceNumber(),
                 invoice.getVendorName(),
                 invoice.getAmount(),
+                invoice.getAmountPaid(),
+                invoice.getOpenAmount(),
                 invoice.getCurrency(),
                 invoice.getStatus(),
                 invoice.getInvoiceDate(),
-                invoice.getDueDate());
+                invoice.getDueDate(),
+                invoice.getLastPaymentDate());
     }
 
     public Long getId() {
@@ -56,6 +66,14 @@ public class VendorInvoiceDTO {
         return amount;
     }
 
+    public BigDecimal getAmountPaid() {
+        return amountPaid;
+    }
+
+    public BigDecimal getOpenAmount() {
+        return openAmount;
+    }
+
     public String getCurrency() {
         return currency;
     }
@@ -70,5 +88,9 @@ public class VendorInvoiceDTO {
 
     public LocalDate getDueDate() {
         return dueDate;
+    }
+
+    public LocalDate getLastPaymentDate() {
+        return lastPaymentDate;
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/CreateCrmActivityRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/CreateCrmActivityRequest.java
@@ -7,6 +7,7 @@ public class CreateCrmActivityRequest {
     private CrmActivityType type = CrmActivityType.NOTE;
     private String notes;
     private Long contactId;
+    private java.time.LocalDateTime timestamp;
 
     public CrmActivityType getType() {
         return type;
@@ -32,10 +33,21 @@ public class CreateCrmActivityRequest {
         this.contactId = contactId;
     }
 
+    public java.time.LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(java.time.LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
     public CrmActivity toEntity() {
         CrmActivity activity = new CrmActivity();
         activity.setType(type);
         activity.setNotes(notes);
+        if (timestamp != null) {
+            activity.setTimestamp(timestamp);
+        }
         return activity;
     }
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateCampaignRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateCampaignRequest.java
@@ -1,0 +1,62 @@
+package com.chrono.chrono.dto.crm;
+
+import com.chrono.chrono.entities.crm.CampaignStatus;
+
+import java.time.LocalDate;
+
+public class UpdateCampaignRequest {
+    private String name;
+    private CampaignStatus status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer budget;
+    private String channel;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CampaignStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(CampaignStatus status) {
+        this.status = status;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public Integer getBudget() {
+        return budget;
+    }
+
+    public void setBudget(Integer budget) {
+        this.budget = budget;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateLeadStatusRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateLeadStatusRequest.java
@@ -1,0 +1,15 @@
+package com.chrono.chrono.dto.crm;
+
+import com.chrono.chrono.entities.crm.LeadStatus;
+
+public class UpdateLeadStatusRequest {
+    private LeadStatus status;
+
+    public LeadStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LeadStatus status) {
+        this.status = status;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateOpportunityRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/crm/UpdateOpportunityRequest.java
@@ -1,0 +1,35 @@
+package com.chrono.chrono.dto.crm;
+
+import com.chrono.chrono.entities.crm.OpportunityStage;
+
+import java.time.LocalDate;
+
+public class UpdateOpportunityRequest {
+    private OpportunityStage stage;
+    private Double probability;
+    private LocalDate expectedCloseDate;
+
+    public OpportunityStage getStage() {
+        return stage;
+    }
+
+    public void setStage(OpportunityStage stage) {
+        this.stage = stage;
+    }
+
+    public Double getProbability() {
+        return probability;
+    }
+
+    public void setProbability(Double probability) {
+        this.probability = probability;
+    }
+
+    public LocalDate getExpectedCloseDate() {
+        return expectedCloseDate;
+    }
+
+    public void setExpectedCloseDate(LocalDate expectedCloseDate) {
+        this.expectedCloseDate = expectedCloseDate;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/accounting/CustomerInvoice.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/accounting/CustomerInvoice.java
@@ -27,6 +27,11 @@ public class CustomerInvoice {
     @Column(precision = 19, scale = 4, nullable = false)
     private BigDecimal amount = BigDecimal.ZERO;
 
+    @Column(precision = 19, scale = 4, nullable = false)
+    private BigDecimal amountPaid = BigDecimal.ZERO;
+
+    private LocalDate lastPaymentDate;
+
     @Column(length = 3)
     private String currency = "CHF";
 
@@ -90,6 +95,30 @@ public class CustomerInvoice {
 
     public void setAmount(BigDecimal amount) {
         this.amount = amount;
+    }
+
+    public BigDecimal getAmountPaid() {
+        return amountPaid == null ? BigDecimal.ZERO : amountPaid;
+    }
+
+    public void setAmountPaid(BigDecimal amountPaid) {
+        this.amountPaid = amountPaid;
+    }
+
+    public LocalDate getLastPaymentDate() {
+        return lastPaymentDate;
+    }
+
+    public void setLastPaymentDate(LocalDate lastPaymentDate) {
+        this.lastPaymentDate = lastPaymentDate;
+    }
+
+    @Transient
+    public BigDecimal getOpenAmount() {
+        BigDecimal paid = getAmountPaid();
+        BigDecimal total = amount != null ? amount : BigDecimal.ZERO;
+        BigDecimal remaining = total.subtract(paid != null ? paid : BigDecimal.ZERO);
+        return remaining.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : remaining;
     }
 
     public String getCurrency() {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/accounting/VendorInvoice.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/accounting/VendorInvoice.java
@@ -27,6 +27,11 @@ public class VendorInvoice {
     @Column(precision = 19, scale = 4, nullable = false)
     private BigDecimal amount = BigDecimal.ZERO;
 
+    @Column(precision = 19, scale = 4, nullable = false)
+    private BigDecimal amountPaid = BigDecimal.ZERO;
+
+    private LocalDate lastPaymentDate;
+
     @Column(length = 3)
     private String currency = "CHF";
 
@@ -88,6 +93,30 @@ public class VendorInvoice {
 
     public void setAmount(BigDecimal amount) {
         this.amount = amount;
+    }
+
+    public BigDecimal getAmountPaid() {
+        return amountPaid == null ? BigDecimal.ZERO : amountPaid;
+    }
+
+    public void setAmountPaid(BigDecimal amountPaid) {
+        this.amountPaid = amountPaid;
+    }
+
+    public LocalDate getLastPaymentDate() {
+        return lastPaymentDate;
+    }
+
+    public void setLastPaymentDate(LocalDate lastPaymentDate) {
+        this.lastPaymentDate = lastPaymentDate;
+    }
+
+    @Transient
+    public BigDecimal getOpenAmount() {
+        BigDecimal paid = getAmountPaid();
+        BigDecimal total = amount != null ? amount : BigDecimal.ZERO;
+        BigDecimal remaining = total.subtract(paid != null ? paid : BigDecimal.ZERO);
+        return remaining.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : remaining;
     }
 
     public String getCurrency() {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/accounting/CustomerInvoiceRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/accounting/CustomerInvoiceRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+
 public interface CustomerInvoiceRepository extends JpaRepository<CustomerInvoice, Long> {
-    Page<CustomerInvoice> findByStatus(InvoiceStatus status, Pageable pageable);
+    Page<CustomerInvoice> findByStatusIn(Collection<InvoiceStatus> statuses, Pageable pageable);
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/accounting/VendorInvoiceRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/accounting/VendorInvoiceRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+
 public interface VendorInvoiceRepository extends JpaRepository<VendorInvoice, Long> {
-    Page<VendorInvoice> findByStatus(InvoiceStatus status, Pageable pageable);
+    Page<VendorInvoice> findByStatusIn(Collection<InvoiceStatus> statuses, Pageable pageable);
 }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/accounting/AssetManagementService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/accounting/AssetManagementService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 public class AssetManagementService {
@@ -29,6 +30,11 @@ public class AssetManagementService {
         Asset saved = assetRepository.save(asset);
         postAcquisition(saved);
         return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Asset> listAssets() {
+        return assetRepository.findAll();
     }
 
     private void postAcquisition(Asset asset) {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/crm/CrmService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/crm/CrmService.java
@@ -7,7 +7,9 @@ import com.chrono.chrono.repositories.crm.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class CrmService {
@@ -42,10 +44,55 @@ public class CrmService {
         return customerAddressRepository.save(address);
     }
 
+    @Transactional(readOnly = true)
+    public List<CustomerAddress> listAddresses(Customer customer) {
+        return customerAddressRepository.findByCustomer(customer);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CustomerAddress> findAddress(Long id) {
+        return customerAddressRepository.findById(id);
+    }
+
+    @Transactional
+    public CustomerAddress updateAddress(CustomerAddress existing, CustomerAddress changes) {
+        existing.setStreet(changes.getStreet());
+        existing.setPostalCode(changes.getPostalCode());
+        existing.setCity(changes.getCity());
+        existing.setCountry(changes.getCountry());
+        existing.setType(changes.getType());
+        return customerAddressRepository.save(existing);
+    }
+
+    @Transactional
+    public void deleteAddress(CustomerAddress address) {
+        customerAddressRepository.delete(address);
+    }
+
     @Transactional
     public CustomerContact addContact(Customer customer, CustomerContact contact) {
         contact.setCustomer(customer);
         return customerContactRepository.save(contact);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CustomerContact> findContact(Long id) {
+        return customerContactRepository.findById(id);
+    }
+
+    @Transactional
+    public CustomerContact updateContact(CustomerContact contact, CustomerContact changes) {
+        contact.setFirstName(changes.getFirstName());
+        contact.setLastName(changes.getLastName());
+        contact.setEmail(changes.getEmail());
+        contact.setPhone(changes.getPhone());
+        contact.setRoleTitle(changes.getRoleTitle());
+        return customerContactRepository.save(contact);
+    }
+
+    @Transactional
+    public void deleteContact(CustomerContact contact) {
+        customerContactRepository.delete(contact);
     }
 
     @Transactional
@@ -55,8 +102,40 @@ public class CrmService {
         return crmActivityRepository.save(activity);
     }
 
+    @Transactional(readOnly = true)
+    public Optional<CrmActivity> findActivity(Long id) {
+        return crmActivityRepository.findById(id);
+    }
+
+    @Transactional
+    public CrmActivity updateActivity(CrmActivity activity, CrmActivity changes) {
+        activity.setType(changes.getType());
+        activity.setNotes(changes.getNotes());
+        if (changes.getTimestamp() != null) {
+            activity.setTimestamp(changes.getTimestamp());
+        }
+        activity.setContact(changes.getContact());
+        return crmActivityRepository.save(activity);
+    }
+
+    @Transactional
+    public void deleteActivity(CrmActivity activity) {
+        crmActivityRepository.delete(activity);
+    }
+
     @Transactional
     public CrmLead saveLead(CrmLead lead) {
+        return crmLeadRepository.save(lead);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CrmLead> findLead(Long id) {
+        return crmLeadRepository.findById(id);
+    }
+
+    @Transactional
+    public CrmLead updateLeadStatus(CrmLead lead, LeadStatus status) {
+        lead.setStatus(status);
         return crmLeadRepository.save(lead);
     }
 
@@ -65,8 +144,57 @@ public class CrmService {
         return opportunityRepository.save(opportunity);
     }
 
+    @Transactional(readOnly = true)
+    public Optional<Opportunity> findOpportunity(Long id) {
+        return opportunityRepository.findById(id);
+    }
+
+    @Transactional
+    public Opportunity updateOpportunity(Opportunity opportunity, OpportunityStage stage, Double probability,
+                                         LocalDate expectedCloseDate) {
+        if (stage != null) {
+            opportunity.setStage(stage);
+        }
+        if (probability != null) {
+            opportunity.setProbability(probability);
+        }
+        if (expectedCloseDate != null) {
+            opportunity.setExpectedCloseDate(expectedCloseDate);
+        }
+        return opportunityRepository.save(opportunity);
+    }
+
     @Transactional
     public Campaign saveCampaign(Campaign campaign) {
+        return campaignRepository.save(campaign);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Campaign> findCampaign(Long id) {
+        return campaignRepository.findById(id);
+    }
+
+    @Transactional
+    public Campaign updateCampaign(Campaign campaign, CampaignStatus status, String name,
+                                   LocalDate startDate, LocalDate endDate, Integer budget, String channel) {
+        if (status != null) {
+            campaign.setStatus(status);
+        }
+        if (name != null) {
+            campaign.setName(name);
+        }
+        if (startDate != null) {
+            campaign.setStartDate(startDate);
+        }
+        if (endDate != null) {
+            campaign.setEndDate(endDate);
+        }
+        if (budget != null) {
+            campaign.setBudget(budget);
+        }
+        if (channel != null) {
+            campaign.setChannel(channel);
+        }
         return campaignRepository.save(campaign);
     }
 

--- a/Chrono-frontend/src/pages/AdminAccounting/AdminAccountingPage.jsx
+++ b/Chrono-frontend/src/pages/AdminAccounting/AdminAccountingPage.jsx
@@ -29,25 +29,52 @@ const AdminAccountingPage = () => {
     const [journalEntries, setJournalEntries] = useState([]);
     const [receivables, setReceivables] = useState([]);
     const [payables, setPayables] = useState([]);
+    const [assets, setAssets] = useState([]);
     const [loading, setLoading] = useState(true);
     const [accountForm, setAccountForm] = useState(initialAccount);
     const [refreshFlag, setRefreshFlag] = useState(0);
+    const [showJournalForm, setShowJournalForm] = useState(false);
+    const [journalForm, setJournalForm] = useState({
+        entryDate: "",
+        description: "",
+        documentReference: "",
+        lines: [{ accountId: "", debit: "", credit: "", memo: "" }]
+    });
+    const [assetForm, setAssetForm] = useState({
+        assetName: "",
+        acquisitionDate: "",
+        acquisitionCost: "",
+        usefulLifeMonths: "",
+        residualValue: ""
+    });
+    const [paymentModal, setPaymentModal] = useState({
+        open: false,
+        type: "receivable",
+        invoice: null,
+        amount: "",
+        paymentDate: "",
+        memo: ""
+    });
 
     useEffect(() => {
         const load = async () => {
             setLoading(true);
             try {
-                const [accRes, journalRes, recvRes, payRes] = await Promise.all([
+                const [accRes, journalRes, recvRes, payRes, assetRes] = await Promise.all([
                     api.get("/api/accounting/accounts"),
                     api.get("/api/accounting/journal"),
                     api.get("/api/accounting/receivables/open"),
-                    api.get("/api/accounting/payables/open")
+                    api.get("/api/accounting/payables/open"),
+                    api.get("/api/accounting/assets")
                 ]);
                 setAccounts(accRes.data ?? []);
                 const journal = journalRes.data?.content ?? journalRes.data ?? [];
                 setJournalEntries(journal);
-                setReceivables(recvRes.data ?? []);
-                setPayables(payRes.data ?? []);
+                const receivableData = recvRes.data?.content ?? recvRes.data ?? [];
+                const payableData = payRes.data?.content ?? payRes.data ?? [];
+                setReceivables(receivableData);
+                setPayables(payableData);
+                setAssets(assetRes.data ?? []);
             } catch (error) {
                 console.error("Failed to load accounting data", error);
                 notify(t("accounting.loadError", "Finanzdaten konnten nicht geladen werden."), "error");
@@ -71,6 +98,130 @@ const AdminAccountingPage = () => {
         } catch (error) {
             console.error("Failed to create account", error);
             notify(t("accounting.accountSaveFailed", "Konto konnte nicht angelegt werden."), "error");
+        }
+    };
+
+    const addJournalLine = () => {
+        setJournalForm((prev) => ({
+            ...prev,
+            lines: [...prev.lines, { accountId: "", debit: "", credit: "", memo: "" }]
+        }));
+    };
+
+    const updateJournalLine = (index, field, value) => {
+        setJournalForm((prev) => {
+            const lines = prev.lines.map((line, idx) => (idx === index ? { ...line, [field]: value } : line));
+            return { ...prev, lines };
+        });
+    };
+
+    const removeJournalLine = (index) => {
+        setJournalForm((prev) => ({
+            ...prev,
+            lines: prev.lines.filter((_, idx) => idx !== index)
+        }));
+    };
+
+    const handleJournalSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                entryDate: journalForm.entryDate || undefined,
+                description: journalForm.description,
+                documentReference: journalForm.documentReference,
+                source: "MANUAL",
+                lines: journalForm.lines
+                    .filter((line) => line.accountId && (line.debit || line.credit))
+                    .map((line) => ({
+                        accountId: Number(line.accountId),
+                        debit: Number(line.debit || 0),
+                        credit: Number(line.credit || 0),
+                        memo: line.memo
+                    }))
+            };
+            await api.post("/api/accounting/journal", payload);
+            notify(t("accounting.journalSaved", "Journalbuchung erfasst."), "success");
+            setShowJournalForm(false);
+            setJournalForm({
+                entryDate: "",
+                description: "",
+                documentReference: "",
+                lines: [{ accountId: "", debit: "", credit: "", memo: "" }]
+            });
+            setRefreshFlag((flag) => flag + 1);
+        } catch (error) {
+            console.error("Failed to create journal entry", error);
+            notify(t("accounting.journalSaveFailed", "Journalbuchung konnte nicht gespeichert werden."), "error");
+        }
+    };
+
+    const handleAssetSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                assetName: assetForm.assetName,
+                acquisitionDate: assetForm.acquisitionDate || undefined,
+                acquisitionCost: Number(assetForm.acquisitionCost || 0),
+                usefulLifeMonths: Number(assetForm.usefulLifeMonths || 0),
+                residualValue: assetForm.residualValue ? Number(assetForm.residualValue) : undefined
+            };
+            await api.post("/api/accounting/assets", payload);
+            notify(t("accounting.assetSaved", "Anlage erfasst."), "success");
+            setAssetForm({ assetName: "", acquisitionDate: "", acquisitionCost: "", usefulLifeMonths: "", residualValue: "" });
+            setRefreshFlag((flag) => flag + 1);
+        } catch (error) {
+            console.error("Failed to save asset", error);
+            notify(t("accounting.assetSaveFailed", "Anlage konnte nicht gespeichert werden."), "error");
+        }
+    };
+
+    const handleDepreciation = async (assetId) => {
+        try {
+            await api.post(`/api/accounting/assets/${assetId}/depreciate`);
+            notify(t("accounting.depreciationRun", "Abschreibung gebucht."), "success");
+            setRefreshFlag((flag) => flag + 1);
+        } catch (error) {
+            console.error("Failed to depreciate asset", error);
+            notify(t("accounting.depreciationFailed", "Abschreibung fehlgeschlagen."), "error");
+        }
+    };
+
+    const openPaymentModal = (invoice, type) => {
+        setPaymentModal({
+            open: true,
+            type,
+            invoice,
+            amount: Number(invoice?.openAmount ?? invoice?.amount ?? 0).toFixed(2),
+            paymentDate: "",
+            memo: ""
+        });
+    };
+
+    const closePaymentModal = () => {
+        setPaymentModal({ open: false, type: "receivable", invoice: null, amount: "", paymentDate: "", memo: "" });
+    };
+
+    const handlePaymentSubmit = async (event) => {
+        event.preventDefault();
+        if (!paymentModal.invoice) {
+            return;
+        }
+        const endpoint = paymentModal.type === "receivable"
+            ? `/api/accounting/receivables/${paymentModal.invoice.id}/payments`
+            : `/api/accounting/payables/${paymentModal.invoice.id}/payments`;
+        try {
+            const payload = {
+                amount: Number(paymentModal.amount || 0),
+                paymentDate: paymentModal.paymentDate || undefined,
+                memo: paymentModal.memo || undefined
+            };
+            await api.post(endpoint, payload);
+            notify(t("accounting.paymentRecorded", "Zahlung verbucht."), "success");
+            closePaymentModal();
+            setRefreshFlag((flag) => flag + 1);
+        } catch (error) {
+            console.error("Failed to record payment", error);
+            notify(t("accounting.paymentFailed", "Zahlung konnte nicht verbucht werden."), "error");
         }
     };
 
@@ -201,7 +352,17 @@ const AdminAccountingPage = () => {
                         <ul className="list-unstyled">
                             {receivables.map((invoice) => (
                                 <li key={invoice.id}>
-                                    {invoice.invoiceNumber} – {invoice.customerName} – CHF {Number(invoice.amount ?? 0).toFixed(2)}
+                                    <div className="invoice-line">
+                                        <div>
+                                            {invoice.invoiceNumber} – {invoice.customerName} – CHF {Number(invoice.openAmount ?? invoice.amount ?? 0).toFixed(2)}
+                                            {invoice.amountPaid > 0 && (
+                                                <span className="muted"> ({t("accounting.paid", "bezahlt")}: CHF {Number(invoice.amountPaid).toFixed(2)})</span>
+                                            )}
+                                        </div>
+                                        <button type="button" className="secondary" onClick={() => openPaymentModal(invoice, "receivable")}>
+                                            {t("accounting.recordPayment", "Zahlung erfassen")}
+                                        </button>
+                                    </div>
                                 </li>
                             ))}
                             {receivables.length === 0 && <li>{t("accounting.noReceivables", "Keine offenen Debitoren")}</li>}
@@ -212,14 +373,254 @@ const AdminAccountingPage = () => {
                         <ul className="list-unstyled">
                             {payables.map((invoice) => (
                                 <li key={invoice.id}>
-                                    {invoice.invoiceNumber} – {invoice.vendorName} – CHF {Number(invoice.amount ?? 0).toFixed(2)}
+                                    <div className="invoice-line">
+                                        <div>
+                                            {invoice.invoiceNumber} – {invoice.vendorName} – CHF {Number(invoice.openAmount ?? invoice.amount ?? 0).toFixed(2)}
+                                            {invoice.amountPaid > 0 && (
+                                                <span className="muted"> ({t("accounting.paid", "bezahlt")}: CHF {Number(invoice.amountPaid).toFixed(2)})</span>
+                                            )}
+                                        </div>
+                                        <button type="button" className="secondary" onClick={() => openPaymentModal(invoice, "payable")}>
+                                            {t("accounting.recordPayment", "Zahlung erfassen")}
+                                        </button>
+                                    </div>
                                 </li>
                             ))}
                             {payables.length === 0 && <li>{t("accounting.noPayables", "Keine offenen Kreditoren")}</li>}
                         </ul>
                     </article>
                 </section>
+
+                <section className="card">
+                    <div className="section-header">
+                        <h2>{t("accounting.manualJournal", "Manuelle Buchung")}</h2>
+                        <button type="button" className="secondary" onClick={() => setShowJournalForm((prev) => !prev)}>
+                            {showJournalForm
+                                ? t("accounting.closeJournalForm", "Schließen")
+                                : t("accounting.newJournalEntry", "Neue Buchung")}
+                        </button>
+                    </div>
+                    {showJournalForm && (
+                        <form className="form-grid" onSubmit={handleJournalSubmit}>
+                            <label>
+                                {t("accounting.date", "Datum")}
+                                <input
+                                    type="date"
+                                    value={journalForm.entryDate}
+                                    onChange={(e) => setJournalForm({ ...journalForm, entryDate: e.target.value })}
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.description", "Beschreibung")}
+                                <input
+                                    type="text"
+                                    value={journalForm.description}
+                                    onChange={(e) => setJournalForm({ ...journalForm, description: e.target.value })}
+                                    required
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.documentRef", "Belegnummer")}
+                                <input
+                                    type="text"
+                                    value={journalForm.documentReference}
+                                    onChange={(e) => setJournalForm({ ...journalForm, documentReference: e.target.value })}
+                                />
+                            </label>
+
+                            <div className="journal-lines">
+                                {journalForm.lines.map((line, index) => (
+                                    <div key={index} className="journal-line">
+                                        <select
+                                            value={line.accountId}
+                                            onChange={(e) => updateJournalLine(index, "accountId", e.target.value)}
+                                            required
+                                        >
+                                            <option value="">{t("accounting.chooseAccount", "Konto wählen")}</option>
+                                            {accounts.map((account) => (
+                                                <option key={account.id} value={account.id}>
+                                                    {account.code} – {account.name}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            placeholder={t("accounting.debit", "Soll")}
+                                            value={line.debit}
+                                            onChange={(e) => updateJournalLine(index, "debit", e.target.value)}
+                                        />
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            placeholder={t("accounting.credit", "Haben")}
+                                            value={line.credit}
+                                            onChange={(e) => updateJournalLine(index, "credit", e.target.value)}
+                                        />
+                                        <input
+                                            type="text"
+                                            placeholder={t("accounting.memo", "Memo")}
+                                            value={line.memo}
+                                            onChange={(e) => updateJournalLine(index, "memo", e.target.value)}
+                                            required
+                                        />
+                                        {journalForm.lines.length > 1 && (
+                                            <button type="button" className="ghost" onClick={() => removeJournalLine(index)}>
+                                                {t("common.remove", "Entfernen")}
+                                            </button>
+                                        )}
+                                    </div>
+                                ))}
+                                <button type="button" className="secondary" onClick={addJournalLine}>
+                                    {t("accounting.addLine", "Zeile hinzufügen")}
+                                </button>
+                            </div>
+                            <button type="submit" className="primary">
+                                {t("accounting.saveJournal", "Buchung speichern")}
+                            </button>
+                        </form>
+                    )}
+                </section>
+
+                <section className="card-grid">
+                    <article className="card">
+                        <h2>{t("accounting.assetFormTitle", "Neue Anlage")}</h2>
+                        <form className="form-grid" onSubmit={handleAssetSubmit}>
+                            <label>
+                                {t("accounting.assetName", "Name")}
+                                <input
+                                    type="text"
+                                    value={assetForm.assetName}
+                                    onChange={(e) => setAssetForm({ ...assetForm, assetName: e.target.value })}
+                                    required
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.acquisitionDate", "Anschaffungsdatum")}
+                                <input
+                                    type="date"
+                                    value={assetForm.acquisitionDate}
+                                    onChange={(e) => setAssetForm({ ...assetForm, acquisitionDate: e.target.value })}
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.acquisitionCost", "Kosten")}
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    value={assetForm.acquisitionCost}
+                                    onChange={(e) => setAssetForm({ ...assetForm, acquisitionCost: e.target.value })}
+                                    required
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.usefulLife", "Nutzungsdauer (Monate)")}
+                                <input
+                                    type="number"
+                                    value={assetForm.usefulLifeMonths}
+                                    onChange={(e) => setAssetForm({ ...assetForm, usefulLifeMonths: e.target.value })}
+                                    required
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.residualValue", "Restwert")}
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    value={assetForm.residualValue}
+                                    onChange={(e) => setAssetForm({ ...assetForm, residualValue: e.target.value })}
+                                />
+                            </label>
+                            <button type="submit" className="primary">{t("accounting.saveAsset", "Speichern")}</button>
+                        </form>
+                    </article>
+                    <article className="card">
+                        <h2>{t("accounting.assetList", "Anlagenverzeichnis")}</h2>
+                        <div className="table-wrapper">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>{t("accounting.assetName", "Name")}</th>
+                                        <th>{t("accounting.acquisitionDate", "Anschaffungsdatum")}</th>
+                                        <th>{t("accounting.acquisitionCost", "Kosten")}</th>
+                                        <th>{t("accounting.accumulatedDepreciation", "Kumulierte Abschreibung")}</th>
+                                        <th>{t("accounting.status", "Status")}</th>
+                                        <th>{t("accounting.actions", "Aktionen")}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {assets.map((asset) => (
+                                        <tr key={asset.id}>
+                                            <td>{asset.assetName}</td>
+                                            <td>{asset.acquisitionDate}</td>
+                                            <td>CHF {Number(asset.acquisitionCost ?? 0).toFixed(2)}</td>
+                                            <td>CHF {Number(asset.accumulatedDepreciation ?? 0).toFixed(2)}</td>
+                                            <td>{asset.status}</td>
+                                            <td>
+                                                <button
+                                                    type="button"
+                                                    className="secondary"
+                                                    onClick={() => handleDepreciation(asset.id)}
+                                                    disabled={asset.status !== "ACTIVE"}
+                                                >
+                                                    {t("accounting.runDepreciation", "Abschreibung buchen")}
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {assets.length === 0 && (
+                                        <tr>
+                                            <td colSpan="6">{t("accounting.noAssets", "Keine Anlagen erfasst")}</td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </article>
+                </section>
             </main>
+
+            {paymentModal.open && (
+                <div className="modal-backdrop">
+                    <div className="modal">
+                        <h3>{paymentModal.type === "receivable"
+                            ? t("accounting.recordReceivablePayment", "Debitorenzahlung erfassen")
+                            : t("accounting.recordPayablePayment", "Kreditorenzahlung erfassen")}</h3>
+                        <form onSubmit={handlePaymentSubmit} className="form-grid">
+                            <label>
+                                {t("accounting.amount", "Betrag")}
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    value={paymentModal.amount}
+                                    onChange={(e) => setPaymentModal((prev) => ({ ...prev, amount: e.target.value }))}
+                                    required
+                                />
+                            </label>
+                            <label>
+                                {t("accounting.paymentDate", "Zahlungsdatum")}
+                                <input
+                                    type="date"
+                                    value={paymentModal.paymentDate}
+                                    onChange={(e) => setPaymentModal((prev) => ({ ...prev, paymentDate: e.target.value }))}
+                                />
+                            </label>
+                            <label>
+                                Memo
+                                <input
+                                    type="text"
+                                    value={paymentModal.memo}
+                                    onChange={(e) => setPaymentModal((prev) => ({ ...prev, memo: e.target.value }))}
+                                />
+                            </label>
+                            <div className="modal-actions">
+                                <button type="submit" className="primary">{t("accounting.recordPayment", "Zahlung erfassen")}</button>
+                                <button type="button" className="ghost" onClick={closePaymentModal}>{t("common.cancel", "Abbrechen")}</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/Chrono-frontend/src/pages/AdminBanking/BankingOperationsPage.jsx
+++ b/Chrono-frontend/src/pages/AdminBanking/BankingOperationsPage.jsx
@@ -21,6 +21,10 @@ const BankingOperationsPage = () => {
     const [batchMeta, setBatchMeta] = useState({ total: 0 });
 
     const [accountForm, setAccountForm] = useState(initialAccount);
+    const [batchForm, setBatchForm] = useState({ bankAccountId: "", instructions: [] });
+    const [instructionDraft, setInstructionDraft] = useState({ creditorName: "", creditorIban: "", amount: "", currency: "CHF", reference: "" });
+    const [signatureForm, setSignatureForm] = useState({ documentType: "", documentPath: "", email: "" });
+    const [messageForm, setMessageForm] = useState({ recipient: "", subject: "", body: "", transport: "EBICS" });
 
     const load = useCallback(async () => {
         try {
@@ -50,7 +54,6 @@ const BankingOperationsPage = () => {
             setBatchMeta({
                 total: totalBatches,
             });
-
         } catch (error) {
             console.error("Failed to load banking data", error);
             notify(t("banking.loadError", "Bankdaten konnten nicht geladen werden."), "error");
@@ -71,6 +74,102 @@ const BankingOperationsPage = () => {
         } catch (error) {
             console.error("Failed to save account", error);
             notify(t("banking.accountSaveFailed", "Bankkonto konnte nicht angelegt werden."), "error");
+        }
+    };
+
+    const addInstruction = () => {
+        if (!instructionDraft.creditorName || !instructionDraft.amount) {
+            notify(t("banking.instructionIncomplete", "Bitte Empfänger und Betrag angeben."), "warning");
+            return;
+        }
+        setBatchForm((prev) => ({
+            ...prev,
+            instructions: [...prev.instructions, { ...instructionDraft }]
+        }));
+        setInstructionDraft({ creditorName: "", creditorIban: "", amount: "", currency: "CHF", reference: "" });
+    };
+
+    const removeInstruction = (index) => {
+        setBatchForm((prev) => ({
+            ...prev,
+            instructions: prev.instructions.filter((_, idx) => idx !== index)
+        }));
+    };
+
+    const handleBatchSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                bankAccountId: Number(batchForm.bankAccountId),
+                instructions: batchForm.instructions.map((instruction) => ({
+                    creditorName: instruction.creditorName,
+                    creditorIban: instruction.creditorIban,
+                    amount: Number(instruction.amount || 0),
+                    currency: instruction.currency || "CHF",
+                    reference: instruction.reference || undefined
+                }))
+            };
+            if (!payload.bankAccountId || payload.instructions.length === 0) {
+                notify(t("banking.noInstructions", "Bitte ein Konto und mindestens eine Anweisung auswählen."), "warning");
+                return;
+            }
+            await api.post("/api/banking/batches", payload);
+            notify(t("banking.batchCreated", "Zahlungsauftrag erstellt."), "success");
+            setBatchForm({ bankAccountId: "", instructions: [] });
+            await load();
+        } catch (error) {
+            console.error("Failed to create payment batch", error);
+            notify(t("banking.batchCreateFailed", "Zahlungsauftrag konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleApprove = async (batchId) => {
+        try {
+            await api.post(`/api/banking/batches/${batchId}/approve`);
+            notify(t("banking.batchApproved", "Auftrag freigegeben."), "success");
+            await load();
+        } catch (error) {
+            console.error("Failed to approve batch", error);
+            notify(t("banking.batchApproveFailed", "Freigabe fehlgeschlagen."), "error");
+        }
+    };
+
+    const handleTransmit = async (batchId) => {
+        const reference = prompt(t("banking.transmitReference", "Referenz für die Übermittlung"));
+        if (reference === null) {
+            return;
+        }
+        try {
+            await api.post(`/api/banking/batches/${batchId}/transmit`, { reference });
+            notify(t("banking.batchTransmitted", "Auftrag übermittelt."), "success");
+            await load();
+        } catch (error) {
+            console.error("Failed to transmit batch", error);
+            notify(t("banking.batchTransmitFailed", "Übermittlung fehlgeschlagen."), "error");
+        }
+    };
+
+    const handleSignatureSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            await api.post("/api/banking/signatures", signatureForm);
+            notify(t("banking.signatureRequested", "Signatur angefordert."), "success");
+            setSignatureForm({ documentType: "", documentPath: "", email: "" });
+        } catch (error) {
+            console.error("Failed to request signature", error);
+            notify(t("banking.signatureFailed", "Signaturanforderung fehlgeschlagen."), "error");
+        }
+    };
+
+    const handleMessageSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            await api.post("/api/banking/messages", messageForm);
+            notify(t("banking.messageSent", "Nachricht gesendet."), "success");
+            setMessageForm({ recipient: "", subject: "", body: "", transport: "EBICS" });
+        } catch (error) {
+            console.error("Failed to send secure message", error);
+            notify(t("banking.messageFailed", "Nachricht konnte nicht gesendet werden."), "error");
         }
     };
 
@@ -140,6 +239,68 @@ const BankingOperationsPage = () => {
                 </section>
 
                 <section className="card">
+                    <h2>{t("banking.createBatch", "Neuer Zahlungsauftrag")}</h2>
+                    <form className="form-grid" onSubmit={handleBatchSubmit}>
+                        <label>
+                            {t("banking.account", "Bankkonto")}
+                            <select value={batchForm.bankAccountId} onChange={(e) => setBatchForm({ ...batchForm, bankAccountId: e.target.value })} required>
+                                <option value="">{t("banking.chooseAccount", "Konto wählen")}</option>
+                                {accounts.map((account) => (
+                                    <option key={account.id} value={account.id}>{account.name} – {account.iban}</option>
+                                ))}
+                            </select>
+                        </label>
+                        <div className="instruction-builder">
+                            <h3>{t("banking.instructions", "Zahlungsanweisungen")}</h3>
+                            <div className="instruction-form">
+                                <input
+                                    type="text"
+                                    placeholder={t("banking.creditorName", "Empfängername")}
+                                    value={instructionDraft.creditorName}
+                                    onChange={(e) => setInstructionDraft({ ...instructionDraft, creditorName: e.target.value })}
+                                />
+                                <input
+                                    type="text"
+                                    placeholder="IBAN"
+                                    value={instructionDraft.creditorIban}
+                                    onChange={(e) => setInstructionDraft({ ...instructionDraft, creditorIban: e.target.value })}
+                                />
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    placeholder={t("banking.amount", "Betrag")}
+                                    value={instructionDraft.amount}
+                                    onChange={(e) => setInstructionDraft({ ...instructionDraft, amount: e.target.value })}
+                                />
+                                <input
+                                    type="text"
+                                    placeholder={t("banking.currency", "Währung")}
+                                    value={instructionDraft.currency}
+                                    onChange={(e) => setInstructionDraft({ ...instructionDraft, currency: e.target.value })}
+                                />
+                                <input
+                                    type="text"
+                                    placeholder={t("banking.reference", "Verwendungszweck")}
+                                    value={instructionDraft.reference}
+                                    onChange={(e) => setInstructionDraft({ ...instructionDraft, reference: e.target.value })}
+                                />
+                                <button type="button" className="secondary" onClick={addInstruction}>{t("banking.addInstruction", "Hinzufügen")}</button>
+                            </div>
+                            <ul className="list-unstyled">
+                                {batchForm.instructions.map((instruction, index) => (
+                                    <li key={`${instruction.creditorName}-${index}`} className="instruction-item">
+                                        <span>{instruction.creditorName} – {Number(instruction.amount || 0).toFixed(2)} {instruction.currency}</span>
+                                        <button type="button" className="link-button danger" onClick={() => removeInstruction(index)}>{t("common.delete", "Löschen")}</button>
+                                    </li>
+                                ))}
+                                {batchForm.instructions.length === 0 && <li>{t("banking.noInstructions", "Keine Anweisungen hinzugefügt")}</li>}
+                            </ul>
+                        </div>
+                        <button type="submit" className="primary">{t("banking.saveBatch", "Auftrag anlegen")}</button>
+                    </form>
+                </section>
+
+                <section className="card">
                     <div className="section-header">
                         <div>
                             <h2>{t("banking.pendingBatches", "Offene Zahlungsaufträge")}</h2>
@@ -164,7 +325,17 @@ const BankingOperationsPage = () => {
                                         <td>{batch.id}</td>
                                         <td>{batch.status}</td>
                                         <td>{batch.createdAt}</td>
-                                        <td>{batch.instructions?.length ?? 0}</td>
+                                        <td>
+                                            {batch.instructions?.length ?? 0}
+                                            <div className="action-row">
+                                                <button type="button" className="secondary" onClick={() => handleApprove(batch.id)}>
+                                                    {t("banking.approve", "Freigeben")}
+                                                </button>
+                                                <button type="button" className="ghost" onClick={() => handleTransmit(batch.id)}>
+                                                    {t("banking.transmit", "Übermitteln")}
+                                                </button>
+                                            </div>
+                                        </td>
                                     </tr>
                                 ))}
                                 {batches.length === 0 && (
@@ -175,6 +346,53 @@ const BankingOperationsPage = () => {
                             </tbody>
                         </table>
                     </div>
+                </section>
+
+                <section className="card-grid">
+                    <article className="card">
+                        <h2>{t("banking.signature", "Digitale Signatur")}</h2>
+                        <form className="form-grid" onSubmit={handleSignatureSubmit}>
+                            <label>
+                                {t("banking.documentType", "Dokumenttyp")}
+                                <input type="text" value={signatureForm.documentType} onChange={(e) => setSignatureForm({ ...signatureForm, documentType: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("banking.documentPath", "Dokumentpfad")}
+                                <input type="text" value={signatureForm.documentPath} onChange={(e) => setSignatureForm({ ...signatureForm, documentPath: e.target.value })} required />
+                            </label>
+                            <label>
+                                Email
+                                <input type="email" value={signatureForm.email} onChange={(e) => setSignatureForm({ ...signatureForm, email: e.target.value })} required />
+                            </label>
+                            <button type="submit" className="primary">{t("banking.requestSignature", "Signatur anfordern")}</button>
+                        </form>
+                    </article>
+                    <article className="card">
+                        <h2>{t("banking.secureMessage", "Sichere Nachricht")}</h2>
+                        <form className="form-grid" onSubmit={handleMessageSubmit}>
+                            <label>
+                                {t("banking.recipient", "Empfänger")}
+                                <input type="text" value={messageForm.recipient} onChange={(e) => setMessageForm({ ...messageForm, recipient: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("banking.subject", "Betreff")}
+                                <input type="text" value={messageForm.subject} onChange={(e) => setMessageForm({ ...messageForm, subject: e.target.value })} required />
+                            </label>
+                            <label className="full-width">
+                                {t("banking.message", "Nachricht")}
+                                <textarea value={messageForm.body} onChange={(e) => setMessageForm({ ...messageForm, body: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("banking.transport", "Kanal")}
+                                <select value={messageForm.transport} onChange={(e) => setMessageForm({ ...messageForm, transport: e.target.value })}>
+                                    <option value="EBICS">EBICS</option>
+                                    <option value="SWIFT">SWIFT</option>
+                                    <option value="EMAIL">Email</option>
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("banking.send", "Senden")}</button>
+                        </form>
+                    </article>
                 </section>
             </main>
         </div>

--- a/Chrono-frontend/src/pages/CRM/CrmDashboard.jsx
+++ b/Chrono-frontend/src/pages/CRM/CrmDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import Navbar from "../../components/Navbar.jsx";
 import api from "../../utils/api.js";
 import { useNotification } from "../../context/NotificationContext.jsx";
@@ -12,25 +12,260 @@ const CrmDashboard = () => {
     const [leads, setLeads] = useState([]);
     const [opportunities, setOpportunities] = useState([]);
     const [campaigns, setCampaigns] = useState([]);
+    const [customers, setCustomers] = useState([]);
+    const [selectedCustomer, setSelectedCustomer] = useState(null);
+    const [customerContacts, setCustomerContacts] = useState([]);
+    const [customerActivities, setCustomerActivities] = useState([]);
+    const [customerAddresses, setCustomerAddresses] = useState([]);
+    const [leadFilter, setLeadFilter] = useState("QUALIFIED");
+    const [oppFilter, setOppFilter] = useState("NEGOTIATION");
+    const [campaignFilter, setCampaignFilter] = useState("ACTIVE");
+    const [leadForm, setLeadForm] = useState({ companyName: "", contactName: "", email: "", status: "NEW" });
+    const [opportunityForm, setOpportunityForm] = useState({ title: "", value: "", probability: "", stage: "QUALIFICATION" });
+    const [campaignForm, setCampaignForm] = useState({ name: "", status: "PLANNED", channel: "", startDate: "", endDate: "" });
+    const [addressForm, setAddressForm] = useState({ id: null, street: "", postalCode: "", city: "", country: "", type: "OFFICE" });
+    const [contactForm, setContactForm] = useState({ id: null, firstName: "", lastName: "", email: "", phone: "", role: "" });
+    const [activityForm, setActivityForm] = useState({ id: null, notes: "", timestamp: "", contactId: "", type: "NOTE" });
 
     useEffect(() => {
         const load = async () => {
             try {
-                const [leadRes, oppRes, campRes] = await Promise.all([
-                    api.get("/api/crm/leads", { params: { status: "QUALIFIED" } }),
-                    api.get("/api/crm/opportunities", { params: { stage: "NEGOTIATION" } }),
-                    api.get("/api/crm/campaigns", { params: { status: "ACTIVE" } })
+                const [leadRes, oppRes, campRes, customerRes] = await Promise.all([
+                    api.get("/api/crm/leads", { params: { status: leadFilter } }),
+                    api.get("/api/crm/opportunities", { params: { stage: oppFilter } }),
+                    api.get("/api/crm/campaigns", { params: { status: campaignFilter } }),
+                    api.get("/api/customers")
                 ]);
                 setLeads(leadRes.data ?? []);
                 setOpportunities(oppRes.data ?? []);
                 setCampaigns(campRes.data ?? []);
+                setCustomers(customerRes.data ?? []);
             } catch (error) {
                 console.error("Failed to load CRM data", error);
                 notify(t("crm.loadError", "CRM-Daten konnten nicht geladen werden."), "error");
             }
         };
         load();
-    }, [notify, t]);
+    }, [notify, t, leadFilter, oppFilter, campaignFilter]);
+
+    const loadCustomerDetails = async (customer) => {
+        if (!customer) {
+            setSelectedCustomer(null);
+            setCustomerContacts([]);
+            setCustomerActivities([]);
+            setCustomerAddresses([]);
+            return;
+        }
+        setSelectedCustomer(customer);
+        try {
+            const [contactRes, activityRes, addressRes] = await Promise.all([
+                api.get(`/api/crm/customers/${customer.id}/contacts`),
+                api.get(`/api/crm/customers/${customer.id}/activities`),
+                api.get(`/api/crm/customers/${customer.id}/addresses`)
+            ]);
+            setCustomerContacts(contactRes.data ?? []);
+            setCustomerActivities(activityRes.data ?? []);
+            setCustomerAddresses(addressRes.data ?? []);
+        } catch (error) {
+            console.error("Failed to load customer details", error);
+            notify(t("crm.customerLoadFailed", "Kundendetails konnten nicht geladen werden."), "error");
+        }
+    };
+
+    const resetCustomerForms = () => {
+        setAddressForm({ id: null, street: "", postalCode: "", city: "", country: "", type: "OFFICE" });
+        setContactForm({ id: null, firstName: "", lastName: "", email: "", phone: "", role: "" });
+        setActivityForm({ id: null, notes: "", timestamp: "", contactId: "", type: "NOTE" });
+    };
+
+    const handleLeadSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            await api.post("/api/crm/leads", leadForm);
+            notify(t("crm.leadCreated", "Lead erstellt."), "success");
+            setLeadForm({ companyName: "", contactName: "", email: "", status: "NEW" });
+            setLeadFilter("NEW");
+        } catch (error) {
+            console.error("Failed to create lead", error);
+            notify(t("crm.leadCreateFailed", "Lead konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleLeadStatusChange = async (leadId, status) => {
+        try {
+            await api.patch(`/api/crm/leads/${leadId}`, { status });
+            notify(t("crm.leadUpdated", "Lead aktualisiert."), "success");
+            setLeadFilter(status);
+        } catch (error) {
+            console.error("Failed to update lead", error);
+            notify(t("crm.leadUpdateFailed", "Lead konnte nicht aktualisiert werden."), "error");
+        }
+    };
+
+    const handleOpportunitySubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                title: opportunityForm.title,
+                value: opportunityForm.value ? Number(opportunityForm.value) : undefined,
+                probability: opportunityForm.probability ? Number(opportunityForm.probability) : undefined,
+                stage: opportunityForm.stage
+            };
+            await api.post("/api/crm/opportunities", payload);
+            notify(t("crm.opportunityCreated", "Opportunity erstellt."), "success");
+            setOpportunityForm({ title: "", value: "", probability: "", stage: "QUALIFICATION" });
+            setOppFilter("QUALIFICATION");
+        } catch (error) {
+            console.error("Failed to create opportunity", error);
+            notify(t("crm.opportunityCreateFailed", "Opportunity konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleOpportunityStageChange = async (id, stage) => {
+        try {
+            await api.patch(`/api/crm/opportunities/${id}`, { stage });
+            notify(t("crm.opportunityUpdated", "Opportunity aktualisiert."), "success");
+            setOppFilter(stage);
+        } catch (error) {
+            console.error("Failed to update opportunity", error);
+            notify(t("crm.opportunityUpdateFailed", "Opportunity konnte nicht aktualisiert werden."), "error");
+        }
+    };
+
+    const handleCampaignSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            await api.post("/api/crm/campaigns", campaignForm);
+            notify(t("crm.campaignCreated", "Kampagne erstellt."), "success");
+            setCampaignForm({ name: "", status: "PLANNED", channel: "", startDate: "", endDate: "" });
+            setCampaignFilter("PLANNED");
+        } catch (error) {
+            console.error("Failed to create campaign", error);
+            notify(t("crm.campaignCreateFailed", "Kampagne konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleCampaignUpdate = async (id, status) => {
+        try {
+            await api.patch(`/api/crm/campaigns/${id}`, { status });
+            notify(t("crm.campaignUpdated", "Kampagne aktualisiert."), "success");
+            setCampaignFilter(status);
+        } catch (error) {
+            console.error("Failed to update campaign", error);
+            notify(t("crm.campaignUpdateFailed", "Kampagne konnte nicht aktualisiert werden."), "error");
+        }
+    };
+
+    const handleAddressSubmit = async (event) => {
+        event.preventDefault();
+        if (!selectedCustomer) return;
+        try {
+            const payload = { type: addressForm.type, street: addressForm.street, postalCode: addressForm.postalCode, city: addressForm.city, country: addressForm.country };
+            const endpoint = addressForm.id
+                ? `/api/crm/customers/${selectedCustomer.id}/addresses/${addressForm.id}`
+                : `/api/crm/customers/${selectedCustomer.id}/addresses`;
+            if (addressForm.id) {
+                await api.put(endpoint, payload);
+            } else {
+                await api.post(endpoint, payload);
+            }
+            notify(t("crm.addressSaved", "Adresse gespeichert."), "success");
+            await loadCustomerDetails(selectedCustomer);
+            setAddressForm({ id: null, street: "", postalCode: "", city: "", country: "", type: "OFFICE" });
+        } catch (error) {
+            console.error("Failed to save address", error);
+            notify(t("crm.addressSaveFailed", "Adresse konnte nicht gespeichert werden."), "error");
+        }
+    };
+
+    const handleAddressDelete = async (addressId) => {
+        if (!selectedCustomer) return;
+        try {
+            await api.delete(`/api/crm/customers/${selectedCustomer.id}/addresses/${addressId}`);
+            notify(t("crm.addressDeleted", "Adresse gelöscht."), "success");
+            await loadCustomerDetails(selectedCustomer);
+        } catch (error) {
+            console.error("Failed to delete address", error);
+            notify(t("crm.addressDeleteFailed", "Adresse konnte nicht gelöscht werden."), "error");
+        }
+    };
+
+    const handleContactSubmit = async (event) => {
+        event.preventDefault();
+        if (!selectedCustomer) return;
+        try {
+            const payload = { firstName: contactForm.firstName, lastName: contactForm.lastName, email: contactForm.email, phone: contactForm.phone, role: contactForm.role };
+            const endpoint = contactForm.id
+                ? `/api/crm/customers/${selectedCustomer.id}/contacts/${contactForm.id}`
+                : `/api/crm/customers/${selectedCustomer.id}/contacts`;
+            if (contactForm.id) {
+                await api.put(endpoint, payload);
+            } else {
+                await api.post(endpoint, payload);
+            }
+            notify(t("crm.contactSaved", "Kontakt gespeichert."), "success");
+            await loadCustomerDetails(selectedCustomer);
+            setContactForm({ id: null, firstName: "", lastName: "", email: "", phone: "", role: "" });
+        } catch (error) {
+            console.error("Failed to save contact", error);
+            notify(t("crm.contactSaveFailed", "Kontakt konnte nicht gespeichert werden."), "error");
+        }
+    };
+
+    const handleContactDelete = async (id) => {
+        if (!selectedCustomer) return;
+        try {
+            await api.delete(`/api/crm/customers/${selectedCustomer.id}/contacts/${id}`);
+            notify(t("crm.contactDeleted", "Kontakt gelöscht."), "success");
+            await loadCustomerDetails(selectedCustomer);
+        } catch (error) {
+            console.error("Failed to delete contact", error);
+            notify(t("crm.contactDeleteFailed", "Kontakt konnte nicht gelöscht werden."), "error");
+        }
+    };
+
+    const handleActivitySubmit = async (event) => {
+        event.preventDefault();
+        if (!selectedCustomer) return;
+        try {
+            const payload = {
+                type: activityForm.type,
+                notes: activityForm.notes,
+                contactId: activityForm.contactId ? Number(activityForm.contactId) : undefined,
+                timestamp: activityForm.timestamp ? new Date(activityForm.timestamp).toISOString() : undefined
+            };
+            const endpoint = activityForm.id
+                ? `/api/crm/customers/${selectedCustomer.id}/activities/${activityForm.id}`
+                : `/api/crm/customers/${selectedCustomer.id}/activities`;
+            if (activityForm.id) {
+                await api.put(endpoint, payload);
+            } else {
+                await api.post(endpoint, payload);
+            }
+            notify(t("crm.activitySaved", "Aktivität gespeichert."), "success");
+            await loadCustomerDetails(selectedCustomer);
+            setActivityForm({ id: null, notes: "", timestamp: "", contactId: "", type: "NOTE" });
+        } catch (error) {
+            console.error("Failed to save activity", error);
+            notify(t("crm.activitySaveFailed", "Aktivität konnte nicht gespeichert werden."), "error");
+        }
+    };
+
+    const handleActivityDelete = async (id) => {
+        if (!selectedCustomer) return;
+        try {
+            await api.delete(`/api/crm/customers/${selectedCustomer.id}/activities/${id}`);
+            notify(t("crm.activityDeleted", "Aktivität gelöscht."), "success");
+            await loadCustomerDetails(selectedCustomer);
+        } catch (error) {
+            console.error("Failed to delete activity", error);
+            notify(t("crm.activityDeleteFailed", "Aktivität konnte nicht gelöscht werden."), "error");
+        }
+    };
+
+    const leadStatuses = useMemo(() => ["NEW", "QUALIFIED", "CONVERTED", "DISQUALIFIED"], []);
+    const opportunityStages = useMemo(() => ["QUALIFICATION", "PROPOSAL", "NEGOTIATION", "WON", "LOST"], []);
+    const campaignStatuses = useMemo(() => ["PLANNED", "ACTIVE", "COMPLETED", "ARCHIVED"], []);
 
     return (
         <div className="admin-page crm-page">
@@ -44,53 +279,341 @@ const CrmDashboard = () => {
 
                 <section className="card-grid">
                     <article className="card">
-                        <h2>{t("crm.leads", "Qualifizierte Leads")}</h2>
-                        <p className="metric">{leads.length}</p>
+                        <h2>{t("crm.customerOverview", "Kunden")}</h2>
+                        <ul className="list-unstyled">
+                            {customers.map((customer) => (
+                                <li key={customer.id}>
+                                    <button type="button" className={`link-button${selectedCustomer?.id === customer.id ? " active" : ""}`} onClick={() => loadCustomerDetails(customer)}>
+                                        {customer.name}
+                                    </button>
+                                </li>
+                            ))}
+                            {customers.length === 0 && <li>{t("crm.noCustomers", "Keine Kunden")}</li>}
+                        </ul>
                     </article>
-                    <article className="card">
-                        <h2>{t("crm.pipeline", "Pipeline (Verhandlungen)")}</h2>
-                        <p className="metric">{opportunities.length}</p>
-                    </article>
-                    <article className="card">
-                        <h2>{t("crm.campaigns", "Aktive Kampagnen")}</h2>
-                        <p className="metric">{campaigns.length}</p>
-                    </article>
+                    {selectedCustomer && (
+                        <article className="card customer-detail">
+                            <header>
+                                <h2>{selectedCustomer.name}</h2>
+                                <button type="button" className="ghost" onClick={() => { setSelectedCustomer(null); resetCustomerForms(); }}>{t("common.close", "Schließen")}</button>
+                            </header>
+                            <div className="detail-grid">
+                                <section>
+                                    <h3>{t("crm.addresses", "Adressen")}</h3>
+                                    <ul className="list-unstyled">
+                                        {customerAddresses.map((address) => (
+                                            <li key={address.id}>
+                                                <div>
+                                                    <strong>{address.type}</strong>: {address.street}, {address.postalCode} {address.city}
+                                                </div>
+                                                <div className="action-row">
+                                                    <button type="button" className="link-button" onClick={() => setAddressForm({ id: address.id, street: address.street ?? "", postalCode: address.postalCode ?? "", city: address.city ?? "", country: address.country ?? "", type: address.type ?? "OFFICE" })}>{t("common.edit", "Bearbeiten")}</button>
+                                                    <button type="button" className="link-button danger" onClick={() => handleAddressDelete(address.id)}>{t("common.delete", "Löschen")}</button>
+                                                </div>
+                                            </li>
+                                        ))}
+                                        {customerAddresses.length === 0 && <li>{t("crm.noAddresses", "Keine Adressen")}</li>}
+                                    </ul>
+                                    <form className="form-grid" onSubmit={handleAddressSubmit}>
+                                        <label>
+                                            {t("crm.street", "Straße")}
+                                            <input type="text" value={addressForm.street} onChange={(e) => setAddressForm({ ...addressForm, street: e.target.value })} required />
+                                        </label>
+                                        <label>
+                                            {t("crm.postalCode", "PLZ")}
+                                            <input type="text" value={addressForm.postalCode} onChange={(e) => setAddressForm({ ...addressForm, postalCode: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.city", "Ort")}
+                                            <input type="text" value={addressForm.city} onChange={(e) => setAddressForm({ ...addressForm, city: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.country", "Land")}
+                                            <input type="text" value={addressForm.country} onChange={(e) => setAddressForm({ ...addressForm, country: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.addressType", "Typ")}
+                                            <select value={addressForm.type} onChange={(e) => setAddressForm({ ...addressForm, type: e.target.value })}>
+                                                <option value="OFFICE">{t("crm.office", "Büro")}</option>
+                                                <option value="BILLING">{t("crm.billing", "Rechnung")}</option>
+                                                <option value="SHIPPING">{t("crm.shipping", "Versand")}</option>
+                                            </select>
+                                        </label>
+                                        <div className="form-actions">
+                                            <button type="submit" className="primary">{addressForm.id ? t("common.update", "Aktualisieren") : t("common.add", "Hinzufügen")}</button>
+                                            {addressForm.id && <button type="button" className="ghost" onClick={() => setAddressForm({ id: null, street: "", postalCode: "", city: "", country: "", type: "OFFICE" })}>{t("common.cancel", "Abbrechen")}</button>}
+                                        </div>
+                                    </form>
+                                </section>
+                                <section>
+                                    <h3>{t("crm.contacts", "Kontakte")}</h3>
+                                    <ul className="list-unstyled">
+                                        {customerContacts.map((contact) => (
+                                            <li key={contact.id}>
+                                                <div>
+                                                    <strong>{contact.firstName} {contact.lastName}</strong> – {contact.email}
+                                                    {contact.role && <span className="muted"> ({contact.role})</span>}
+                                                </div>
+                                                <div className="action-row">
+                                                    <button type="button" className="link-button" onClick={() => setContactForm({ id: contact.id, firstName: contact.firstName ?? "", lastName: contact.lastName ?? "", email: contact.email ?? "", phone: contact.phone ?? "", role: contact.role ?? "" })}>{t("common.edit", "Bearbeiten")}</button>
+                                                    <button type="button" className="link-button danger" onClick={() => handleContactDelete(contact.id)}>{t("common.delete", "Löschen")}</button>
+                                                </div>
+                                            </li>
+                                        ))}
+                                        {customerContacts.length === 0 && <li>{t("crm.noContacts", "Keine Kontakte")}</li>}
+                                    </ul>
+                                    <form className="form-grid" onSubmit={handleContactSubmit}>
+                                        <label>
+                                            {t("crm.firstName", "Vorname")}
+                                            <input type="text" value={contactForm.firstName} onChange={(e) => setContactForm({ ...contactForm, firstName: e.target.value })} required />
+                                        </label>
+                                        <label>
+                                            {t("crm.lastName", "Nachname")}
+                                            <input type="text" value={contactForm.lastName} onChange={(e) => setContactForm({ ...contactForm, lastName: e.target.value })} required />
+                                        </label>
+                                        <label>
+                                            Email
+                                            <input type="email" value={contactForm.email} onChange={(e) => setContactForm({ ...contactForm, email: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.phone", "Telefon")}
+                                            <input type="text" value={contactForm.phone} onChange={(e) => setContactForm({ ...contactForm, phone: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.role", "Funktion")}
+                                            <input type="text" value={contactForm.role} onChange={(e) => setContactForm({ ...contactForm, role: e.target.value })} />
+                                        </label>
+                                        <div className="form-actions">
+                                            <button type="submit" className="primary">{contactForm.id ? t("common.update", "Aktualisieren") : t("common.add", "Hinzufügen")}</button>
+                                            {contactForm.id && <button type="button" className="ghost" onClick={() => setContactForm({ id: null, firstName: "", lastName: "", email: "", phone: "", role: "" })}>{t("common.cancel", "Abbrechen")}</button>}
+                                        </div>
+                                    </form>
+                                </section>
+                                <section className="activities">
+                                    <h3>{t("crm.activities", "Aktivitäten")}</h3>
+                                    <ul className="list-unstyled">
+                                        {customerActivities.map((activity) => (
+                                            <li key={activity.id}>
+                                                <div>
+                                                    <strong>{activity.type}</strong> – {activity.notes}
+                                                    {activity.createdAt && <span className="muted"> ({activity.createdAt})</span>}
+                                                </div>
+                                                <div className="action-row">
+                                                    <button type="button" className="link-button" onClick={() => setActivityForm({ id: activity.id, notes: activity.notes ?? "", timestamp: activity.createdAt ? activity.createdAt.replace("Z", "").slice(0, 16) : "", contactId: activity.contactId ?? "", type: activity.type ?? "NOTE" })}>{t("common.edit", "Bearbeiten")}</button>
+                                                    <button type="button" className="link-button danger" onClick={() => handleActivityDelete(activity.id)}>{t("common.delete", "Löschen")}</button>
+                                                </div>
+                                            </li>
+                                        ))}
+                                        {customerActivities.length === 0 && <li>{t("crm.noActivities", "Keine Aktivitäten")}</li>}
+                                    </ul>
+                                    <form className="form-grid" onSubmit={handleActivitySubmit}>
+                                        <label>
+                                            {t("crm.type", "Typ")}
+                                            <select value={activityForm.type} onChange={(e) => setActivityForm({ ...activityForm, type: e.target.value })}>
+                                                <option value="NOTE">{t("crm.note", "Notiz")}</option>
+                                                <option value="CALL">{t("crm.call", "Anruf")}</option>
+                                                <option value="EMAIL">Email</option>
+                                                <option value="MEETING">{t("crm.meeting", "Meeting")}</option>
+                                            </select>
+                                        </label>
+                                        <label>
+                                            {t("crm.timestamp", "Zeitpunkt")}
+                                            <input type="datetime-local" value={activityForm.timestamp} onChange={(e) => setActivityForm({ ...activityForm, timestamp: e.target.value })} />
+                                        </label>
+                                        <label>
+                                            {t("crm.contact", "Kontakt")}
+                                            <select value={activityForm.contactId} onChange={(e) => setActivityForm({ ...activityForm, contactId: e.target.value })}>
+                                                <option value="">{t("crm.optional", "Optional")}</option>
+                                                {customerContacts.map((contact) => (
+                                                    <option key={contact.id} value={contact.id}>{contact.firstName} {contact.lastName}</option>
+                                                ))}
+                                            </select>
+                                        </label>
+                                        <label className="full-width">
+                                            {t("crm.notes", "Notizen")}
+                                            <textarea value={activityForm.notes} onChange={(e) => setActivityForm({ ...activityForm, notes: e.target.value })} required />
+                                        </label>
+                                        <div className="form-actions">
+                                            <button type="submit" className="primary">{activityForm.id ? t("common.update", "Aktualisieren") : t("common.add", "Hinzufügen")}</button>
+                                            {activityForm.id && <button type="button" className="ghost" onClick={() => setActivityForm({ id: null, notes: "", timestamp: "", contactId: "", type: "NOTE" })}>{t("common.cancel", "Abbrechen")}</button>}
+                                        </div>
+                                    </form>
+                                </section>
+                            </div>
+                        </article>
+                    )}
                 </section>
 
                 <section className="card">
-                    <h2>{t("crm.leadList", "Leads")}</h2>
-                    <ul className="list-unstyled">
-                        {leads.map((lead) => (
-                            <li key={lead.id}>
-                                <strong>{lead.companyName || lead.contactName}</strong> – {lead.email}
-                            </li>
-                        ))}
-                        {leads.length === 0 && <li>{t("crm.noLeads", "Keine Leads")}</li>}
-                    </ul>
+                    <div className="section-header">
+                        <h2>{t("crm.leadList", "Leads")}</h2>
+                        <select value={leadFilter} onChange={(e) => setLeadFilter(e.target.value)}>
+                            {leadStatuses.map((status) => (
+                                <option key={status} value={status}>{status}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="two-column">
+                        <ul className="list-unstyled">
+                            {leads.map((lead) => (
+                                <li key={lead.id}>
+                                    <div>
+                                        <strong>{lead.companyName || lead.contactName}</strong> – {lead.email}
+                                    </div>
+                                    <div className="action-row">
+                                        <label>
+                                            {t("crm.status", "Status")}
+                                            <select value={lead.status} onChange={(e) => handleLeadStatusChange(lead.id, e.target.value)}>
+                                                {leadStatuses.map((status) => (
+                                                    <option key={status} value={status}>{status}</option>
+                                                ))}
+                                            </select>
+                                        </label>
+                                    </div>
+                                </li>
+                            ))}
+                            {leads.length === 0 && <li>{t("crm.noLeads", "Keine Leads")}</li>}
+                        </ul>
+                        <form className="form-grid" onSubmit={handleLeadSubmit}>
+                            <label>
+                                {t("crm.company", "Firma")}
+                                <input type="text" value={leadForm.companyName} onChange={(e) => setLeadForm({ ...leadForm, companyName: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.contactName", "Ansprechpartner")}
+                                <input type="text" value={leadForm.contactName} onChange={(e) => setLeadForm({ ...leadForm, contactName: e.target.value })} />
+                            </label>
+                            <label>
+                                Email
+                                <input type="email" value={leadForm.email} onChange={(e) => setLeadForm({ ...leadForm, email: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("crm.status", "Status")}
+                                <select value={leadForm.status} onChange={(e) => setLeadForm({ ...leadForm, status: e.target.value })}>
+                                    {leadStatuses.map((status) => (
+                                        <option key={status} value={status}>{status}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("crm.addLead", "Lead anlegen")}</button>
+                        </form>
+                    </div>
                 </section>
 
                 <section className="card">
-                    <h2>{t("crm.opportunityList", "Opportunities")}</h2>
-                    <ul className="list-unstyled">
-                        {opportunities.map((opportunity) => (
-                            <li key={opportunity.id}>
-                                {opportunity.title} – CHF {Number(opportunity.value ?? 0).toFixed(2)}
-                            </li>
-                        ))}
-                        {opportunities.length === 0 && <li>{t("crm.noOpportunities", "Keine Opportunities")}</li>}
-                    </ul>
+                    <div className="section-header">
+                        <h2>{t("crm.opportunityList", "Opportunities")}</h2>
+                        <select value={oppFilter} onChange={(e) => setOppFilter(e.target.value)}>
+                            {opportunityStages.map((stage) => (
+                                <option key={stage} value={stage}>{stage}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="two-column">
+                        <ul className="list-unstyled">
+                            {opportunities.map((opportunity) => (
+                                <li key={opportunity.id}>
+                                    <div>
+                                        <strong>{opportunity.title}</strong> – CHF {Number(opportunity.value ?? 0).toFixed(2)}
+                                    </div>
+                                    <div className="action-row">
+                                        <label>
+                                            {t("crm.stage", "Phase")}
+                                            <select value={opportunity.stage} onChange={(e) => handleOpportunityStageChange(opportunity.id, e.target.value)}>
+                                                {opportunityStages.map((stage) => (
+                                                    <option key={stage} value={stage}>{stage}</option>
+                                                ))}
+                                            </select>
+                                        </label>
+                                    </div>
+                                </li>
+                            ))}
+                            {opportunities.length === 0 && <li>{t("crm.noOpportunities", "Keine Opportunities")}</li>}
+                        </ul>
+                        <form className="form-grid" onSubmit={handleOpportunitySubmit}>
+                            <label>
+                                {t("crm.title", "Titel")}
+                                <input type="text" value={opportunityForm.title} onChange={(e) => setOpportunityForm({ ...opportunityForm, title: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("crm.value", "Wert")}
+                                <input type="number" step="0.01" value={opportunityForm.value} onChange={(e) => setOpportunityForm({ ...opportunityForm, value: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.probability", "Wahrscheinlichkeit")}
+                                <input type="number" step="0.01" value={opportunityForm.probability} onChange={(e) => setOpportunityForm({ ...opportunityForm, probability: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.stage", "Phase")}
+                                <select value={opportunityForm.stage} onChange={(e) => setOpportunityForm({ ...opportunityForm, stage: e.target.value })}>
+                                    {opportunityStages.map((stage) => (
+                                        <option key={stage} value={stage}>{stage}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("crm.addOpportunity", "Opportunity anlegen")}</button>
+                        </form>
+                    </div>
                 </section>
 
                 <section className="card">
-                    <h2>{t("crm.campaignList", "Kampagnen")}</h2>
-                    <ul className="list-unstyled">
-                        {campaigns.map((campaign) => (
-                            <li key={campaign.id}>
-                                {campaign.name} – {campaign.channel}
-                            </li>
-                        ))}
-                        {campaigns.length === 0 && <li>{t("crm.noCampaigns", "Keine aktiven Kampagnen")}</li>}
-                    </ul>
+                    <div className="section-header">
+                        <h2>{t("crm.campaignList", "Kampagnen")}</h2>
+                        <select value={campaignFilter} onChange={(e) => setCampaignFilter(e.target.value)}>
+                            {campaignStatuses.map((status) => (
+                                <option key={status} value={status}>{status}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="two-column">
+                        <ul className="list-unstyled">
+                            {campaigns.map((campaign) => (
+                                <li key={campaign.id}>
+                                    <div>
+                                        <strong>{campaign.name}</strong> – {campaign.channel}
+                                    </div>
+                                    <div className="action-row">
+                                        <label>
+                                            {t("crm.status", "Status")}
+                                            <select value={campaign.status} onChange={(e) => handleCampaignUpdate(campaign.id, e.target.value)}>
+                                                {campaignStatuses.map((status) => (
+                                                    <option key={status} value={status}>{status}</option>
+                                                ))}
+                                            </select>
+                                        </label>
+                                    </div>
+                                </li>
+                            ))}
+                            {campaigns.length === 0 && <li>{t("crm.noCampaigns", "Keine aktiven Kampagnen")}</li>}
+                        </ul>
+                        <form className="form-grid" onSubmit={handleCampaignSubmit}>
+                            <label>
+                                {t("crm.campaignName", "Name")}
+                                <input type="text" value={campaignForm.name} onChange={(e) => setCampaignForm({ ...campaignForm, name: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("crm.channel", "Kanal")}
+                                <input type="text" value={campaignForm.channel} onChange={(e) => setCampaignForm({ ...campaignForm, channel: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.startDate", "Start")}
+                                <input type="date" value={campaignForm.startDate} onChange={(e) => setCampaignForm({ ...campaignForm, startDate: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.endDate", "Ende")}
+                                <input type="date" value={campaignForm.endDate} onChange={(e) => setCampaignForm({ ...campaignForm, endDate: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("crm.status", "Status")}
+                                <select value={campaignForm.status} onChange={(e) => setCampaignForm({ ...campaignForm, status: e.target.value })}>
+                                    {campaignStatuses.map((status) => (
+                                        <option key={status} value={status}>{status}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("crm.addCampaign", "Kampagne anlegen")}</button>
+                        </form>
+                    </div>
                 </section>
             </main>
         </div>

--- a/Chrono-frontend/src/pages/SupplyChain/SupplyChainDashboard.jsx
+++ b/Chrono-frontend/src/pages/SupplyChain/SupplyChainDashboard.jsx
@@ -13,6 +13,15 @@ const SupplyChainDashboard = () => {
     const [warehouses, setWarehouses] = useState([]);
     const [stock, setStock] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [productForm, setProductForm] = useState({ sku: "", name: "", description: "", unitCost: "", unitPrice: "" });
+    const [warehouseForm, setWarehouseForm] = useState({ name: "", location: "" });
+    const [adjustForm, setAdjustForm] = useState({ productId: "", warehouseId: "", quantity: "", type: "ADJUSTMENT", reference: "" });
+    const [purchaseForm, setPurchaseForm] = useState({ orderNumber: "", vendorName: "", expectedDate: "", warehouseId: "" });
+    const [purchaseLines, setPurchaseLines] = useState([{ productId: "", quantity: "", unitCost: "" }]);
+    const [receiveForm, setReceiveForm] = useState({ orderId: "", warehouseId: "" });
+    const [salesForm, setSalesForm] = useState({ orderNumber: "", customerName: "", dueDate: "", warehouseId: "" });
+    const [salesLines, setSalesLines] = useState([{ productId: "", quantity: "", unitPrice: "" }]);
+    const [fulfillForm, setFulfillForm] = useState({ orderId: "", warehouseId: "" });
 
     useEffect(() => {
         const load = async () => {
@@ -47,6 +56,162 @@ const SupplyChainDashboard = () => {
             return sum + (entry.quantity ?? 0) * cost;
         }, 0);
     }, [stock, products]);
+
+    const handleProductSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                sku: productForm.sku || undefined,
+                name: productForm.name,
+                description: productForm.description,
+                unitCost: productForm.unitCost ? Number(productForm.unitCost) : undefined,
+                unitPrice: productForm.unitPrice ? Number(productForm.unitPrice) : undefined
+            };
+            await api.post("/api/supply-chain/products", payload);
+            notify(t("supplyChain.productCreated", "Produkt angelegt."), "success");
+            setProductForm({ sku: "", name: "", description: "", unitCost: "", unitPrice: "" });
+            setLoading(true);
+            setTimeout(() => setLoading(false), 0);
+        } catch (error) {
+            console.error("Failed to create product", error);
+            notify(t("supplyChain.productCreateFailed", "Produkt konnte nicht angelegt werden."), "error");
+        }
+    };
+
+    const handleWarehouseSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            await api.post("/api/supply-chain/warehouses", warehouseForm);
+            notify(t("supplyChain.warehouseCreated", "Lager angelegt."), "success");
+            setWarehouseForm({ name: "", location: "" });
+            setLoading(true);
+            setTimeout(() => setLoading(false), 0);
+        } catch (error) {
+            console.error("Failed to create warehouse", error);
+            notify(t("supplyChain.warehouseCreateFailed", "Lager konnte nicht angelegt werden."), "error");
+        }
+    };
+
+    const handleAdjustmentSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                productId: Number(adjustForm.productId),
+                warehouseId: Number(adjustForm.warehouseId),
+                quantityChange: Number(adjustForm.quantity),
+                type: adjustForm.type,
+                reference: adjustForm.reference || undefined
+            };
+            await api.post("/api/supply-chain/stock/adjust", payload);
+            notify(t("supplyChain.adjustmentSaved", "Bestandskorrektur gebucht."), "success");
+            setAdjustForm({ productId: "", warehouseId: "", quantity: "", type: "ADJUSTMENT", reference: "" });
+            setLoading(true);
+            setTimeout(() => setLoading(false), 0);
+        } catch (error) {
+            console.error("Failed to adjust stock", error);
+            notify(t("supplyChain.adjustmentFailed", "Bestandskorrektur fehlgeschlagen."), "error");
+        }
+    };
+
+    const addPurchaseLine = () => setPurchaseLines((lines) => [...lines, { productId: "", quantity: "", unitCost: "" }]);
+    const updatePurchaseLine = (index, field, value) => {
+        setPurchaseLines((lines) => lines.map((line, idx) => (idx === index ? { ...line, [field]: value } : line)));
+    };
+    const removePurchaseLine = (index) => setPurchaseLines((lines) => lines.filter((_, idx) => idx !== index));
+
+    const handlePurchaseSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                orderNumber: purchaseForm.orderNumber || undefined,
+                vendorName: purchaseForm.vendorName,
+                expectedDate: purchaseForm.expectedDate || undefined,
+                lines: purchaseLines
+                    .filter((line) => line.productId && line.quantity)
+                    .map((line) => ({
+                        productId: Number(line.productId),
+                        quantity: Number(line.quantity),
+                        unitCost: Number(line.unitCost || 0)
+                    }))
+            };
+            const response = await api.post("/api/supply-chain/purchase-orders", payload);
+            notify(t("supplyChain.purchaseCreated", "Einkaufsbestellung erfasst."), "success");
+            setPurchaseForm({ orderNumber: "", vendorName: "", expectedDate: "", warehouseId: "" });
+            setPurchaseLines([{ productId: "", quantity: "", unitCost: "" }]);
+            if (purchaseForm.warehouseId) {
+                setReceiveForm({ orderId: response.data?.id ?? "", warehouseId: purchaseForm.warehouseId });
+            }
+        } catch (error) {
+            console.error("Failed to create purchase order", error);
+            notify(t("supplyChain.purchaseCreateFailed", "Einkaufsbestellung konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleReceiveSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                warehouseId: Number(receiveForm.warehouseId)
+            };
+            await api.post(`/api/supply-chain/purchase-orders/${receiveForm.orderId}/receive`, payload);
+            notify(t("supplyChain.receiptBooked", "Wareneingang gebucht."), "success");
+            setReceiveForm({ orderId: "", warehouseId: "" });
+            setLoading(true);
+            setTimeout(() => setLoading(false), 0);
+        } catch (error) {
+            console.error("Failed to receive purchase order", error);
+            notify(t("supplyChain.receiptFailed", "Wareneingang konnte nicht gebucht werden."), "error");
+        }
+    };
+
+    const addSalesLine = () => setSalesLines((lines) => [...lines, { productId: "", quantity: "", unitPrice: "" }]);
+    const updateSalesLine = (index, field, value) => {
+        setSalesLines((lines) => lines.map((line, idx) => (idx === index ? { ...line, [field]: value } : line)));
+    };
+    const removeSalesLine = (index) => setSalesLines((lines) => lines.filter((_, idx) => idx !== index));
+
+    const handleSalesSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = {
+                orderNumber: salesForm.orderNumber || undefined,
+                customerName: salesForm.customerName,
+                dueDate: salesForm.dueDate || undefined,
+                lines: salesLines
+                    .filter((line) => line.productId && line.quantity)
+                    .map((line) => ({
+                        productId: Number(line.productId),
+                        quantity: Number(line.quantity),
+                        unitPrice: Number(line.unitPrice || 0)
+                    }))
+            };
+            const response = await api.post("/api/supply-chain/sales-orders", payload);
+            notify(t("supplyChain.salesCreated", "Verkaufsauftrag erfasst."), "success");
+            setSalesForm({ orderNumber: "", customerName: "", dueDate: "", warehouseId: "" });
+            setSalesLines([{ productId: "", quantity: "", unitPrice: "" }]);
+            if (salesForm.warehouseId) {
+                setFulfillForm({ orderId: response.data?.id ?? "", warehouseId: salesForm.warehouseId });
+            }
+        } catch (error) {
+            console.error("Failed to create sales order", error);
+            notify(t("supplyChain.salesCreateFailed", "Verkaufsauftrag konnte nicht erstellt werden."), "error");
+        }
+    };
+
+    const handleFulfillSubmit = async (event) => {
+        event.preventDefault();
+        try {
+            const payload = { warehouseId: Number(fulfillForm.warehouseId) };
+            await api.post(`/api/supply-chain/sales-orders/${fulfillForm.orderId}/fulfill`, payload);
+            notify(t("supplyChain.fulfillmentBooked", "Warenausgang gebucht."), "success");
+            setFulfillForm({ orderId: "", warehouseId: "" });
+            setLoading(true);
+            setTimeout(() => setLoading(false), 0);
+        } catch (error) {
+            console.error("Failed to fulfill sales order", error);
+            notify(t("supplyChain.fulfillmentFailed", "Warenausgang konnte nicht gebucht werden."), "error");
+        }
+    };
 
     return (
         <div className="admin-page supply-chain-page">
@@ -103,6 +268,220 @@ const SupplyChainDashboard = () => {
                             </table>
                         </div>
                     )}
+                </section>
+
+                <section className="card-grid">
+                    <article className="card">
+                        <h2>{t("supplyChain.newProduct", "Neues Produkt")}</h2>
+                        <form className="form-grid" onSubmit={handleProductSubmit}>
+                            <label>
+                                SKU
+                                <input type="text" value={productForm.sku} onChange={(e) => setProductForm({ ...productForm, sku: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.productName", "Name")}
+                                <input type="text" value={productForm.name} onChange={(e) => setProductForm({ ...productForm, name: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.description", "Beschreibung")}
+                                <input type="text" value={productForm.description} onChange={(e) => setProductForm({ ...productForm, description: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.unitCost", "Einstandspreis")}
+                                <input type="number" step="0.01" value={productForm.unitCost} onChange={(e) => setProductForm({ ...productForm, unitCost: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.unitPrice", "Verkaufspreis")}
+                                <input type="number" step="0.01" value={productForm.unitPrice} onChange={(e) => setProductForm({ ...productForm, unitPrice: e.target.value })} />
+                            </label>
+                            <button type="submit" className="primary">{t("common.save", "Speichern")}</button>
+                        </form>
+                    </article>
+                    <article className="card">
+                        <h2>{t("supplyChain.newWarehouse", "Neues Lager")}</h2>
+                        <form className="form-grid" onSubmit={handleWarehouseSubmit}>
+                            <label>
+                                {t("supplyChain.warehouseName", "Name")}
+                                <input type="text" value={warehouseForm.name} onChange={(e) => setWarehouseForm({ ...warehouseForm, name: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.location", "Standort")}
+                                <input type="text" value={warehouseForm.location} onChange={(e) => setWarehouseForm({ ...warehouseForm, location: e.target.value })} />
+                            </label>
+                            <button type="submit" className="primary">{t("common.save", "Speichern")}</button>
+                        </form>
+                    </article>
+                </section>
+
+                <section className="card-grid">
+                    <article className="card">
+                        <h2>{t("supplyChain.inventoryAdjustment", "Bestandskorrektur")}</h2>
+                        <form className="form-grid" onSubmit={handleAdjustmentSubmit}>
+                            <label>
+                                {t("supplyChain.product", "Produkt")}
+                                <select value={adjustForm.productId} onChange={(e) => setAdjustForm({ ...adjustForm, productId: e.target.value })} required>
+                                    <option value="">{t("supplyChain.chooseProduct", "Produkt wählen")}</option>
+                                    {products.map((product) => (
+                                        <option key={product.id} value={product.id}>{product.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label>
+                                {t("supplyChain.warehouse", "Lager")}
+                                <select value={adjustForm.warehouseId} onChange={(e) => setAdjustForm({ ...adjustForm, warehouseId: e.target.value })} required>
+                                    <option value="">{t("supplyChain.chooseWarehouse", "Lager wählen")}</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>{warehouse.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label>
+                                {t("supplyChain.quantity", "Menge")}
+                                <input type="number" value={adjustForm.quantity} onChange={(e) => setAdjustForm({ ...adjustForm, quantity: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.movementType", "Typ")}
+                                <select value={adjustForm.type} onChange={(e) => setAdjustForm({ ...adjustForm, type: e.target.value })}>
+                                    <option value="ADJUSTMENT">{t("supplyChain.adjustment", "Korrektur")}</option>
+                                    <option value="WRITE_OFF">{t("supplyChain.writeOff", "Abschreibung")}</option>
+                                    <option value="GAIN">{t("supplyChain.gain", "Bestandsmehrung")}</option>
+                                </select>
+                            </label>
+                            <label>
+                                {t("supplyChain.reference", "Referenz")}
+                                <input type="text" value={adjustForm.reference} onChange={(e) => setAdjustForm({ ...adjustForm, reference: e.target.value })} />
+                            </label>
+                            <button type="submit" className="primary">{t("supplyChain.postAdjustment", "Buchen")}</button>
+                        </form>
+                    </article>
+                </section>
+
+                <section className="card">
+                    <h2>{t("supplyChain.purchaseOrders", "Einkauf")}</h2>
+                    <div className="form-grid">
+                        <form onSubmit={handlePurchaseSubmit} className="form-grid">
+                            <label>
+                                {t("supplyChain.orderNumber", "Bestellnummer")}
+                                <input type="text" value={purchaseForm.orderNumber} onChange={(e) => setPurchaseForm({ ...purchaseForm, orderNumber: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.vendor", "Lieferant")}
+                                <input type="text" value={purchaseForm.vendorName} onChange={(e) => setPurchaseForm({ ...purchaseForm, vendorName: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.expectedDate", "Liefertermin")}
+                                <input type="date" value={purchaseForm.expectedDate} onChange={(e) => setPurchaseForm({ ...purchaseForm, expectedDate: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.defaultWarehouse", "Standardlager für Eingang")}
+                                <select value={purchaseForm.warehouseId} onChange={(e) => setPurchaseForm({ ...purchaseForm, warehouseId: e.target.value })}>
+                                    <option value="">{t("supplyChain.chooseWarehouse", "Lager wählen")}</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>{warehouse.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <div className="po-lines">
+                                {purchaseLines.map((line, index) => (
+                                    <div key={index} className="po-line">
+                                        <select value={line.productId} onChange={(e) => updatePurchaseLine(index, "productId", e.target.value)} required>
+                                            <option value="">{t("supplyChain.product", "Produkt")}</option>
+                                            {products.map((product) => (
+                                                <option key={product.id} value={product.id}>{product.name}</option>
+                                            ))}
+                                        </select>
+                                        <input type="number" step="0.01" placeholder={t("supplyChain.quantity", "Menge")} value={line.quantity} onChange={(e) => updatePurchaseLine(index, "quantity", e.target.value)} required />
+                                        <input type="number" step="0.01" placeholder={t("supplyChain.unitCost", "Einstandspreis")} value={line.unitCost} onChange={(e) => updatePurchaseLine(index, "unitCost", e.target.value)} />
+                                        {purchaseLines.length > 1 && (
+                                            <button type="button" className="ghost" onClick={() => removePurchaseLine(index)}>{t("common.remove", "Entfernen")}</button>
+                                        )}
+                                    </div>
+                                ))}
+                                <button type="button" className="secondary" onClick={addPurchaseLine}>{t("supplyChain.addLine", "Zeile hinzufügen")}</button>
+                            </div>
+                            <button type="submit" className="primary">{t("supplyChain.createPurchase", "Bestellung anlegen")}</button>
+                        </form>
+                        <form onSubmit={handleReceiveSubmit} className="form-grid">
+                            <label>
+                                {t("supplyChain.purchaseOrderId", "Bestell-ID")}
+                                <input type="number" value={receiveForm.orderId} onChange={(e) => setReceiveForm({ ...receiveForm, orderId: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.receivingWarehouse", "Warenannahme Lager")}
+                                <select value={receiveForm.warehouseId} onChange={(e) => setReceiveForm({ ...receiveForm, warehouseId: e.target.value })} required>
+                                    <option value="">{t("supplyChain.chooseWarehouse", "Lager wählen")}</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>{warehouse.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("supplyChain.receiveGoods", "Wareneingang buchen")}</button>
+                        </form>
+                    </div>
+                </section>
+
+                <section className="card">
+                    <h2>{t("supplyChain.salesOrders", "Verkauf")}</h2>
+                    <div className="form-grid">
+                        <form onSubmit={handleSalesSubmit} className="form-grid">
+                            <label>
+                                {t("supplyChain.orderNumber", "Bestellnummer")}
+                                <input type="text" value={salesForm.orderNumber} onChange={(e) => setSalesForm({ ...salesForm, orderNumber: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.customer", "Kunde")}
+                                <input type="text" value={salesForm.customerName} onChange={(e) => setSalesForm({ ...salesForm, customerName: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.dueDate", "Fälligkeitsdatum")}
+                                <input type="date" value={salesForm.dueDate} onChange={(e) => setSalesForm({ ...salesForm, dueDate: e.target.value })} />
+                            </label>
+                            <label>
+                                {t("supplyChain.fulfillmentWarehouse", "Versandlager")}
+                                <select value={salesForm.warehouseId} onChange={(e) => setSalesForm({ ...salesForm, warehouseId: e.target.value })}>
+                                    <option value="">{t("supplyChain.chooseWarehouse", "Lager wählen")}</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>{warehouse.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <div className="po-lines">
+                                {salesLines.map((line, index) => (
+                                    <div key={index} className="po-line">
+                                        <select value={line.productId} onChange={(e) => updateSalesLine(index, "productId", e.target.value)} required>
+                                            <option value="">{t("supplyChain.product", "Produkt")}</option>
+                                            {products.map((product) => (
+                                                <option key={product.id} value={product.id}>{product.name}</option>
+                                            ))}
+                                        </select>
+                                        <input type="number" step="0.01" placeholder={t("supplyChain.quantity", "Menge")} value={line.quantity} onChange={(e) => updateSalesLine(index, "quantity", e.target.value)} required />
+                                        <input type="number" step="0.01" placeholder={t("supplyChain.unitPrice", "Verkaufspreis")} value={line.unitPrice} onChange={(e) => updateSalesLine(index, "unitPrice", e.target.value)} />
+                                        {salesLines.length > 1 && (
+                                            <button type="button" className="ghost" onClick={() => removeSalesLine(index)}>{t("common.remove", "Entfernen")}</button>
+                                        )}
+                                    </div>
+                                ))}
+                                <button type="button" className="secondary" onClick={addSalesLine}>{t("supplyChain.addLine", "Zeile hinzufügen")}</button>
+                            </div>
+                            <button type="submit" className="primary">{t("supplyChain.createSales", "Auftrag anlegen")}</button>
+                        </form>
+                        <form onSubmit={handleFulfillSubmit} className="form-grid">
+                            <label>
+                                {t("supplyChain.salesOrderId", "Auftrags-ID")}
+                                <input type="number" value={fulfillForm.orderId} onChange={(e) => setFulfillForm({ ...fulfillForm, orderId: e.target.value })} required />
+                            </label>
+                            <label>
+                                {t("supplyChain.shippingWarehouse", "Versandlager")}
+                                <select value={fulfillForm.warehouseId} onChange={(e) => setFulfillForm({ ...fulfillForm, warehouseId: e.target.value })} required>
+                                    <option value="">{t("supplyChain.chooseWarehouse", "Lager wählen")}</option>
+                                    {warehouses.map((warehouse) => (
+                                        <option key={warehouse.id} value={warehouse.id}>{warehouse.name}</option>
+                                    ))}
+                                </select>
+                            </label>
+                            <button type="submit" className="primary">{t("supplyChain.fulfillOrder", "Warenausgang buchen")}</button>
+                        </form>
+                    </div>
                 </section>
             </main>
         </div>

--- a/Chrono-frontend/src/styles/AdminAccountingPageScoped.css
+++ b/Chrono-frontend/src/styles/AdminAccountingPageScoped.css
@@ -152,6 +152,67 @@
     color: inherit;
 }
 
+.admin-page.accounting-page .invoice-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.admin-page.accounting-page .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.admin-page.accounting-page .journal-lines {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.admin-page.accounting-page .journal-line {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.5rem;
+    align-items: end;
+}
+
+.admin-page.accounting-page .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.admin-page.accounting-page .modal {
+    background: #fff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    width: min(500px, 100%);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+}
+
+[data-theme="dark"] .admin-page.accounting-page .modal {
+    background: #1e293b;
+    color: #e2e8f0;
+}
+
+.admin-page.accounting-page .modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    grid-column: 1 / -1;
+}
+
 @media (max-width: 768px) {
     .admin-page.accounting-page .admin-content {
         padding: 1.75rem 1rem 2.5rem;

--- a/Chrono-frontend/src/styles/BankingOperationsPageScoped.css
+++ b/Chrono-frontend/src/styles/BankingOperationsPageScoped.css
@@ -66,7 +66,9 @@
     font-weight: 500;
 }
 
-.admin-page.banking-page .form-grid input {
+.admin-page.banking-page .form-grid input,
+.admin-page.banking-page .form-grid select,
+.admin-page.banking-page .form-grid textarea {
     border-radius: 10px;
     border: 1px solid rgba(15, 118, 110, 0.45);
     padding: 0.6rem 0.85rem;
@@ -74,9 +76,61 @@
     color: inherit;
 }
 
-[data-theme="dark"] .admin-page.banking-page .form-grid input {
+[data-theme="dark"] .admin-page.banking-page .form-grid input,
+[data-theme="dark"] .admin-page.banking-page .form-grid select,
+[data-theme="dark"] .admin-page.banking-page .form-grid textarea {
     background: rgba(15, 118, 110, 0.45);
     border-color: rgba(110, 231, 183, 0.55);
+}
+
+.admin-page.banking-page .form-grid textarea {
+    min-height: 120px;
+}
+
+.admin-page.banking-page .instruction-builder {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.admin-page.banking-page .instruction-form {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.5rem;
+    align-items: end;
+}
+
+.admin-page.banking-page .instruction-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.admin-page.banking-page .action-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.35rem;
+}
+
+.admin-page.banking-page .link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #0f766e;
+    cursor: pointer;
+    text-decoration: underline;
+    font: inherit;
+}
+
+.admin-page.banking-page .link-button.danger {
+    color: #b91c1c;
+}
+
+.admin-page.banking-page .full-width {
+    grid-column: 1 / -1;
 }
 
 .admin-page.banking-page .list-unstyled {

--- a/Chrono-frontend/src/styles/CrmDashboardScoped.css
+++ b/Chrono-frontend/src/styles/CrmDashboardScoped.css
@@ -94,6 +94,108 @@
     color: #c7d2fe;
 }
 
+.admin-page.crm-page .link-button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #5b21b6;
+    cursor: pointer;
+    font: inherit;
+    text-decoration: underline;
+}
+
+.admin-page.crm-page .link-button.danger {
+    color: #dc2626;
+}
+
+.admin-page.crm-page .link-button.active {
+    font-weight: 600;
+}
+
+.admin-page.crm-page .customer-detail header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.admin-page.crm-page .detail-grid {
+    display: grid;
+    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.admin-page.crm-page .form-grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    align-items: end;
+    margin-top: 1rem;
+}
+
+.admin-page.crm-page .form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 500;
+}
+
+.admin-page.crm-page .form-grid input,
+.admin-page.crm-page .form-grid select,
+.admin-page.crm-page .form-grid textarea {
+    border: 1px solid rgba(91, 33, 182, 0.35);
+    border-radius: 10px;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.95rem;
+    background: rgba(250, 245, 255, 0.85);
+    color: inherit;
+}
+
+.admin-page.crm-page .form-grid textarea {
+    min-height: 120px;
+}
+
+[data-theme="dark"] .admin-page.crm-page .form-grid input,
+[data-theme="dark"] .admin-page.crm-page .form-grid select,
+[data-theme="dark"] .admin-page.crm-page .form-grid textarea {
+    background: rgba(49, 46, 129, 0.85);
+    border-color: rgba(165, 180, 252, 0.5);
+}
+
+.admin-page.crm-page .form-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.admin-page.crm-page .form-actions button {
+    min-width: 120px;
+}
+
+.admin-page.crm-page .action-row {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.admin-page.crm-page .two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+}
+
+.admin-page.crm-page .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.admin-page.crm-page .full-width {
+    grid-column: 1 / -1;
+}
+
 @media (max-width: 768px) {
     .admin-page.crm-page .admin-content {
         padding: 1.75rem 1rem 2.5rem;

--- a/Chrono-frontend/src/styles/SupplyChainDashboardScoped.css
+++ b/Chrono-frontend/src/styles/SupplyChainDashboardScoped.css
@@ -109,6 +109,50 @@
     background: rgba(59, 130, 246, 0.2);
 }
 
+.admin-page.supply-chain-page .form-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: end;
+}
+
+.admin-page.supply-chain-page .form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 500;
+}
+
+.admin-page.supply-chain-page .form-grid input,
+.admin-page.supply-chain-page .form-grid select {
+    border: 1px solid rgba(30, 64, 175, 0.45);
+    border-radius: 10px;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.92);
+    color: inherit;
+}
+
+[data-theme="dark"] .admin-page.supply-chain-page .form-grid input,
+[data-theme="dark"] .admin-page.supply-chain-page .form-grid select {
+    background: rgba(15, 23, 42, 0.85);
+    border-color: rgba(96, 165, 250, 0.6);
+}
+
+.admin-page.supply-chain-page .po-lines {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.admin-page.supply-chain-page .po-line {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    align-items: end;
+}
+
 @media (max-width: 768px) {
     .admin-page.supply-chain-page .admin-content {
         padding: 1.75rem 1rem 2.5rem;


### PR DESCRIPTION
## Summary
- add manual journal posting, asset registry, and receivable/payable payment APIs with supporting DTO updates
- expand CRM services and UI to manage customer addresses, contacts, activities, and update lead/opportunity/campaign statuses
- expose supply chain inventory adjustments, purchasing/receiving, sales/fulfillment, and banking batch/signature/message workflows in the frontend

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e2fac592148325b564f3f3a3a4c1e5