### PR TITLE
Allow CRM users to load customers without tracking flag

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/CustomerController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/CustomerController.java
@@ -43,7 +43,16 @@ public class CustomerController {
      * Akzeptiert jetzt ein User-Objekt direkt.
      */
     private boolean featureEnabled(User user) {
-        return user != null && user.getCompany() != null && Boolean.TRUE.equals(user.getCompany().getCustomerTrackingEnabled());
+        if (user == null || user.getCompany() == null) {
+            return false;
+        }
+
+        if (Boolean.TRUE.equals(user.getCompany().getCustomerTrackingEnabled())) {
+            return true;
+        }
+
+        return user.getCompany().getEnabledFeatures() != null
+                && user.getCompany().getEnabledFeatures().contains("crm");
     }
 
     /**


### PR DESCRIPTION
## Summary
- allow the customer API to accept CRM-enabled companies even when the customer tracking flag is disabled
- keep existing guard rails while checking the company's optional feature set for `crm`

## Testing
- mvn -q -e -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e2ffacac6c83259dcdcbf10c35b39c