### PR TITLE
Handle username override when loading correction requests

### DIFF
--- a/Chrono-frontend/src/pages/Registration.jsx
+++ b/Chrono-frontend/src/pages/Registration.jsx
@@ -425,10 +425,14 @@ const Registration = () => {
                                 <p className="price-item">
                                     <span className="label">Ausgewählte Features:</span>
                                     <span className="value">
-                    {[BASE_FEATURE, ...FEATURES.filter(f => selectedFeatures.includes(f.key))]
-                        .map(f => f.name)
-                        .join(", ")}
-                  </span>
+                                        {[BASE_FEATURE,
+                                            ...FEATURE_CATALOG.filter((feature) =>
+                                                selectedFeatures.includes(feature.key)
+                                            ),
+                                        ]
+                                            .map((feature) => feature.name)
+                                            .join(", ")}
+                                    </span>
                                 </p>
                                 <p className="price-item">
                                     <span className="label">Preis je Mitarbeiter:</span>


### PR DESCRIPTION
## Summary
- accept an optional username query parameter when loading personal correction requests and fall back to the authenticated principal
- guard against unauthorized or cross-user access attempts and respond with appropriate HTTP statuses instead of triggering server errors
- wrap the service call so a missing user now returns a 404-style response rather than bubbling up an exception
- fix the registration pricing preview so it reads selected feature names from the shared feature catalog constant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e380c428648325be46fdf7002fe0eb