### PR TITLE
Fix demo correction request serialization

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/CorrectionRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/CorrectionRequest.java
@@ -4,6 +4,7 @@ import com.chrono.chrono.entities.TimeTrackingEntry;
 import com.chrono.chrono.entities.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ public class CorrectionRequest {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "target_entry_id", nullable = true)
+    @JsonIgnore
     private TimeTrackingEntry targetEntry;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")


### PR DESCRIPTION
## Summary
- prevent lazy loading issues when serializing correction requests by ignoring the full target entry entity
- keep derived fields like original timestamps available for the dashboard while avoiding backend 500 errors

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e38406b9f0832593e0d2cb4ea452f0