### PR TITLE
Expand dashboard coverage with controller and service tests

### DIFF
--- a/Chrono-backend/src/test/java/com/chrono/chrono/controller/DashboardControllerTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/controller/DashboardControllerTest.java
@@ -1,0 +1,37 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.dto.DashboardResponse;
+import com.chrono.chrono.services.DashboardService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardControllerTest {
+
+    @Mock
+    private DashboardService dashboardService;
+
+    @InjectMocks
+    private DashboardController dashboardController;
+
+    @Test
+    void getUserDashboard_parsesIsoDatesForAllDashboardRoutes() {
+        DashboardResponse expected = new DashboardResponse();
+        when(dashboardService.getUserDashboardForWeek("demo-admin", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7)))
+                .thenReturn(expected);
+
+        DashboardResponse actual = dashboardController.getUserDashboard("demo-admin", "2024-01-01", "2024-01-07");
+
+        assertSame(expected, actual);
+        verify(dashboardService).getUserDashboardForWeek("demo-admin", LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 7));
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/DashboardServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/DashboardServiceTest.java
@@ -1,0 +1,162 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.DailyTimeSummaryDTO;
+import com.chrono.chrono.dto.DashboardResponse;
+import com.chrono.chrono.entities.Role;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TimeTrackingService timeTrackingService;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private User user;
+    private LocalDate start;
+    private LocalDate end;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setUsername("demo-admin");
+        user.setRoles(Set.of(new Role("ROLE_ADMIN")));
+        user.setIsHourly(false);
+        user.setIsPercentage(false);
+        start = LocalDate.of(2024, 1, 1);
+        end = LocalDate.of(2024, 1, 7);
+    }
+
+    @Test
+    void getUserDashboardForWeek_filtersSummariesWithinRange() {
+        DailyTimeSummaryDTO monday = summary("demo-admin", LocalDate.of(2024, 1, 1), 480, 60);
+        DailyTimeSummaryDTO friday = summary("demo-admin", LocalDate.of(2024, 1, 5), 510, 45);
+        DailyTimeSummaryDTO nextWeek = summary("demo-admin", LocalDate.of(2024, 1, 8), 300, 30);
+
+        when(userRepository.findByUsername("demo-admin")).thenReturn(Optional.of(user));
+        when(timeTrackingService.getUserHistory("demo-admin"))
+                .thenReturn(List.of(monday, friday, nextWeek));
+
+        DashboardResponse response = dashboardService.getUserDashboardForWeek("demo-admin", start, end);
+
+        assertEquals("demo-admin", response.getUsername());
+        assertEquals("ROLE_ADMIN", response.getRoleName());
+        assertEquals(2, response.getDailySummaries().size());
+        assertTrue(response.getDailySummaries().containsAll(List.of(monday, friday)));
+        assertTrue(response.getDailySummaries().stream().noneMatch(dto -> dto.getDate().isAfter(end)));
+        verify(timeTrackingService).getUserHistory("demo-admin");
+    }
+
+    @Test
+    void getUserDashboardForWeek_includesBoundaryDatesAndHourlyTotals() {
+        user.setIsHourly(true);
+        DailyTimeSummaryDTO startDay = summary("demo-admin", start, 450, 30);
+        DailyTimeSummaryDTO endDay = summary("demo-admin", end, 420, 60);
+
+        when(userRepository.findByUsername("demo-admin")).thenReturn(Optional.of(user));
+        when(timeTrackingService.getUserHistory("demo-admin"))
+                .thenReturn(List.of(startDay, endDay));
+
+        DashboardResponse response = dashboardService.getUserDashboardForWeek("demo-admin", start, end);
+
+        assertEquals(2, response.getDailySummaries().size());
+        assertTrue(response.getDailySummaries().containsAll(List.of(startDay, endDay)));
+        int weeklyWorkedMinutes = response.getDailySummaries().stream()
+                .mapToInt(DailyTimeSummaryDTO::getWorkedMinutes)
+                .sum();
+        assertEquals(870, weeklyWorkedMinutes);
+    }
+
+    @Test
+    void getUserDashboardForWeek_handlesPercentageUsers() {
+        user.setIsPercentage(true);
+        DailyTimeSummaryDTO midWeek = summary("demo-admin", LocalDate.of(2024, 1, 3), 360, 45);
+
+        when(userRepository.findByUsername("demo-admin")).thenReturn(Optional.of(user));
+        when(timeTrackingService.getUserHistory("demo-admin"))
+                .thenReturn(List.of(midWeek));
+
+        DashboardResponse response = dashboardService.getUserDashboardForWeek("demo-admin", start, end);
+
+        assertEquals(1, response.getDailySummaries().size());
+        assertEquals(midWeek, response.getDailySummaries().get(0));
+        assertTrue(response.getDailySummaries().get(0).getWorkedMinutes() > 0);
+    }
+
+    @Test
+    void getUserDashboardForWeek_supportsDemoUsersAndSetsFallbackRole() {
+        user.setRoles(Set.of());
+        user.setDemo(true);
+        DailyTimeSummaryDTO demoDay = summary("demo-admin", LocalDate.of(2024, 1, 4), 540, 30);
+
+        when(userRepository.findByUsername("demo-admin")).thenReturn(Optional.of(user));
+        when(timeTrackingService.getUserHistory("demo-admin"))
+                .thenReturn(List.of(demoDay));
+
+        DashboardResponse response = dashboardService.getUserDashboardForWeek("demo-admin", start, end);
+
+        assertEquals("NONE", response.getRoleName());
+        assertEquals(1, response.getDailySummaries().size());
+        assertEquals(demoDay, response.getDailySummaries().get(0));
+    }
+
+    @Test
+    void getUserDashboardForWeek_returnsEmptySummariesWhenNoMatches() {
+        DailyTimeSummaryDTO outsideRange = summary("demo-admin", LocalDate.of(2024, 2, 1), 300, 30);
+
+        when(userRepository.findByUsername("demo-admin")).thenReturn(Optional.of(user));
+        when(timeTrackingService.getUserHistory("demo-admin"))
+                .thenReturn(List.of(outsideRange));
+
+        DashboardResponse response = dashboardService.getUserDashboardForWeek("demo-admin", start, end);
+
+        assertNotNull(response.getDailySummaries());
+        assertTrue(response.getDailySummaries().isEmpty());
+    }
+
+    @Test
+    void getUserDashboardForWeek_throwsWhenUserMissing() {
+        when(userRepository.findByUsername("unknown")).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () ->
+                dashboardService.getUserDashboardForWeek("unknown", start, end));
+    }
+
+    private DailyTimeSummaryDTO summary(String username, LocalDate date, int workedMinutes, int breakMinutes) {
+        return new DailyTimeSummaryDTO(
+                username,
+                date,
+                workedMinutes,
+                breakMinutes,
+                List.of(),
+                null,
+                false,
+                new DailyTimeSummaryDTO.PrimaryTimes(LocalTime.of(9, 0), LocalTime.of(17, 0), false)
+        );
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/TimeTrackingServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/TimeTrackingServiceTest.java
@@ -1,0 +1,160 @@
+package com.chrono.chrono.services;
+
+import com.chrono.chrono.dto.DailyTimeSummaryDTO;
+import com.chrono.chrono.entities.DailyNote;
+import com.chrono.chrono.entities.TimeTrackingEntry;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.CustomerRepository;
+import com.chrono.chrono.repositories.DailyNoteRepository;
+import com.chrono.chrono.repositories.PayslipRepository;
+import com.chrono.chrono.repositories.ProjectRepository;
+import com.chrono.chrono.repositories.SickLeaveRepository;
+import com.chrono.chrono.repositories.TaskRepository;
+import com.chrono.chrono.repositories.TimeTrackingEntryRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.repositories.VacationRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TimeTrackingServiceTest {
+
+    @Mock
+    private TimeTrackingEntryRepository timeTrackingEntryRepository;
+    @Mock
+    private WorkScheduleService workScheduleService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private VacationRequestRepository vacationRequestRepository;
+    @Mock
+    private SickLeaveRepository sickLeaveRepository;
+    @Mock
+    private CustomerRepository customerRepository;
+    @Mock
+    private ProjectRepository projectRepository;
+    @Mock
+    private DailyNoteRepository dailyNoteRepository;
+    @Mock
+    private TaskRepository taskRepository;
+    @Mock
+    private PayslipRepository payslipRepository;
+
+    @InjectMocks
+    private TimeTrackingService timeTrackingService;
+
+    private User user;
+    private LocalDate date;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+        date = LocalDate.of(2024, 1, 3);
+    }
+
+    @Test
+    void getDailySummary_calculatesWorkedAndBreakMinutes() {
+        TimeTrackingEntry startMorning = entry(user, date.atTime(9, 0), TimeTrackingEntry.PunchType.START);
+        TimeTrackingEntry endMorning = entry(user, date.atTime(12, 0), TimeTrackingEntry.PunchType.ENDE);
+        TimeTrackingEntry startAfternoon = entry(user, date.atTime(13, 0), TimeTrackingEntry.PunchType.START);
+        TimeTrackingEntry endAfternoon = entry(user, date.atTime(17, 0), TimeTrackingEntry.PunchType.ENDE);
+
+        when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
+        when(timeTrackingEntryRepository.findByUserAndEntryDateOrderByEntryTimestampAsc(user, date))
+                .thenReturn(List.of(startMorning, endMorning, startAfternoon, endAfternoon));
+        DailyNote note = new DailyNote();
+        note.setContent("Abschluss erstellt");
+        when(dailyNoteRepository.findByUserAndNoteDate(user, date)).thenReturn(Optional.of(note));
+
+        DailyTimeSummaryDTO summary = timeTrackingService.getDailySummary("alice", date);
+
+        assertEquals("alice", summary.getUsername());
+        assertEquals(420, summary.getWorkedMinutes());
+        assertEquals(60, summary.getBreakMinutes());
+        assertEquals("Abschluss erstellt", summary.getDailyNote());
+        assertFalse(summary.isNeedsCorrection());
+        assertEquals(LocalTime.of(9, 0), summary.getPrimaryTimes().getFirstStartTime());
+        assertEquals(LocalTime.of(17, 0), summary.getPrimaryTimes().getLastEndTime());
+        assertFalse(summary.getPrimaryTimes().isOpen());
+        assertEquals(4, summary.getEntries().size());
+    }
+
+    @Test
+    void computeDailyWorkDifference_usesExpectedMinutesFromSchedule() {
+        TimeTrackingEntry start = entry(user, date.atTime(9, 0), TimeTrackingEntry.PunchType.START);
+        TimeTrackingEntry end = entry(user, date.atTime(16, 0), TimeTrackingEntry.PunchType.ENDE);
+
+        when(dailyNoteRepository.findByUserAndNoteDate(user, date)).thenReturn(Optional.empty());
+        when(workScheduleService.computeExpectedWorkMinutes(eq(user), eq(date), any())).thenReturn(480);
+
+        int diff = timeTrackingService.computeDailyWorkDifference(user, date, Collections.emptyList(), List.of(start, end));
+
+        assertEquals(-60, diff);
+    }
+
+    @Test
+    void getDailySummary_marksOpenDayWhenLastEntryIsStart() {
+        TimeTrackingEntry startMorning = entry(user, date.atTime(9, 0), TimeTrackingEntry.PunchType.START);
+        TimeTrackingEntry endMorning = entry(user, date.atTime(12, 0), TimeTrackingEntry.PunchType.ENDE);
+        TimeTrackingEntry startAfternoon = entry(user, date.atTime(13, 0), TimeTrackingEntry.PunchType.START);
+
+        when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
+        when(timeTrackingEntryRepository.findByUserAndEntryDateOrderByEntryTimestampAsc(user, date))
+                .thenReturn(List.of(startMorning, endMorning, startAfternoon));
+        when(dailyNoteRepository.findByUserAndNoteDate(user, date)).thenReturn(Optional.empty());
+
+        DailyTimeSummaryDTO summary = timeTrackingService.getDailySummary("alice", date);
+
+        assertEquals(180, summary.getWorkedMinutes());
+        assertEquals(60, summary.getBreakMinutes());
+        assertTrue(summary.getPrimaryTimes().isOpen());
+        assertEquals(LocalTime.of(9, 0), summary.getPrimaryTimes().getFirstStartTime());
+        assertNull(summary.getPrimaryTimes().getLastEndTime());
+    }
+
+    @Test
+    void getDailySummary_flagsNeedsCorrectionForAutoEndPunch() {
+        TimeTrackingEntry start = entry(user, date.atTime(9, 0), TimeTrackingEntry.PunchType.START);
+        TimeTrackingEntry autoEnd = entry(user, date.atTime(23, 20), TimeTrackingEntry.PunchType.ENDE);
+        autoEnd.setSource(TimeTrackingEntry.PunchSource.SYSTEM_AUTO_END);
+
+        when(userRepository.findByUsername("alice")).thenReturn(Optional.of(user));
+        when(timeTrackingEntryRepository.findByUserAndEntryDateOrderByEntryTimestampAsc(user, date))
+                .thenReturn(List.of(start, autoEnd));
+        when(dailyNoteRepository.findByUserAndNoteDate(user, date)).thenReturn(Optional.empty());
+
+        DailyTimeSummaryDTO summary = timeTrackingService.getDailySummary("alice", date);
+
+        assertTrue(summary.isNeedsCorrection());
+    }
+
+    private TimeTrackingEntry entry(User user, LocalDateTime timestamp, TimeTrackingEntry.PunchType type) {
+        TimeTrackingEntry entry = new TimeTrackingEntry();
+        entry.setUser(user);
+        entry.setEntryTimestamp(timestamp);
+        entry.setPunchType(type);
+        entry.setSource(TimeTrackingEntry.PunchSource.MANUAL_PUNCH);
+        return entry;
+    }
+}


### PR DESCRIPTION
## Summary
- add DashboardServiceTest verifying weekly filtering, hourly/percentage/demo users, and fallback roles
- cover DashboardController date parsing to ensure dashboard routes hit the service with LocalDate parameters

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e38f33700c8325817771e6b86eb57c