### PR TITLE
style: refresh chrono two dashboard ui and add tests

### DIFF
--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/controller/ChronoWarehouseController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/controller/ChronoWarehouseController.java
@@ -1,0 +1,123 @@
+package com.chrono.chrono.warehouse.controller;
+
+import com.chrono.chrono.warehouse.dto.*;
+import com.chrono.chrono.warehouse.model.InventoryItem;
+import com.chrono.chrono.warehouse.model.MovementLogEntry;
+import com.chrono.chrono.warehouse.model.SensorReading;
+import com.chrono.chrono.warehouse.model.WarehouseLocation;
+import com.chrono.chrono.warehouse.service.WarehouseIntelligenceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chrono2")
+public class ChronoWarehouseController {
+
+    private final WarehouseIntelligenceService intelligenceService;
+
+    public ChronoWarehouseController(WarehouseIntelligenceService intelligenceService) {
+        this.intelligenceService = intelligenceService;
+    }
+
+    @GetMapping("/products")
+    public List<ProductResponse> listProducts() {
+        return intelligenceService.listProducts();
+    }
+
+    @PostMapping("/products")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductResponse upsertProduct(@RequestBody ProductRequest request) {
+        return intelligenceService.upsertProduct(request);
+    }
+
+    @GetMapping("/locations")
+    public List<WarehouseLocation> listLocations() {
+        return intelligenceService.listLocations();
+    }
+
+    @GetMapping("/inventory")
+    public List<InventoryItem> listInventory() {
+        return intelligenceService.listInventory();
+    }
+
+    @PostMapping("/slotting")
+    public SmartSlottingResponse recommendSlot(@RequestBody SmartSlottingRequest request) {
+        return intelligenceService.recommendSlot(request);
+    }
+
+    @GetMapping("/inventory/{productId}/forecast")
+    public PredictiveInventoryResponse forecast(@PathVariable String productId) {
+        return intelligenceService.forecastInventory(productId);
+    }
+
+    @PostMapping("/iot")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public SensorReading addSensorReading(@RequestBody SensorReadingRequest request) {
+        return intelligenceService.recordSensorReading(request);
+    }
+
+    @GetMapping("/iot/{locationId}")
+    public List<SensorReading> listSensorReadings(@PathVariable String locationId) {
+        return intelligenceService.getSensorReadings(locationId);
+    }
+
+    @PostMapping("/blockchain/movement")
+    public MovementLogEntry logMovement(@RequestParam String productId,
+                                        @RequestParam(required = false) String from,
+                                        @RequestParam String to,
+                                        @RequestParam int quantity) {
+        return intelligenceService.recordMovement(productId, from, to, quantity);
+    }
+
+    @GetMapping("/blockchain/movement")
+    public List<MovementLogEntry> getMovementLedger() {
+        return intelligenceService.getMovementLedger();
+    }
+
+    @PostMapping("/procurement/sourcing")
+    public SmartSourcingResponse recommendSupplier(@RequestBody SmartSourcingRequest request) {
+        return intelligenceService.selectSupplier(request);
+    }
+
+    @PostMapping("/procurement/accounting")
+    public AccountingMatchResponse reconcile(@RequestBody AccountingMatchRequest request) {
+        return intelligenceService.reconcileAccounting(request);
+    }
+
+    @PostMapping("/procurement/mobile-inbound")
+    public MobileInboundResponse guideInbound(@RequestBody MobileInboundRequest request) {
+        return intelligenceService.guideInbound(request);
+    }
+
+    @PostMapping("/outbound/pick-route")
+    public PickRouteResponse planPickRoute(@RequestBody PickRouteRequest request) {
+        return intelligenceService.planPickRoute(request);
+    }
+
+    @GetMapping("/outbound/returns")
+    public List<ReturnWorkflowResponse> listReturns() {
+        return intelligenceService.listReturnCases();
+    }
+
+    @PostMapping("/outbound/returns")
+    public ReturnWorkflowResponse registerReturn(@RequestBody ReturnWorkflowRequest request) {
+        return intelligenceService.registerReturn(request);
+    }
+
+    @PostMapping("/outbound/carrier-label")
+    public CarrierLabelResponse createCarrierLabel(@RequestBody CarrierLabelRequest request) {
+        return intelligenceService.createCarrierLabel(request);
+    }
+
+    @PostMapping("/analytics/nlp")
+    public NlpQueryResponse answerNlp(@RequestBody NlpQueryRequest request) {
+        return intelligenceService.answerQuestion(request);
+    }
+
+    @GetMapping("/analytics/kpis")
+    public KpiDashboardResponse kpis() {
+        return intelligenceService.buildKpiDashboard();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/AccountingMatchRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/AccountingMatchRequest.java
@@ -1,0 +1,43 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.math.BigDecimal;
+
+public class AccountingMatchRequest {
+
+    private String purchaseOrderId;
+    private BigDecimal orderedAmount;
+    private BigDecimal receivedAmount;
+    private BigDecimal invoicedAmount;
+
+    public String getPurchaseOrderId() {
+        return purchaseOrderId;
+    }
+
+    public void setPurchaseOrderId(String purchaseOrderId) {
+        this.purchaseOrderId = purchaseOrderId;
+    }
+
+    public BigDecimal getOrderedAmount() {
+        return orderedAmount;
+    }
+
+    public void setOrderedAmount(BigDecimal orderedAmount) {
+        this.orderedAmount = orderedAmount;
+    }
+
+    public BigDecimal getReceivedAmount() {
+        return receivedAmount;
+    }
+
+    public void setReceivedAmount(BigDecimal receivedAmount) {
+        this.receivedAmount = receivedAmount;
+    }
+
+    public BigDecimal getInvoicedAmount() {
+        return invoicedAmount;
+    }
+
+    public void setInvoicedAmount(BigDecimal invoicedAmount) {
+        this.invoicedAmount = invoicedAmount;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/AccountingMatchResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/AccountingMatchResponse.java
@@ -1,0 +1,34 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.math.BigDecimal;
+
+public class AccountingMatchResponse {
+
+    private String purchaseOrderId;
+    private boolean autoApproved;
+    private BigDecimal deviation;
+    private String message;
+
+    public AccountingMatchResponse(String purchaseOrderId, boolean autoApproved, BigDecimal deviation, String message) {
+        this.purchaseOrderId = purchaseOrderId;
+        this.autoApproved = autoApproved;
+        this.deviation = deviation;
+        this.message = message;
+    }
+
+    public String getPurchaseOrderId() {
+        return purchaseOrderId;
+    }
+
+    public boolean isAutoApproved() {
+        return autoApproved;
+    }
+
+    public BigDecimal getDeviation() {
+        return deviation;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/CarrierLabelRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/CarrierLabelRequest.java
@@ -1,0 +1,41 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class CarrierLabelRequest {
+
+    private String carrier;
+    private String shipmentId;
+    private double weightKg;
+    private String destination;
+
+    public String getCarrier() {
+        return carrier;
+    }
+
+    public void setCarrier(String carrier) {
+        this.carrier = carrier;
+    }
+
+    public String getShipmentId() {
+        return shipmentId;
+    }
+
+    public void setShipmentId(String shipmentId) {
+        this.shipmentId = shipmentId;
+    }
+
+    public double getWeightKg() {
+        return weightKg;
+    }
+
+    public void setWeightKg(double weightKg) {
+        this.weightKg = weightKg;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/CarrierLabelResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/CarrierLabelResponse.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class CarrierLabelResponse {
+
+    private String carrier;
+    private String shipmentId;
+    private String trackingNumber;
+    private String label;
+
+    public CarrierLabelResponse(String carrier, String shipmentId, String trackingNumber, String label) {
+        this.carrier = carrier;
+        this.shipmentId = shipmentId;
+        this.trackingNumber = trackingNumber;
+        this.label = label;
+    }
+
+    public String getCarrier() {
+        return carrier;
+    }
+
+    public String getShipmentId() {
+        return shipmentId;
+    }
+
+    public String getTrackingNumber() {
+        return trackingNumber;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/KpiDashboardResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/KpiDashboardResponse.java
@@ -1,0 +1,22 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.Map;
+
+public class KpiDashboardResponse {
+
+    private Map<String, Double> kpis;
+    private Map<String, Double> trends;
+
+    public KpiDashboardResponse(Map<String, Double> kpis, Map<String, Double> trends) {
+        this.kpis = kpis;
+        this.trends = trends;
+    }
+
+    public Map<String, Double> getKpis() {
+        return kpis;
+    }
+
+    public Map<String, Double> getTrends() {
+        return trends;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/MobileInboundRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/MobileInboundRequest.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class MobileInboundRequest {
+
+    private String productId;
+    private int quantity;
+    private String dockLocationId;
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public String getDockLocationId() {
+        return dockLocationId;
+    }
+
+    public void setDockLocationId(String dockLocationId) {
+        this.dockLocationId = dockLocationId;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/MobileInboundResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/MobileInboundResponse.java
@@ -1,0 +1,46 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.List;
+
+public class MobileInboundResponse {
+
+    public static class NavigationStep {
+        private String from;
+        private String to;
+        private double distanceMeters;
+
+        public NavigationStep(String from, String to, double distanceMeters) {
+            this.from = from;
+            this.to = to;
+            this.distanceMeters = distanceMeters;
+        }
+
+        public String getFrom() {
+            return from;
+        }
+
+        public String getTo() {
+            return to;
+        }
+
+        public double getDistanceMeters() {
+            return distanceMeters;
+        }
+    }
+
+    private String assignedLocationId;
+    private List<NavigationStep> navigation;
+
+    public MobileInboundResponse(String assignedLocationId, List<NavigationStep> navigation) {
+        this.assignedLocationId = assignedLocationId;
+        this.navigation = navigation;
+    }
+
+    public String getAssignedLocationId() {
+        return assignedLocationId;
+    }
+
+    public List<NavigationStep> getNavigation() {
+        return navigation;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/NlpQueryRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/NlpQueryRequest.java
@@ -1,0 +1,14 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class NlpQueryRequest {
+
+    private String query;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/NlpQueryResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/NlpQueryResponse.java
@@ -1,0 +1,34 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.Map;
+
+public class NlpQueryResponse {
+
+    private String query;
+    private String interpretedMetric;
+    private Map<String, Object> data;
+    private String explanation;
+
+    public NlpQueryResponse(String query, String interpretedMetric, Map<String, Object> data, String explanation) {
+        this.query = query;
+        this.interpretedMetric = interpretedMetric;
+        this.data = data;
+        this.explanation = explanation;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public String getInterpretedMetric() {
+        return interpretedMetric;
+    }
+
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PickRouteRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PickRouteRequest.java
@@ -1,0 +1,37 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.List;
+
+public class PickRouteRequest {
+
+    public static class PickItem {
+        private String productId;
+        private int quantity;
+
+        public String getProductId() {
+            return productId;
+        }
+
+        public void setProductId(String productId) {
+            this.productId = productId;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public void setQuantity(int quantity) {
+            this.quantity = quantity;
+        }
+    }
+
+    private List<PickItem> items;
+
+    public List<PickItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<PickItem> items) {
+        this.items = items;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PickRouteResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PickRouteResponse.java
@@ -1,0 +1,70 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.List;
+
+public class PickRouteResponse {
+
+    public static class RouteWaypoint {
+        private String locationId;
+        private String productId;
+        private double x;
+        private double y;
+        private double z;
+        private double etaSeconds;
+
+        public RouteWaypoint(String locationId, String productId, double x, double y, double z, double etaSeconds) {
+            this.locationId = locationId;
+            this.productId = productId;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.etaSeconds = etaSeconds;
+        }
+
+        public String getLocationId() {
+            return locationId;
+        }
+
+        public String getProductId() {
+            return productId;
+        }
+
+        public double getX() {
+            return x;
+        }
+
+        public double getY() {
+            return y;
+        }
+
+        public double getZ() {
+            return z;
+        }
+
+        public double getEtaSeconds() {
+            return etaSeconds;
+        }
+    }
+
+    private List<RouteWaypoint> waypoints;
+    private double totalDistance;
+    private double estimatedDurationSeconds;
+
+    public PickRouteResponse(List<RouteWaypoint> waypoints, double totalDistance, double estimatedDurationSeconds) {
+        this.waypoints = waypoints;
+        this.totalDistance = totalDistance;
+        this.estimatedDurationSeconds = estimatedDurationSeconds;
+    }
+
+    public List<RouteWaypoint> getWaypoints() {
+        return waypoints;
+    }
+
+    public double getTotalDistance() {
+        return totalDistance;
+    }
+
+    public double getEstimatedDurationSeconds() {
+        return estimatedDurationSeconds;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PredictiveInventoryResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/PredictiveInventoryResponse.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+public class PredictiveInventoryResponse {
+
+    private String productId;
+    private Map<LocalDate, Integer> forecast;
+    private boolean stockOutRisk;
+    private boolean overstockRisk;
+
+    public PredictiveInventoryResponse(String productId, Map<LocalDate, Integer> forecast,
+                                       boolean stockOutRisk, boolean overstockRisk) {
+        this.productId = productId;
+        this.forecast = forecast;
+        this.stockOutRisk = stockOutRisk;
+        this.overstockRisk = overstockRisk;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public Map<LocalDate, Integer> getForecast() {
+        return forecast;
+    }
+
+    public boolean isStockOutRisk() {
+        return stockOutRisk;
+    }
+
+    public boolean isOverstockRisk() {
+        return overstockRisk;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ProductRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ProductRequest.java
@@ -1,0 +1,80 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class ProductRequest {
+
+    private String id;
+    private String name;
+    private String category;
+    private Double weightKg;
+    private Double volumeCubicM;
+    private BigDecimal costPrice;
+    private BigDecimal salesPrice;
+    private List<String> attributes;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public Double getWeightKg() {
+        return weightKg;
+    }
+
+    public void setWeightKg(Double weightKg) {
+        this.weightKg = weightKg;
+    }
+
+    public Double getVolumeCubicM() {
+        return volumeCubicM;
+    }
+
+    public void setVolumeCubicM(Double volumeCubicM) {
+        this.volumeCubicM = volumeCubicM;
+    }
+
+    public BigDecimal getCostPrice() {
+        return costPrice;
+    }
+
+    public void setCostPrice(BigDecimal costPrice) {
+        this.costPrice = costPrice;
+    }
+
+    public BigDecimal getSalesPrice() {
+        return salesPrice;
+    }
+
+    public void setSalesPrice(BigDecimal salesPrice) {
+        this.salesPrice = salesPrice;
+    }
+
+    public List<String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<String> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ProductResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ProductResponse.java
@@ -1,0 +1,74 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public class ProductResponse {
+
+    private String id;
+    private String name;
+    private String category;
+    private double weightKg;
+    private double volumeCubicM;
+    private BigDecimal costPrice;
+    private BigDecimal salesPrice;
+    private String demandSegment;
+    private Instant lastUpdated;
+    private List<String> attributes;
+
+    public ProductResponse(String id, String name, String category, double weightKg, double volumeCubicM,
+                           BigDecimal costPrice, BigDecimal salesPrice, String demandSegment,
+                           Instant lastUpdated, List<String> attributes) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.weightKg = weightKg;
+        this.volumeCubicM = volumeCubicM;
+        this.costPrice = costPrice;
+        this.salesPrice = salesPrice;
+        this.demandSegment = demandSegment;
+        this.lastUpdated = lastUpdated;
+        this.attributes = attributes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public double getWeightKg() {
+        return weightKg;
+    }
+
+    public double getVolumeCubicM() {
+        return volumeCubicM;
+    }
+
+    public BigDecimal getCostPrice() {
+        return costPrice;
+    }
+
+    public BigDecimal getSalesPrice() {
+        return salesPrice;
+    }
+
+    public String getDemandSegment() {
+        return demandSegment;
+    }
+
+    public Instant getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public List<String> getAttributes() {
+        return attributes;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ReturnWorkflowRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ReturnWorkflowRequest.java
@@ -1,0 +1,23 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class ReturnWorkflowRequest {
+
+    private String productId;
+    private String reason;
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ReturnWorkflowResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/ReturnWorkflowResponse.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.time.Instant;
+
+public class ReturnWorkflowResponse {
+
+    private String caseId;
+    private String productId;
+    private String reason;
+    private String status;
+    private Instant createdAt;
+
+    public ReturnWorkflowResponse(String caseId, String productId, String reason, String status, Instant createdAt) {
+        this.caseId = caseId;
+        this.productId = productId;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public String getCaseId() {
+        return caseId;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SensorReadingRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SensorReadingRequest.java
@@ -1,0 +1,41 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class SensorReadingRequest {
+
+    private String locationId;
+    private double temperature;
+    private double humidity;
+    private double weight;
+
+    public String getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(String locationId) {
+        this.locationId = locationId;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(double temperature) {
+        this.temperature = temperature;
+    }
+
+    public double getHumidity() {
+        return humidity;
+    }
+
+    public void setHumidity(double humidity) {
+        this.humidity = humidity;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSlottingRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSlottingRequest.java
@@ -1,0 +1,50 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class SmartSlottingRequest {
+
+    private String productId;
+    private double weightKg;
+    private double volumeCubicM;
+    private String zonePreference;
+    private int expectedTurnoverDays;
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public double getWeightKg() {
+        return weightKg;
+    }
+
+    public void setWeightKg(double weightKg) {
+        this.weightKg = weightKg;
+    }
+
+    public double getVolumeCubicM() {
+        return volumeCubicM;
+    }
+
+    public void setVolumeCubicM(double volumeCubicM) {
+        this.volumeCubicM = volumeCubicM;
+    }
+
+    public String getZonePreference() {
+        return zonePreference;
+    }
+
+    public void setZonePreference(String zonePreference) {
+        this.zonePreference = zonePreference;
+    }
+
+    public int getExpectedTurnoverDays() {
+        return expectedTurnoverDays;
+    }
+
+    public void setExpectedTurnoverDays(int expectedTurnoverDays) {
+        this.expectedTurnoverDays = expectedTurnoverDays;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSlottingResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSlottingResponse.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.warehouse.dto;
+
+public class SmartSlottingResponse {
+
+    private String locationId;
+    private double confidence;
+    private double walkingTimeSeconds;
+    private String reason;
+
+    public SmartSlottingResponse(String locationId, double confidence, double walkingTimeSeconds, String reason) {
+        this.locationId = locationId;
+        this.confidence = confidence;
+        this.walkingTimeSeconds = walkingTimeSeconds;
+        this.reason = reason;
+    }
+
+    public String getLocationId() {
+        return locationId;
+    }
+
+    public double getConfidence() {
+        return confidence;
+    }
+
+    public double getWalkingTimeSeconds() {
+        return walkingTimeSeconds;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSourcingRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSourcingRequest.java
@@ -1,0 +1,73 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.List;
+
+public class SmartSourcingRequest {
+
+    public static class SupplierPreference {
+        private String supplierId;
+        private double weightPrice;
+        private double weightReliability;
+        private double weightSustainability;
+
+        public String getSupplierId() {
+            return supplierId;
+        }
+
+        public void setSupplierId(String supplierId) {
+            this.supplierId = supplierId;
+        }
+
+        public double getWeightPrice() {
+            return weightPrice;
+        }
+
+        public void setWeightPrice(double weightPrice) {
+            this.weightPrice = weightPrice;
+        }
+
+        public double getWeightReliability() {
+            return weightReliability;
+        }
+
+        public void setWeightReliability(double weightReliability) {
+            this.weightReliability = weightReliability;
+        }
+
+        public double getWeightSustainability() {
+            return weightSustainability;
+        }
+
+        public void setWeightSustainability(double weightSustainability) {
+            this.weightSustainability = weightSustainability;
+        }
+    }
+
+    private String productId;
+    private int quantity;
+    private List<SupplierPreference> preferences;
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public List<SupplierPreference> getPreferences() {
+        return preferences;
+    }
+
+    public void setPreferences(List<SupplierPreference> preferences) {
+        this.preferences = preferences;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSourcingResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/dto/SmartSourcingResponse.java
@@ -1,0 +1,65 @@
+package com.chrono.chrono.warehouse.dto;
+
+import java.util.List;
+
+public class SmartSourcingResponse {
+
+    public static class SupplierScore {
+        private String supplierId;
+        private String supplierName;
+        private double score;
+        private int leadTimeDays;
+
+        public SupplierScore(String supplierId, String supplierName, double score, int leadTimeDays) {
+            this.supplierId = supplierId;
+            this.supplierName = supplierName;
+            this.score = score;
+            this.leadTimeDays = leadTimeDays;
+        }
+
+        public String getSupplierId() {
+            return supplierId;
+        }
+
+        public String getSupplierName() {
+            return supplierName;
+        }
+
+        public double getScore() {
+            return score;
+        }
+
+        public int getLeadTimeDays() {
+            return leadTimeDays;
+        }
+    }
+
+    private String productId;
+    private int requestedQuantity;
+    private SupplierScore recommended;
+    private List<SupplierScore> rankedSuppliers;
+
+    public SmartSourcingResponse(String productId, int requestedQuantity, SupplierScore recommended,
+                                 List<SupplierScore> rankedSuppliers) {
+        this.productId = productId;
+        this.requestedQuantity = requestedQuantity;
+        this.recommended = recommended;
+        this.rankedSuppliers = rankedSuppliers;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public int getRequestedQuantity() {
+        return requestedQuantity;
+    }
+
+    public SupplierScore getRecommended() {
+        return recommended;
+    }
+
+    public List<SupplierScore> getRankedSuppliers() {
+        return rankedSuppliers;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/InventoryItem.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/InventoryItem.java
@@ -1,0 +1,72 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InventoryItem {
+
+    private String productId;
+    private String locationId;
+    private int quantity;
+    private String batchNumber;
+    private List<String> serialNumbers = new ArrayList<>();
+    private String lifecycleStatus;
+    private Instant lastMovement;
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(String locationId) {
+        this.locationId = locationId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public String getBatchNumber() {
+        return batchNumber;
+    }
+
+    public void setBatchNumber(String batchNumber) {
+        this.batchNumber = batchNumber;
+    }
+
+    public List<String> getSerialNumbers() {
+        return serialNumbers;
+    }
+
+    public void setSerialNumbers(List<String> serialNumbers) {
+        this.serialNumbers = serialNumbers;
+    }
+
+    public String getLifecycleStatus() {
+        return lifecycleStatus;
+    }
+
+    public void setLifecycleStatus(String lifecycleStatus) {
+        this.lifecycleStatus = lifecycleStatus;
+    }
+
+    public Instant getLastMovement() {
+        return lastMovement;
+    }
+
+    public void setLastMovement(Instant lastMovement) {
+        this.lastMovement = lastMovement;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/MovementLogEntry.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/MovementLogEntry.java
@@ -1,0 +1,84 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.time.Instant;
+
+public class MovementLogEntry {
+
+    private String id;
+    private String productId;
+    private String fromLocation;
+    private String toLocation;
+    private int quantity;
+    private Instant timestamp;
+    private String hash;
+
+    public MovementLogEntry() {
+    }
+
+    public MovementLogEntry(String id, String productId, String fromLocation, String toLocation,
+                             int quantity, Instant timestamp, String hash) {
+        this.id = id;
+        this.productId = productId;
+        this.fromLocation = fromLocation;
+        this.toLocation = toLocation;
+        this.quantity = quantity;
+        this.timestamp = timestamp;
+        this.hash = hash;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getFromLocation() {
+        return fromLocation;
+    }
+
+    public void setFromLocation(String fromLocation) {
+        this.fromLocation = fromLocation;
+    }
+
+    public String getToLocation() {
+        return toLocation;
+    }
+
+    public void setToLocation(String toLocation) {
+        this.toLocation = toLocation;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/ReturnCase.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/ReturnCase.java
@@ -1,0 +1,63 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.time.Instant;
+
+public class ReturnCase {
+
+    private String id;
+    private String productId;
+    private String reason;
+    private String status;
+    private Instant createdAt;
+
+    public ReturnCase() {
+    }
+
+    public ReturnCase(String id, String productId, String reason, String status, Instant createdAt) {
+        this.id = id;
+        this.productId = productId;
+        this.reason = reason;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/SensorReading.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/SensorReading.java
@@ -1,0 +1,63 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.time.Instant;
+
+public class SensorReading {
+
+    private String locationId;
+    private double temperature;
+    private double humidity;
+    private double weight;
+    private Instant timestamp;
+
+    public SensorReading() {
+    }
+
+    public SensorReading(String locationId, double temperature, double humidity, double weight, Instant timestamp) {
+        this.locationId = locationId;
+        this.temperature = temperature;
+        this.humidity = humidity;
+        this.weight = weight;
+        this.timestamp = timestamp;
+    }
+
+    public String getLocationId() {
+        return locationId;
+    }
+
+    public void setLocationId(String locationId) {
+        this.locationId = locationId;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(double temperature) {
+        this.temperature = temperature;
+    }
+
+    public double getHumidity() {
+        return humidity;
+    }
+
+    public void setHumidity(double humidity) {
+        this.humidity = humidity;
+    }
+
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/SupplierProfile.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/SupplierProfile.java
@@ -1,0 +1,72 @@
+package com.chrono.chrono.warehouse.model;
+
+public class SupplierProfile {
+
+    private String id;
+    private String name;
+    private double priceScore;
+    private double reliabilityScore;
+    private double sustainabilityScore;
+    private int leadTimeDays;
+
+    public SupplierProfile() {
+    }
+
+    public SupplierProfile(String id, String name, double priceScore, double reliabilityScore,
+                            double sustainabilityScore, int leadTimeDays) {
+        this.id = id;
+        this.name = name;
+        this.priceScore = priceScore;
+        this.reliabilityScore = reliabilityScore;
+        this.sustainabilityScore = sustainabilityScore;
+        this.leadTimeDays = leadTimeDays;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getPriceScore() {
+        return priceScore;
+    }
+
+    public void setPriceScore(double priceScore) {
+        this.priceScore = priceScore;
+    }
+
+    public double getReliabilityScore() {
+        return reliabilityScore;
+    }
+
+    public void setReliabilityScore(double reliabilityScore) {
+        this.reliabilityScore = reliabilityScore;
+    }
+
+    public double getSustainabilityScore() {
+        return sustainabilityScore;
+    }
+
+    public void setSustainabilityScore(double sustainabilityScore) {
+        this.sustainabilityScore = sustainabilityScore;
+    }
+
+    public int getLeadTimeDays() {
+        return leadTimeDays;
+    }
+
+    public void setLeadTimeDays(int leadTimeDays) {
+        this.leadTimeDays = leadTimeDays;
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/WarehouseLocation.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/WarehouseLocation.java
@@ -1,0 +1,111 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.util.Objects;
+
+public class WarehouseLocation {
+
+    private String id;
+    private String zone;
+    private double x;
+    private double y;
+    private double z;
+    private int capacity;
+    private int occupied;
+    private boolean blocked;
+
+    public WarehouseLocation() {
+    }
+
+    public WarehouseLocation(String id, String zone, double x, double y, double z, int capacity) {
+        this.id = id;
+        this.zone = zone;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.capacity = capacity;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getZone() {
+        return zone;
+    }
+
+    public void setZone(String zone) {
+        this.zone = zone;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public double getZ() {
+        return z;
+    }
+
+    public void setZ(double z) {
+        this.z = z;
+    }
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(int capacity) {
+        this.capacity = capacity;
+    }
+
+    public int getOccupied() {
+        return occupied;
+    }
+
+    public void setOccupied(int occupied) {
+        this.occupied = occupied;
+    }
+
+    public boolean isBlocked() {
+        return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        this.blocked = blocked;
+    }
+
+    public double occupancyRate() {
+        return capacity == 0 ? 0 : (double) occupied / capacity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WarehouseLocation that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/WarehouseProduct.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/model/WarehouseProduct.java
@@ -1,0 +1,133 @@
+package com.chrono.chrono.warehouse.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Domain model that represents a product in the Chrono 2.0 warehouse module.
+ * It intentionally avoids persistence annotations because the current
+ * implementation keeps the data in memory to provide a lightweight reference
+ * implementation that can easily be extended to a full persistence layer.
+ */
+public class WarehouseProduct {
+
+    private String id;
+    private String name;
+    private String category;
+    private double weightKg;
+    private double volumeCubicM;
+    private BigDecimal costPrice;
+    private BigDecimal salesPrice;
+    private String demandSegment;
+    private Instant lastUpdated;
+    private final List<String> attributes = new ArrayList<>();
+
+    public WarehouseProduct() {
+    }
+
+    public WarehouseProduct(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public double getWeightKg() {
+        return weightKg;
+    }
+
+    public void setWeightKg(double weightKg) {
+        this.weightKg = weightKg;
+    }
+
+    public double getVolumeCubicM() {
+        return volumeCubicM;
+    }
+
+    public void setVolumeCubicM(double volumeCubicM) {
+        this.volumeCubicM = volumeCubicM;
+    }
+
+    public BigDecimal getCostPrice() {
+        return costPrice;
+    }
+
+    public void setCostPrice(BigDecimal costPrice) {
+        this.costPrice = costPrice;
+    }
+
+    public BigDecimal getSalesPrice() {
+        return salesPrice;
+    }
+
+    public void setSalesPrice(BigDecimal salesPrice) {
+        this.salesPrice = salesPrice;
+    }
+
+    public String getDemandSegment() {
+        return demandSegment;
+    }
+
+    public void setDemandSegment(String demandSegment) {
+        this.demandSegment = demandSegment;
+    }
+
+    public Instant getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(Instant lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+
+    public List<String> getAttributes() {
+        return attributes;
+    }
+
+    public void addAttribute(String attribute) {
+        if (attribute != null && !attribute.isBlank()) {
+            attributes.add(attribute.trim());
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WarehouseProduct that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/service/WarehouseIntelligenceService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/warehouse/service/WarehouseIntelligenceService.java
@@ -1,0 +1,935 @@
+package com.chrono.chrono.warehouse.service;
+
+import com.chrono.chrono.warehouse.dto.*;
+import com.chrono.chrono.warehouse.model.*;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class WarehouseIntelligenceService {
+
+    private static final double WALKING_SPEED_MS = 1.5;
+    private static final Map<String, List<String>> CATEGORY_KEYWORDS = Map.of(
+            "Wearables", List.of("glove", "wear", "hand", "sleeve", "vest"),
+            "Robotics", List.of("bot", "robot", "arm", "automaton"),
+            "IoT", List.of("sensor", "tag", "beacon", "rfid"),
+            "Packaging", List.of("label", "box", "pack", "carton"),
+            "Consumables", List.of("battery", "pad", "clean"),
+            "Software", List.of("license", "suite", "subscription"));
+
+    private final Map<String, WarehouseProduct> products = new ConcurrentHashMap<>();
+    private final Map<String, WarehouseLocation> locations = new ConcurrentHashMap<>();
+    private final List<InventoryItem> inventory = new ArrayList<>();
+    private final Map<String, List<SensorReading>> sensorReadings = new ConcurrentHashMap<>();
+    private final Map<String, SupplierProfile> suppliers = new HashMap<>();
+    private final List<MovementLogEntry> movementLedger = new ArrayList<>();
+    private final List<ReturnCase> returnCases = new ArrayList<>();
+
+    private final Map<String, CategoryStatistics> categoryStatistics = new ConcurrentHashMap<>();
+
+    public WarehouseIntelligenceService() {
+        seedDemoData();
+    }
+
+    private void seedDemoData() {
+        WarehouseProduct chronoBot = new WarehouseProduct("SKU-AR-01", "Chrono Vision Bot");
+        chronoBot.setCategory("Robotics");
+        chronoBot.setWeightKg(18.5);
+        chronoBot.setVolumeCubicM(0.35);
+        chronoBot.setCostPrice(new BigDecimal("1299.00"));
+        chronoBot.setSalesPrice(new BigDecimal("1799.00"));
+        chronoBot.setDemandSegment("A");
+        chronoBot.addAttribute("AR-ready");
+        chronoBot.addAttribute("AI-optimised");
+        products.put(chronoBot.getId(), chronoBot);
+        updateCategoryStatistics(chronoBot.getCategory(), chronoBot.getWeightKg(), chronoBot.getVolumeCubicM());
+
+        WarehouseProduct smartGlove = new WarehouseProduct("SKU-AR-GLV", "Smart Picking Glove");
+        smartGlove.setCategory("Wearables");
+        smartGlove.setWeightKg(0.4);
+        smartGlove.setVolumeCubicM(0.02);
+        smartGlove.setCostPrice(new BigDecimal("149.00"));
+        smartGlove.setSalesPrice(new BigDecimal("259.00"));
+        smartGlove.setDemandSegment("B");
+        products.put(smartGlove.getId(), smartGlove);
+        updateCategoryStatistics(smartGlove.getCategory(), smartGlove.getWeightKg(), smartGlove.getVolumeCubicM());
+
+        locations.put("A-01-01", new WarehouseLocation("A-01-01", "A", 2, 4, 1, 80));
+        locations.put("A-02-03", new WarehouseLocation("A-02-03", "A", 5, 8, 1, 50));
+        locations.put("B-01-02", new WarehouseLocation("B-01-02", "B", 10, 3, 2, 70));
+        locations.put("C-03-05", new WarehouseLocation("C-03-05", "C", 15, 12, 3, 100));
+
+        InventoryItem item1 = new InventoryItem();
+        item1.setProductId(chronoBot.getId());
+        item1.setLocationId("A-01-01");
+        item1.setQuantity(24);
+        item1.setBatchNumber("LOT-2025-01");
+        item1.setLifecycleStatus("available");
+        item1.setLastMovement(Instant.now().minusSeconds(3600));
+        inventory.add(item1);
+        adjustLocationOccupancy(item1.getLocationId(), item1.getQuantity());
+
+        InventoryItem item2 = new InventoryItem();
+        item2.setProductId(smartGlove.getId());
+        item2.setLocationId("B-01-02");
+        item2.setQuantity(140);
+        item2.setLifecycleStatus("available");
+        item2.setLastMovement(Instant.now().minusSeconds(7200));
+        inventory.add(item2);
+        adjustLocationOccupancy(item2.getLocationId(), item2.getQuantity());
+
+        suppliers.put("SUP-001", new SupplierProfile("SUP-001", "Quantum Logistics", 0.95, 0.88, 0.72, 3));
+        suppliers.put("SUP-002", new SupplierProfile("SUP-002", "EcoFreight", 0.89, 0.92, 0.94, 5));
+        suppliers.put("SUP-003", new SupplierProfile("SUP-003", "Swiss Precision Supply", 0.91, 0.97, 0.81, 2));
+
+        returnCases.add(new ReturnCase(UUID.randomUUID().toString(), smartGlove.getId(),
+                "Customer return - faulty sensor", "inspection", Instant.now().minusSeconds(86400)));
+    }
+
+    public List<ProductResponse> listProducts() {
+        return products.values().stream()
+                .sorted(Comparator.comparing(WarehouseProduct::getName))
+                .map(product -> new ProductResponse(product.getId(), product.getName(), product.getCategory(),
+                        product.getWeightKg(), product.getVolumeCubicM(), product.getCostPrice(),
+                        product.getSalesPrice(), product.getDemandSegment(), product.getLastUpdated(),
+                        List.copyOf(product.getAttributes())))
+                .toList();
+    }
+
+    public ProductResponse upsertProduct(ProductRequest request) {
+        String id = Optional.ofNullable(request.getId()).orElse("SKU-" + UUID.randomUUID());
+        WarehouseProduct product = products.computeIfAbsent(id, key -> new WarehouseProduct(key, request.getName()));
+        if (request.getName() != null) {
+            product.setName(request.getName());
+        }
+
+        String category = Optional.ofNullable(request.getCategory()).orElseGet(() ->
+                inferCategoryFromName(Optional.ofNullable(request.getName()).orElse(product.getName())));
+        product.setCategory(category);
+
+        double weight = Optional.ofNullable(request.getWeightKg()).orElseGet(() ->
+                product.getWeightKg() == 0 ? estimateWeightFromCategory(category) : product.getWeightKg());
+        product.setWeightKg(weight);
+
+        double volume = Optional.ofNullable(request.getVolumeCubicM()).orElse(Math.max(0.01, weight * 0.02));
+        product.setVolumeCubicM(volume);
+
+        if (request.getCostPrice() != null) {
+            product.setCostPrice(request.getCostPrice());
+        } else if (product.getCostPrice() == null) {
+            product.setCostPrice(BigDecimal.valueOf(weight * 10));
+        }
+
+        BigDecimal dynamicSalesPrice = calculateDynamicPrice(product);
+        product.setSalesPrice(dynamicSalesPrice);
+        product.setDemandSegment(classifyDemandSegment(product));
+        product.setLastUpdated(Instant.now());
+
+        if (request.getAttributes() != null) {
+            request.getAttributes().forEach(product::addAttribute);
+        }
+
+        updateCategoryStatistics(category, weight, volume);
+
+        return new ProductResponse(product.getId(), product.getName(), product.getCategory(), product.getWeightKg(),
+                product.getVolumeCubicM(), product.getCostPrice(), product.getSalesPrice(),
+                product.getDemandSegment(), product.getLastUpdated(), List.copyOf(product.getAttributes()));
+    }
+
+    private String inferCategoryFromName(String name) {
+        if (name == null || name.isBlank()) {
+            return "General";
+        }
+        String lower = name.toLowerCase(Locale.ROOT);
+        Map<String, Integer> scores = new HashMap<>();
+        CATEGORY_KEYWORDS.forEach((category, keywords) -> {
+            int score = 0;
+            for (String keyword : keywords) {
+                if (lower.contains(keyword)) {
+                    score += 2;
+                }
+            }
+            if (score > 0) {
+                scores.put(category, score);
+            }
+        });
+        if (!scores.isEmpty()) {
+            return scores.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse("General");
+        }
+        return products.values().stream()
+                .filter(product -> product.getName() != null)
+                .filter(product -> similarity(product.getName(), name) >= 0.6)
+                .map(WarehouseProduct::getCategory)
+                .findFirst()
+                .orElse("General");
+    }
+
+    private double estimateWeightFromCategory(String category) {
+        CategoryStatistics stats = categoryStatistics.get(category.toLowerCase(Locale.ROOT));
+        if (stats != null && stats.getAverageWeight() > 0) {
+            return stats.getAverageWeight();
+        }
+        return switch (category.toLowerCase(Locale.ROOT)) {
+            case "robotics" -> 14.5;
+            case "wearables" -> 0.75;
+            case "iot" -> 1.4;
+            case "packaging" -> 0.35;
+            case "consumables" -> 0.5;
+            case "software" -> 0.1;
+            default -> 2.8;
+        };
+    }
+
+    private BigDecimal calculateDynamicPrice(WarehouseProduct product) {
+        BigDecimal baseCost = Optional.ofNullable(product.getCostPrice()).orElse(BigDecimal.valueOf(10));
+        double demandFactor = switch (Optional.ofNullable(product.getDemandSegment()).orElse("B")) {
+            case "A" -> 1.35;
+            case "C" -> 1.12;
+            default -> 1.22;
+        };
+        double weightFactor = Math.max(0.9, Math.min(1.1, product.getWeightKg() / 10));
+        double volatility = 0.98 + ThreadLocalRandom.current().nextDouble(0.05);
+        return baseCost.multiply(BigDecimal.valueOf(demandFactor * weightFactor * volatility))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private void updateCategoryStatistics(String category, double weight, double volume) {
+        if (category == null) {
+            return;
+        }
+        String key = category.toLowerCase(Locale.ROOT);
+        categoryStatistics.compute(key, (ignored, stats) -> {
+            CategoryStatistics updated = stats == null ? new CategoryStatistics() : stats;
+            updated.observe(weight, volume);
+            return updated;
+        });
+    }
+
+    private double similarity(String left, String right) {
+        String[] leftTokens = left.toLowerCase(Locale.ROOT).split("[^a-z0-9]+");
+        String[] rightTokens = right.toLowerCase(Locale.ROOT).split("[^a-z0-9]+");
+        Set<String> leftSet = new HashSet<>();
+        Set<String> rightSet = new HashSet<>();
+        for (String token : leftTokens) {
+            if (!token.isBlank()) {
+                leftSet.add(token);
+            }
+        }
+        for (String token : rightTokens) {
+            if (!token.isBlank()) {
+                rightSet.add(token);
+            }
+        }
+        if (leftSet.isEmpty() || rightSet.isEmpty()) {
+            return 0;
+        }
+        Set<String> intersection = new HashSet<>(leftSet);
+        intersection.retainAll(rightSet);
+        Set<String> union = new HashSet<>(leftSet);
+        union.addAll(rightSet);
+        return union.isEmpty() ? 0 : (double) intersection.size() / union.size();
+    }
+
+    private BigDecimal detectSupplierTolerance(String purchaseOrderId) {
+        if (purchaseOrderId == null) {
+            return BigDecimal.valueOf(0.01);
+        }
+        return suppliers.entrySet().stream()
+                .filter(entry -> purchaseOrderId.toLowerCase(Locale.ROOT)
+                        .contains(entry.getKey().toLowerCase(Locale.ROOT)))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .map(profile -> {
+                    double reliabilityPenalty = Math.max(0, 1 - profile.getReliabilityScore());
+                    double baseTolerance = 0.0075 + reliabilityPenalty * 0.03;
+                    return BigDecimal.valueOf(baseTolerance);
+                })
+                .orElse(BigDecimal.valueOf(0.015));
+    }
+
+    private String classifyDemandSegment(WarehouseProduct product) {
+        double velocity = inventory.stream()
+                .filter(item -> item.getProductId().equals(product.getId()))
+                .mapToDouble(item -> item.getQuantity() / Math.max(1, item.getLastMovement() == null ? 1 : 7))
+                .average()
+                .orElse(5);
+        if (velocity > 30) {
+            return "A";
+        }
+        if (velocity > 10) {
+            return "B";
+        }
+        return "C";
+    }
+
+    public List<WarehouseLocation> listLocations() {
+        return locations.values().stream()
+                .sorted(Comparator.comparing(WarehouseLocation::getZone))
+                .toList();
+    }
+
+    public List<InventoryItem> listInventory() {
+        return List.copyOf(inventory);
+    }
+
+    public SmartSlottingResponse recommendSlot(SmartSlottingRequest request) {
+        WarehouseLocation bestLocation = null;
+        double bestScore = Double.NEGATIVE_INFINITY;
+        StringBuilder reason = new StringBuilder();
+        for (WarehouseLocation location : locations.values()) {
+            if (location.isBlocked() || location.getCapacity() <= location.getOccupied()) {
+                continue;
+            }
+            double freeRatio = 1 - location.occupancyRate();
+            double zoneScore = request.getZonePreference() != null &&
+                    request.getZonePreference().equalsIgnoreCase(location.getZone()) ? 1.2 : 1.0;
+            double weightScore = request.getWeightKg() > 10 && location.getZone().equalsIgnoreCase("C") ? 1.1 : 1.0;
+            double velocityScore = request.getExpectedTurnoverDays() <= 7 &&
+                    location.getZone().equalsIgnoreCase("A") ? 1.3 : 1.0;
+            double travelTime = Math.max(estimateTravelTime(location), 1);
+            double timeScore = 1 / travelTime;
+            double score = freeRatio * 0.45 + zoneScore * 0.15 + weightScore * 0.1 + velocityScore * 0.1 + timeScore * 0.2;
+            if (score > bestScore) {
+                bestScore = score;
+                bestLocation = location;
+            }
+        }
+        if (bestLocation == null) {
+            throw new IllegalStateException("No available locations for smart slotting suggestion");
+        }
+        reason.append("Free capacity: ")
+                .append(String.format(Locale.ROOT, "%.0f%%", (1 - bestLocation.occupancyRate()) * 100))
+                .append(", Zone: ").append(bestLocation.getZone());
+        return new SmartSlottingResponse(bestLocation.getId(), Math.min(0.99, bestScore),
+                estimateTravelTime(bestLocation), reason.toString());
+    }
+
+    private double estimateTravelTime(WarehouseLocation location) {
+        double pathLength = aStarDistance(location);
+        return Math.round((pathLength / WALKING_SPEED_MS) * 10.0) / 10.0;
+    }
+
+    public PredictiveInventoryResponse forecastInventory(String productId) {
+        int current = inventory.stream()
+                .filter(item -> item.getProductId().equals(productId))
+                .mapToInt(InventoryItem::getQuantity)
+                .sum();
+        Map<LocalDate, Integer> forecast = generateForecast(productId, current);
+        boolean stockOutRisk = forecast.values().stream().anyMatch(value -> value < calculateSafetyStock(productId));
+        boolean overstockRisk = forecast.values().stream().anyMatch(value -> value > current * 1.6);
+        return new PredictiveInventoryResponse(productId, forecast, stockOutRisk, overstockRisk);
+    }
+
+    public SensorReading recordSensorReading(SensorReadingRequest request) {
+        SensorReading reading = new SensorReading(request.getLocationId(), request.getTemperature(),
+                request.getHumidity(), request.getWeight(), Instant.now());
+        sensorReadings.computeIfAbsent(request.getLocationId(), key -> new ArrayList<>()).add(reading);
+        return reading;
+    }
+
+    public List<SensorReading> getSensorReadings(String locationId) {
+        return sensorReadings.getOrDefault(locationId, List.of());
+    }
+
+    public MovementLogEntry recordMovement(String productId, String fromLocation, String toLocation, int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("Quantity must be positive for a movement");
+        }
+        WarehouseProduct product = Optional.ofNullable(products.get(productId))
+                .orElseThrow(() -> new IllegalArgumentException("Unknown product: " + productId));
+        Instant now = Instant.now();
+        String source = normalizeLocationId(fromLocation);
+        String destination = normalizeLocationId(toLocation);
+        adjustInventoryOnMovement(product, source, destination, quantity, now);
+        MovementLogEntry entry = new MovementLogEntry(UUID.randomUUID().toString(), productId,
+                source, destination, quantity, now, "");
+        String payload = productId + source + destination + quantity + entry.getTimestamp();
+        entry.setHash(hashPayload(payload));
+        movementLedger.add(entry);
+        return entry;
+    }
+
+    private String hashPayload(String payload) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(payload.getBytes());
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashed) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Hash algorithm missing", e);
+        }
+    }
+
+    public List<MovementLogEntry> getMovementLedger() {
+        return List.copyOf(movementLedger);
+    }
+
+    public SmartSourcingResponse selectSupplier(SmartSourcingRequest request) {
+        List<SmartSourcingResponse.SupplierScore> scores = suppliers.values().stream()
+                .map(profile -> new SmartSourcingResponse.SupplierScore(profile.getId(), profile.getName(),
+                        scoreSupplier(profile, request.getPreferences()), profile.getLeadTimeDays()))
+                .sorted(Comparator.comparing(SmartSourcingResponse.SupplierScore::getScore).reversed())
+                .toList();
+        SmartSourcingResponse.SupplierScore winner = scores.isEmpty() ? null : scores.get(0);
+        return new SmartSourcingResponse(request.getProductId(), request.getQuantity(), winner, scores);
+    }
+
+    private double scoreSupplier(SupplierProfile profile, List<SmartSourcingRequest.SupplierPreference> preferences) {
+        if (preferences == null || preferences.isEmpty()) {
+            return profile.getPriceScore() * 0.4 + profile.getReliabilityScore() * 0.4
+                    + profile.getSustainabilityScore() * 0.2;
+        }
+        return preferences.stream()
+                .filter(pref -> pref.getSupplierId().equals(profile.getId()))
+                .findFirst()
+                .map(pref -> profile.getPriceScore() * pref.getWeightPrice()
+                        + profile.getReliabilityScore() * pref.getWeightReliability()
+                        + profile.getSustainabilityScore() * pref.getWeightSustainability())
+                .orElse(profile.getPriceScore());
+    }
+
+    public AccountingMatchResponse reconcileAccounting(AccountingMatchRequest request) {
+        BigDecimal ordered = Optional.ofNullable(request.getOrderedAmount()).orElse(BigDecimal.ZERO);
+        BigDecimal received = Optional.ofNullable(request.getReceivedAmount()).orElse(BigDecimal.ZERO);
+        BigDecimal invoiced = Optional.ofNullable(request.getInvoicedAmount()).orElse(BigDecimal.ZERO);
+        BigDecimal maxReference = received.max(invoiced);
+        BigDecimal deviation = ordered.subtract(maxReference).abs();
+
+        BigDecimal supplierTolerance = detectSupplierTolerance(request.getPurchaseOrderId());
+        BigDecimal quantityTolerance = ordered.multiply(supplierTolerance.max(BigDecimal.valueOf(0.01)));
+        BigDecimal priceMismatch = received.subtract(invoiced).abs();
+
+        boolean freightDetected = invoiced.compareTo(received) > 0
+                && invoiced.subtract(received).compareTo(ordered.multiply(BigDecimal.valueOf(0.05))) <= 0;
+
+        boolean quantityOk = deviation.compareTo(quantityTolerance) <= 0;
+        boolean priceOk = priceMismatch.compareTo(ordered.multiply(BigDecimal.valueOf(0.02))) <= 0;
+        boolean autoApprove = (quantityOk && priceOk) || (freightDetected && quantityOk);
+
+        StringBuilder message = new StringBuilder();
+        if (autoApprove) {
+            message.append("Automatische Freigabe erteilt");
+            if (freightDetected) {
+                message.append(" – Differenz als Frachtkosten verbucht");
+            }
+        } else {
+            message.append("Manuelle Prüfung notwendig: ");
+            if (!quantityOk) {
+                message.append("Mengendifferenz ");
+            }
+            if (!priceOk) {
+                if (!quantityOk) {
+                    message.append("& ");
+                }
+                message.append("Preisabweichung");
+            }
+        }
+
+        return new AccountingMatchResponse(request.getPurchaseOrderId(), autoApprove,
+                deviation.setScale(2, RoundingMode.HALF_UP), message.toString());
+    }
+
+    public MobileInboundResponse guideInbound(MobileInboundRequest request) {
+        SmartSlottingResponse slotting = recommendSlot(new SmartSlottingRequest() {{
+            setProductId(request.getProductId());
+            setWeightKg(inferWeight(request.getProductId()));
+            setVolumeCubicM(estimateVolume(request.getProductId()));
+            setZonePreference("A");
+            setExpectedTurnoverDays(5);
+        }});
+        List<MobileInboundResponse.NavigationStep> steps = List.of(
+                new MobileInboundResponse.NavigationStep(request.getDockLocationId(), "Main-Aisle",
+                        distanceBetween(request.getDockLocationId(), "Main-Aisle")),
+                new MobileInboundResponse.NavigationStep("Main-Aisle", slotting.getLocationId(),
+                        distanceBetween("Main-Aisle", slotting.getLocationId()))
+        );
+        return new MobileInboundResponse(slotting.getLocationId(), steps);
+    }
+
+    private double inferWeight(String productId) {
+        return Optional.ofNullable(products.get(productId)).map(WarehouseProduct::getWeightKg).orElse(5.0);
+    }
+
+    private double estimateVolume(String productId) {
+        return Optional.ofNullable(products.get(productId)).map(WarehouseProduct::getVolumeCubicM).orElse(0.2);
+    }
+
+    private double distanceBetween(String from, String to) {
+        double[] origin = coordinatesForLocation(from);
+        double[] destination = coordinatesForLocation(to);
+        double dx = origin[0] - destination[0];
+        double dy = origin[1] - destination[1];
+        double dz = origin[2] - destination[2];
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    private double[] coordinatesForLocation(String id) {
+        String normalized = normalizeLocationId(id);
+        if (normalized == null || normalized.isBlank()) {
+            return new double[]{0, 0, 0};
+        }
+        WarehouseLocation location = locations.get(normalized);
+        if (location != null) {
+            return new double[]{location.getX(), location.getY(), location.getZ()};
+        }
+        return switch (normalized.toLowerCase(Locale.ROOT)) {
+            case "dock-1" -> new double[]{-2, 0, 0};
+            case "main-aisle" -> new double[]{0, 5, 0};
+            case "packing" -> new double[]{-5, 3, 0};
+            default -> new double[]{0, 0, 0};
+        };
+    }
+
+    private double euclideanDistance(double[] from, double[] to) {
+        double dx = from[0] - to[0];
+        double dy = from[1] - to[1];
+        double dz = from[2] - to[2];
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    public PickRouteResponse planPickRoute(PickRouteRequest request) {
+        if (request.getItems() == null || request.getItems().isEmpty()) {
+            return new PickRouteResponse(List.of(), 0, 0);
+        }
+
+        Map<String, Integer> requiredQuantities = new HashMap<>();
+        for (PickRouteRequest.PickItem item : request.getItems()) {
+            if (item.getProductId() == null) {
+                continue;
+            }
+            requiredQuantities.merge(item.getProductId(), Math.max(0, item.getQuantity()), Integer::sum);
+        }
+
+        List<RouteNode> nodes = new ArrayList<>();
+        requiredQuantities.forEach((productId, quantity) -> {
+            int remaining = quantity;
+            List<InventoryItem> candidates = inventory.stream()
+                    .filter(inv -> inv.getProductId().equals(productId))
+                    .sorted(Comparator.comparingInt(InventoryItem::getQuantity).reversed())
+                    .toList();
+            for (InventoryItem candidate : candidates) {
+                if (remaining <= 0) {
+                    break;
+                }
+                WarehouseLocation location = locations.get(candidate.getLocationId());
+                if (location == null) {
+                    continue;
+                }
+                int pickQuantity = Math.min(remaining, candidate.getQuantity());
+                nodes.add(new RouteNode(productId, location, pickQuantity));
+                remaining -= pickQuantity;
+            }
+            if (remaining > 0) {
+                throw new IllegalStateException("Nicht genügend Bestand für Produkt " + productId);
+            }
+        });
+
+        List<RouteNode> ordered = optimiseRoute(nodes);
+        List<PickRouteResponse.RouteWaypoint> waypoints = new ArrayList<>();
+        double[] current = {0, 0, 0};
+        double totalDistance = 0;
+        double cumulativeSeconds = 0;
+        for (RouteNode node : ordered) {
+            double[] destination = {node.location().getX(), node.location().getY(), node.location().getZ()};
+            double legDistance = euclideanDistance(current, destination);
+            totalDistance += legDistance;
+            cumulativeSeconds += legDistance / WALKING_SPEED_MS;
+            cumulativeSeconds += node.quantity() * 4.0;
+            waypoints.add(new PickRouteResponse.RouteWaypoint(node.location().getId(), node.productId(),
+                    destination[0], destination[1], destination[2], Math.round(cumulativeSeconds * 10.0) / 10.0));
+            current = destination;
+        }
+        return new PickRouteResponse(waypoints, Math.round(totalDistance * 10.0) / 10.0,
+                Math.round(cumulativeSeconds * 10.0) / 10.0);
+    }
+
+    public ReturnWorkflowResponse registerReturn(ReturnWorkflowRequest request) {
+        ReturnCase newCase = new ReturnCase(UUID.randomUUID().toString(), request.getProductId(),
+                request.getReason(), "inspection", Instant.now());
+        returnCases.add(newCase);
+        return mapReturnCase(newCase);
+    }
+
+    public List<ReturnWorkflowResponse> listReturnCases() {
+        return returnCases.stream().map(this::mapReturnCase).toList();
+    }
+
+    private ReturnWorkflowResponse mapReturnCase(ReturnCase returnCase) {
+        return new ReturnWorkflowResponse(returnCase.getId(), returnCase.getProductId(),
+                returnCase.getReason(), returnCase.getStatus(), returnCase.getCreatedAt());
+    }
+
+    public CarrierLabelResponse createCarrierLabel(CarrierLabelRequest request) {
+        String tracking = request.getCarrier().substring(0, Math.min(3, request.getCarrier().length())).toUpperCase(Locale.ROOT)
+                + "-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase(Locale.ROOT);
+        String label = "Carrier: " + request.getCarrier() + "\nShipment: " + request.getShipmentId() +
+                "\nWeight: " + request.getWeightKg() + " kg\nDestination: " + request.getDestination();
+        return new CarrierLabelResponse(request.getCarrier(), request.getShipmentId(), tracking, label);
+    }
+
+    public NlpQueryResponse answerQuestion(NlpQueryRequest request) {
+        String query = Optional.ofNullable(request.getQuery()).orElse("?");
+        String lower = query.toLowerCase(Locale.ROOT);
+        Map<String, Object> data = new HashMap<>();
+        String metric = "inventory_value";
+
+        if (containsAny(lower, List.of("überbestand", "overstock", "überhang"))) {
+            metric = "overstock_value";
+            double value = inventory.stream()
+                    .mapToDouble(item -> {
+                        WarehouseProduct product = products.get(item.getProductId());
+                        if (product == null || product.getCostPrice() == null) {
+                            return 0;
+                        }
+                        int capacity = Optional.ofNullable(locations.get(item.getLocationId()))
+                                .map(WarehouseLocation::getCapacity).orElse(0);
+                        int threshold = capacity == 0 ? 50 : (int) Math.round(capacity * 0.8);
+                        int over = Math.max(0, item.getQuantity() - threshold);
+                        return product.getCostPrice().doubleValue() * over;
+                    }).sum();
+            data.put("value", Math.round(value * 100.0) / 100.0);
+            data.put("currency", "CHF");
+        } else if (containsAny(lower, List.of("pick-rate", "kommission", "picks"))) {
+            metric = "pick_rate";
+            double movementPerHour = movementLedger.stream()
+                    .filter(entry -> entry.getTimestamp().isAfter(Instant.now().minus(1, ChronoUnit.DAYS)))
+                    .count() * 2.5;
+            data.put("value", Math.round(movementPerHour));
+            data.put("unit", "picks/hour");
+        } else if (containsAny(lower, List.of("forecast", "prognose", "bedarf"))) {
+            metric = "inventory_forecast";
+            String productId = identifyProductFromQuery(lower)
+                    .orElseGet(() -> inventory.stream().findFirst().map(InventoryItem::getProductId).orElse(""));
+            PredictiveInventoryResponse forecast = forecastInventory(productId);
+            data.put("productId", productId);
+            data.put("weeks", forecast.getForecast());
+        } else if (containsAny(lower, List.of("temperatur", "temperature"))) {
+            metric = "temperature_alert";
+            double maxTemp = sensorReadings.values().stream()
+                    .flatMap(List::stream)
+                    .mapToDouble(SensorReading::getTemperature)
+                    .max()
+                    .orElse(0);
+            data.put("value", maxTemp);
+            data.put("unit", "°C");
+        } else {
+            double value = inventory.stream()
+                    .mapToDouble(item -> Optional.ofNullable(products.get(item.getProductId()))
+                            .map(WarehouseProduct::getCostPrice)
+                            .map(BigDecimal::doubleValue)
+                            .orElse(0.0) * item.getQuantity())
+                    .sum();
+            data.put("value", Math.round(value * 100.0) / 100.0);
+            data.put("currency", "CHF");
+        }
+        return new NlpQueryResponse(query, metric, data,
+                "Die Anfrage wurde KI-gestützt interpretiert und mit aggregierten Lagerdaten beantwortet.");
+    }
+
+    public KpiDashboardResponse buildKpiDashboard() {
+        Map<String, Double> kpis = Map.of(
+                "pick_rate", 318.0,
+                "inventory_turnover", 8.6,
+                "on_time_delivery", 97.2,
+                "scrap_rate", 1.3
+        );
+        Map<String, Double> trends = Map.of(
+                "pick_rate", 4.2,
+                "inventory_turnover", 1.1,
+                "on_time_delivery", 0.4,
+                "scrap_rate", -0.2
+        );
+        return new KpiDashboardResponse(kpis, trends);
+    }
+
+    private boolean containsAny(String query, List<String> tokens) {
+        for (String token : tokens) {
+            if (query.contains(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<String> identifyProductFromQuery(String query) {
+        return products.values().stream()
+                .filter(product -> product.getName() != null)
+                .filter(product -> query.contains(product.getName().toLowerCase(Locale.ROOT))
+                        || query.contains(product.getId().toLowerCase(Locale.ROOT)))
+                .map(WarehouseProduct::getId)
+                .findFirst();
+    }
+
+    private Map<LocalDate, Integer> generateForecast(String productId, int current) {
+        Map<LocalDate, Integer> forecast = new HashMap<>();
+        Map<LocalDate, Integer> history = new HashMap<>();
+        for (MovementLogEntry entry : movementLedger) {
+            if (!Objects.equals(entry.getProductId(), productId)) {
+                continue;
+            }
+            LocalDate date = entry.getTimestamp().atZone(ZoneId.systemDefault()).toLocalDate();
+            int delta = 0;
+            if (entry.getFromLocation() != null && !entry.getFromLocation().isBlank()) {
+                delta -= entry.getQuantity();
+            }
+            if (entry.getToLocation() != null && !entry.getToLocation().isBlank()) {
+                delta += entry.getQuantity();
+            }
+            history.merge(date, delta, Integer::sum);
+        }
+
+        double averageDailyChange = history.entrySet().stream()
+                .filter(entry -> entry.getKey().isAfter(LocalDate.now().minusDays(30)))
+                .mapToDouble(Map.Entry::getValue)
+                .average()
+                .orElse(0);
+
+        double weekdaySeasonality = history.entrySet().stream()
+                .filter(entry -> entry.getKey().getMonth() == LocalDate.now().getMonth())
+                .mapToDouble(Map.Entry::getValue)
+                .average()
+                .orElse(averageDailyChange);
+
+        double expectedChange = (averageDailyChange * 0.7) + (weekdaySeasonality * 0.3);
+        int projection = current;
+        for (int week = 1; week <= 6; week++) {
+            projection += Math.round(expectedChange * 7);
+            forecast.put(LocalDate.now().plusWeeks(week), Math.max(0, projection));
+        }
+        return forecast;
+    }
+
+    private int calculateSafetyStock(String productId) {
+        double avgDailyConsumption = movementLedger.stream()
+                .filter(entry -> Objects.equals(entry.getProductId(), productId))
+                .mapToInt(entry -> entry.getFromLocation() != null && !entry.getFromLocation().isBlank()
+                        ? entry.getQuantity() : 0)
+                .average()
+                .orElse(5);
+        double leadTime = suppliers.values().stream()
+                .mapToDouble(SupplierProfile::getLeadTimeDays)
+                .average()
+                .orElse(5);
+        return (int) Math.round(avgDailyConsumption * leadTime * 0.5);
+    }
+
+    private void adjustInventoryOnMovement(WarehouseProduct product, String fromLocation, String toLocation,
+                                            int quantity, Instant timestamp) {
+        if (fromLocation != null && !fromLocation.isBlank()) {
+            InventoryItem sourceItem = inventory.stream()
+                    .filter(item -> item.getProductId().equals(product.getId())
+                            && fromLocation.equals(item.getLocationId()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Keine Bestände an Standort " + fromLocation + " für Produkt " + product.getId()));
+            if (sourceItem.getQuantity() < quantity) {
+                throw new IllegalStateException("Unzureichender Bestand an Standort " + fromLocation);
+            }
+            sourceItem.setQuantity(sourceItem.getQuantity() - quantity);
+            sourceItem.setLastMovement(timestamp);
+            adjustLocationOccupancy(fromLocation, -quantity);
+            if (sourceItem.getQuantity() == 0) {
+                inventory.remove(sourceItem);
+            }
+        }
+
+        if (toLocation != null && !toLocation.isBlank()) {
+            WarehouseLocation destination = Optional.ofNullable(locations.get(toLocation))
+                    .orElseThrow(() -> new IllegalArgumentException("Unbekannter Zielstandort " + toLocation));
+            if (destination.getOccupied() + quantity > destination.getCapacity()) {
+                throw new IllegalStateException("Zielstandort " + toLocation + " ist überbucht");
+            }
+            InventoryItem target = inventory.stream()
+                    .filter(item -> item.getProductId().equals(product.getId())
+                            && toLocation.equals(item.getLocationId()))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        InventoryItem created = new InventoryItem();
+                        created.setProductId(product.getId());
+                        created.setLocationId(toLocation);
+                        created.setLifecycleStatus("available");
+                        inventory.add(created);
+                        return created;
+                    });
+            target.setQuantity(target.getQuantity() + quantity);
+            target.setLastMovement(timestamp);
+            adjustLocationOccupancy(toLocation, quantity);
+        }
+    }
+
+    private void adjustLocationOccupancy(String locationId, int delta) {
+        String normalized = normalizeLocationId(locationId);
+        if (normalized == null || normalized.isBlank()) {
+            return;
+        }
+        WarehouseLocation location = locations.get(normalized);
+        if (location == null) {
+            return;
+        }
+        int updated = Math.max(0, location.getOccupied() + delta);
+        location.setOccupied(Math.min(updated, location.getCapacity()));
+    }
+
+    private String normalizeLocationId(String locationId) {
+        return locationId == null ? null : locationId.trim();
+    }
+
+    private double aStarDistance(WarehouseLocation target) {
+        GridPoint start = new GridPoint(0, 0, 0);
+        GridPoint goal = new GridPoint((int) Math.round(target.getX()), (int) Math.round(target.getY()),
+                (int) Math.round(target.getZ()));
+        int maxX = (int) Math.ceil(locations.values().stream().mapToDouble(WarehouseLocation::getX).max().orElse(10));
+        int maxY = (int) Math.ceil(locations.values().stream().mapToDouble(WarehouseLocation::getY).max().orElse(10));
+        int maxZ = (int) Math.ceil(locations.values().stream().mapToDouble(WarehouseLocation::getZ).max().orElse(3));
+        Set<GridPoint> blocked = new HashSet<>();
+        locations.values().stream()
+                .filter(WarehouseLocation::isBlocked)
+                .map(loc -> new GridPoint((int) Math.round(loc.getX()), (int) Math.round(loc.getY()),
+                        (int) Math.round(loc.getZ())))
+                .forEach(blocked::add);
+
+        PriorityQueue<PathNode> open = new PriorityQueue<>();
+        Map<GridPoint, Double> gScore = new HashMap<>();
+        open.add(new PathNode(start, 0, heuristic(start, goal)));
+        gScore.put(start, 0.0);
+        Set<GridPoint> closed = new HashSet<>();
+
+        while (!open.isEmpty()) {
+            PathNode current = open.poll();
+            if (current.point().equals(goal)) {
+                return current.g();
+            }
+            if (!closed.add(current.point())) {
+                continue;
+            }
+
+            for (GridPoint neighbour : current.point().neighbours()) {
+                if (neighbour.x() < -2 || neighbour.y() < -2 || neighbour.z() < 0
+                        || neighbour.x() > maxX + 2 || neighbour.y() > maxY + 2 || neighbour.z() > maxZ + 5) {
+                    continue;
+                }
+                if (blocked.contains(neighbour)) {
+                    continue;
+                }
+                double tentative = current.g() + current.point().distanceTo(neighbour);
+                if (tentative < gScore.getOrDefault(neighbour, Double.POSITIVE_INFINITY)) {
+                    gScore.put(neighbour, tentative);
+                    open.add(new PathNode(neighbour, tentative, tentative + heuristic(neighbour, goal)));
+                }
+            }
+        }
+        return euclideanDistance(new double[]{start.x(), start.y(), start.z()},
+                new double[]{goal.x(), goal.y(), goal.z()});
+    }
+
+    private double heuristic(GridPoint from, GridPoint to) {
+        return Math.sqrt(Math.pow(from.x() - to.x(), 2) + Math.pow(from.y() - to.y(), 2)
+                + Math.pow(from.z() - to.z(), 2));
+    }
+
+    private List<RouteNode> optimiseRoute(List<RouteNode> nodes) {
+        if (nodes.size() <= 1) {
+            return nodes;
+        }
+        List<RouteNode> remaining = new ArrayList<>(nodes);
+        List<RouteNode> ordered = new ArrayList<>();
+        double[] current = {0, 0, 0};
+        while (!remaining.isEmpty()) {
+            RouteNode best = null;
+            double bestDistance = Double.MAX_VALUE;
+            for (RouteNode candidate : remaining) {
+                double[] target = {candidate.location().getX(), candidate.location().getY(), candidate.location().getZ()};
+                double distance = euclideanDistance(current, target);
+                if (distance < bestDistance) {
+                    bestDistance = distance;
+                    best = candidate;
+                }
+            }
+            ordered.add(best);
+            current = new double[]{best.location().getX(), best.location().getY(), best.location().getZ()};
+            remaining.remove(best);
+        }
+        return ordered;
+    }
+
+    private record RouteNode(String productId, WarehouseLocation location, int quantity) {
+    }
+
+    private record GridPoint(int x, int y, int z) {
+
+        List<GridPoint> neighbours() {
+            return List.of(
+                    new GridPoint(x + 1, y, z),
+                    new GridPoint(x - 1, y, z),
+                    new GridPoint(x, y + 1, z),
+                    new GridPoint(x, y - 1, z),
+                    new GridPoint(x, y, z + 1),
+                    new GridPoint(x, y, z - 1)
+            );
+        }
+
+        double distanceTo(GridPoint other) {
+            return Math.sqrt(Math.pow(x - other.x(), 2) + Math.pow(y - other.y(), 2)
+                    + Math.pow(z - other.z(), 2));
+        }
+    }
+
+    private record PathNode(GridPoint point, double g, double f) implements Comparable<PathNode> {
+        @Override
+        public int compareTo(PathNode other) {
+            return Double.compare(this.f, other.f);
+        }
+    }
+
+    private static class CategoryStatistics {
+        private double totalWeight;
+        private double totalVolume;
+        private int observations;
+
+        void observe(double weight, double volume) {
+            if (weight > 0) {
+                totalWeight += weight;
+            }
+            if (volume > 0) {
+                totalVolume += volume;
+            }
+            observations++;
+        }
+
+        double getAverageWeight() {
+            return observations == 0 ? 0 : totalWeight / observations;
+        }
+
+        double getAverageVolume() {
+            return observations == 0 ? 0 : totalVolume / observations;
+        }
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/warehouse/service/WarehouseIntelligenceServiceTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/warehouse/service/WarehouseIntelligenceServiceTest.java
@@ -1,0 +1,99 @@
+package com.chrono.chrono.warehouse.service;
+
+import com.chrono.chrono.warehouse.dto.PickRouteRequest;
+import com.chrono.chrono.warehouse.dto.PickRouteResponse;
+import com.chrono.chrono.warehouse.dto.ProductRequest;
+import com.chrono.chrono.warehouse.dto.ProductResponse;
+import com.chrono.chrono.warehouse.model.InventoryItem;
+import com.chrono.chrono.warehouse.model.MovementLogEntry;
+import com.chrono.chrono.warehouse.model.WarehouseLocation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WarehouseIntelligenceServiceTest {
+
+    @Test
+    void upsertProductInfersCategoryAndWeight() {
+        WarehouseIntelligenceService service = new WarehouseIntelligenceService();
+        ProductRequest request = new ProductRequest();
+        request.setName("Quantum Sensor Tag");
+
+        ProductResponse response = service.upsertProduct(request);
+
+        assertEquals("Quantum Sensor Tag", response.getName());
+        assertEquals("IoT", response.getCategory());
+        assertEquals(1.4, response.getWeightKg(), 0.001);
+        assertNotNull(response.getSalesPrice());
+    }
+
+    @Test
+    void recordMovementUpdatesInventoryAndOccupancy() {
+        WarehouseIntelligenceService service = new WarehouseIntelligenceService();
+        InventoryItem source = service.listInventory().stream()
+                .filter(item -> item.getProductId().equals("SKU-AR-01"))
+                .findFirst()
+                .orElseThrow();
+        WarehouseLocation sourceLocationBefore = service.listLocations().stream()
+                .filter(location -> location.getId().equals(source.getLocationId()))
+                .findFirst()
+                .orElseThrow();
+
+        int sourceQuantityBefore = source.getQuantity();
+        int sourceOccupancyBefore = sourceLocationBefore.getOccupied();
+
+        MovementLogEntry entry = service.recordMovement(source.getProductId(), source.getLocationId(), "A-02-03", 5);
+
+        assertEquals("SKU-AR-01", entry.getProductId());
+        assertNotNull(entry.getHash());
+        assertEquals(5, entry.getQuantity());
+
+        InventoryItem updatedSource = service.listInventory().stream()
+                .filter(item -> item.getProductId().equals(source.getProductId())
+                        && item.getLocationId().equals(source.getLocationId()))
+                .findFirst()
+                .orElseThrow();
+        InventoryItem destination = service.listInventory().stream()
+                .filter(item -> item.getProductId().equals(source.getProductId())
+                        && item.getLocationId().equals("A-02-03"))
+                .findFirst()
+                .orElseThrow();
+
+        WarehouseLocation sourceLocationAfter = service.listLocations().stream()
+                .filter(location -> location.getId().equals(source.getLocationId()))
+                .findFirst()
+                .orElseThrow();
+        WarehouseLocation destinationLocation = service.listLocations().stream()
+                .filter(location -> location.getId().equals("A-02-03"))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(sourceQuantityBefore - 5, updatedSource.getQuantity());
+        assertEquals(5, destination.getQuantity());
+        assertEquals(sourceOccupancyBefore - 5, sourceLocationAfter.getOccupied());
+        assertEquals(5, destinationLocation.getOccupied());
+    }
+
+    @Test
+    void planPickRouteOptimisesByDistance() {
+        WarehouseIntelligenceService service = new WarehouseIntelligenceService();
+        PickRouteRequest request = new PickRouteRequest();
+        PickRouteRequest.PickItem gloves = new PickRouteRequest.PickItem();
+        gloves.setProductId("SKU-AR-GLV");
+        gloves.setQuantity(2);
+        PickRouteRequest.PickItem bot = new PickRouteRequest.PickItem();
+        bot.setProductId("SKU-AR-01");
+        bot.setQuantity(1);
+        request.setItems(List.of(gloves, bot));
+
+        PickRouteResponse response = service.planPickRoute(request);
+
+        assertEquals(2, response.getWaypoints().size());
+        assertEquals("A-01-01", response.getWaypoints().get(0).getLocationId());
+        assertEquals("B-01-02", response.getWaypoints().get(1).getLocationId());
+        assertTrue(response.getTotalDistance() > 0);
+        assertTrue(response.getEstimatedDurationSeconds() > 0);
+    }
+}

--- a/Chrono-frontend/package-lock.json
+++ b/Chrono-frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@react-three/drei": "^10.7.6",
+        "@react-three/fiber": "^9.3.0",
         "@tanstack/react-query": "^5.83.0",
         "@testing-library/user-event": "^14.6.1",
         "axios": "1.8.2",
@@ -33,6 +35,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.1.3",
         "rollup": "4.22.4",
+        "three": "^0.180.0",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -1976,6 +1979,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -3161,6 +3170,24 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.1.0.tgz",
+      "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -3248,6 +3275,126 @@
         "bindings": "^1.5.0",
         "nan": "^2.14.0"
       }
+    },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.6",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.6.tgz",
+      "integrity": "sha512-ZSFwRlRaa4zjtB7yHO6Q9xQGuyDCzE7whXBhum92JslcMRC3aouivp0rAzszcVymIoJx6PXmibyP+xr+zKdwLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.3.0.tgz",
+      "integrity": "sha512-myPe3YL/C8+Eq939/4qIVEPBW/uxV0iiUbmjfwrs9sGKYDG8ib8Dz3Okq7BQt8P+0k4igedONbjXMQy84aDFmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.32.0",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "^0.31.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.25.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3685,6 +3832,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3776,6 +3929,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3859,6 +4018,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/plist": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -3904,6 +4069,15 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.1.tgz",
+      "integrity": "sha512-RsqPttsBQ+6af0nATFXJJpemYQH7kL9+xLNm1z+0MjQFDKBZDM2R6SBrjdvRmHu9i9fM6povACj57Ft+pKRNOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -3928,6 +4102,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -3949,6 +4144,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -3965,6 +4166,24 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -4101,6 +4320,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@wojtekmaj/date-utils": {
       "version": "1.5.1",
@@ -4887,7 +5112,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4912,6 +5136,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -5338,6 +5571,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
+      "integrity": "sha512-w5oULNpijgTRH0ARFJJ0R5ct1nUM3R3WP7/b8A6j9uTGpRfnsypc/RBMPQV8JQDPayUe37p/TZZY1PcUr4czOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0",
+        "npm": ">=10.8.2"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -5964,11 +6210,28 @@
         "node": ">= 10"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6385,6 +6648,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -6558,6 +6830,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8101,6 +8379,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8299,6 +8583,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
+      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -8535,7 +8825,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8561,6 +8850,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -9077,6 +9372,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9279,7 +9580,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isstream": {
@@ -9305,6 +9605,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -9680,6 +10001,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/listr2": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -9918,6 +10248,16 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
       }
     },
     "node_modules/magic-string": {
@@ -10262,6 +10602,21 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
       "license": "MIT"
     },
     "node_modules/micromark": {
@@ -11505,7 +11860,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11743,6 +12097,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11841,6 +12201,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -12069,6 +12439,27 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -12115,6 +12506,21 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-binary-file-arch": {
@@ -12379,6 +12785,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12822,7 +13237,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -12835,7 +13249,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13157,6 +13570,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
+    },
     "node_modules/std-env": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
@@ -13470,6 +13909,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
@@ -13574,6 +14022,44 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.0.tgz",
+      "integrity": "sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/throttleit": {
       "version": "1.0.1",
@@ -13781,6 +14267,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -13818,6 +14334,43 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/tweetnacl": {
@@ -14186,6 +14739,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -14199,6 +14761,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utrie": {
       "version": "1.0.2",
@@ -14780,6 +15351,17 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -14831,7 +15413,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/Chrono-frontend/package.json
+++ b/Chrono-frontend/package.json
@@ -12,19 +12,18 @@
     "build": "vite build",
     "build:prod": "vite build --config vite.config.prod.js",
     "serve": "vite preview",
-
     "electron": "electron .",
     "dist:win": "npm run build && electron-builder --win",
     "dist:linux": "npm run build && electron-builder --linux",
-
     "test": "vitest run",
     "test:watch": "vitest",
-
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:codegen": "playwright codegen http://localhost:5173"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.6",
+    "@react-three/fiber": "^9.3.0",
     "@tanstack/react-query": "^5.83.0",
     "@testing-library/user-event": "^14.6.1",
     "axios": "1.8.2",
@@ -49,6 +48,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.1.3",
     "rollup": "4.22.4",
+    "three": "^0.180.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/Chrono-frontend/src/App.jsx
+++ b/Chrono-frontend/src/App.jsx
@@ -45,6 +45,7 @@ import PayslipsPage from "./pages/PayslipsPage.jsx";
 import DemoTour from "./pages/DemoTour.jsx";
 import AdminAccountingPage from "./pages/AdminAccounting/AdminAccountingPage.jsx";
 import SupplyChainDashboard from "./pages/SupplyChain/SupplyChainDashboard.jsx";
+import ChronoTwoDashboard from "./pages/ChronoTwo/ChronoTwoDashboard.jsx";
 import CrmDashboard from "./pages/CRM/CrmDashboard.jsx";
 import BankingOperationsPage from "./pages/AdminBanking/BankingOperationsPage.jsx";
 
@@ -139,6 +140,18 @@ function App() {
                                     redirectTo="/admin/dashboard"
                                 >
                                     <AdminAccountingPage />
+                                </PrivateRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/chrono-two"
+                            element={
+                                <PrivateRoute
+                                    requiredRole="ROLE_ADMIN"
+                                    requiredFeature="chrono2"
+                                    redirectTo="/admin/dashboard"
+                                >
+                                    <ChronoTwoDashboard />
                                 </PrivateRoute>
                             }
                         />

--- a/Chrono-frontend/src/components/Navbar.jsx
+++ b/Chrono-frontend/src/components/Navbar.jsx
@@ -224,6 +224,11 @@ const Navbar = () => {
                                                         {t('navbar.supplyChain','Supply Chain')}
                                                     </Link>
                                                 )}
+                                                {hasFeature('chrono2') && (
+                                                    <Link to="/admin/chrono-two" onClick={() => setOpenAdmin(false)}>
+                                                        Chrono 2.0
+                                                    </Link>
+                                                )}
                                                 {hasFeature('crm') && (
                                                     <Link to="/admin/crm" onClick={() => setOpenAdmin(false)}>
                                                         {t('navbar.crm','CRM & Marketing')}

--- a/Chrono-frontend/src/pages/ChronoTwo/ChronoTwoDashboard.jsx
+++ b/Chrono-frontend/src/pages/ChronoTwo/ChronoTwoDashboard.jsx
@@ -1,0 +1,771 @@
+import { useEffect, useMemo, useState } from "react";
+import { Canvas } from "@react-three/fiber";
+import { Line, OrbitControls } from "@react-three/drei";
+import api from "../../utils/api.js";
+import "../../styles/ChronoTwoDashboard.css";
+
+const prettifyMetricKey = (metric) =>
+    metric
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const initialForms = {
+    product: { name: "", category: "", costPrice: "", weightKg: "" },
+    slotting: { productId: "", weightKg: 1, volumeCubicM: 0.1, zonePreference: "A", expectedTurnoverDays: 7 },
+    sourcing: { productId: "", quantity: 10 },
+    accounting: { purchaseOrderId: "PO-", orderedAmount: "", receivedAmount: "", invoicedAmount: "" },
+    inbound: { productId: "", quantity: 10, dockLocationId: "Dock-1" },
+    pick: { items: [{ productId: "", quantity: 1 }] },
+    nlp: "Wie hoch ist unser Überbestand?",
+    sensor: { locationId: "", temperature: 21, humidity: 48, weight: 100 },
+};
+
+const defaultPreference = (supplierId) => ({
+    supplierId,
+    weightPrice: 0.4,
+    weightReliability: 0.4,
+    weightSustainability: 0.2,
+});
+
+const LocationCube = ({ position, occupancyRatio, height, highlight }) => {
+    const baseColor = occupancyRatio > 0.85 ? "#ff5f56" : occupancyRatio > 0.5 ? "#ffa500" : "#1abc9c";
+    const color = highlight ? "#ff4757" : baseColor;
+    return (
+        <mesh position={position}>
+            <boxGeometry args={[0.9, height, 0.9]} />
+            <meshStandardMaterial color={color} opacity={0.8} transparent />
+        </mesh>
+    );
+};
+
+const ChronoTwoDashboard = () => {
+    const [products, setProducts] = useState([]);
+    const [locations, setLocations] = useState([]);
+    const [inventory, setInventory] = useState([]);
+    const [kpis, setKpis] = useState({ kpis: {}, trends: {} });
+    const [returns, setReturns] = useState([]);
+    const [forecast, setForecast] = useState(null);
+    const [slotting, setSlotting] = useState(null);
+    const [sourcing, setSourcing] = useState(null);
+    const [accounting, setAccounting] = useState(null);
+    const [inbound, setInbound] = useState(null);
+    const [pickRoute, setPickRoute] = useState(null);
+    const [nlpResponse, setNlpResponse] = useState(null);
+    const [movementLedger, setMovementLedger] = useState([]);
+    const [sensorForm, setSensorForm] = useState({ ...initialForms.sensor });
+    const [sensorData, setSensorData] = useState({});
+    const [formState, setFormState] = useState(initialForms);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                setLoading(true);
+                const [prodRes, locRes, invRes, kpiRes, returnsRes, ledgerRes] = await Promise.all([
+                    api.get("/chrono2/products"),
+                    api.get("/chrono2/locations"),
+                    api.get("/chrono2/inventory"),
+                    api.get("/chrono2/analytics/kpis"),
+                    api.get("/chrono2/outbound/returns"),
+                    api.get("/chrono2/blockchain/movement"),
+                ]);
+                setProducts(prodRes.data);
+                setLocations(locRes.data);
+                setInventory(invRes.data);
+                setKpis(kpiRes.data);
+                setReturns(returnsRes.data);
+                setMovementLedger(ledgerRes.data);
+                if (prodRes.data.length > 0) {
+                    fetchForecast(prodRes.data[0].id);
+                }
+            } catch (err) {
+                setError(err.message ?? "Fehler beim Laden der Chrono 2.0 Daten");
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, []);
+
+    const occupancyByLocation = useMemo(() => {
+        const map = new Map();
+        locations.forEach((loc) => {
+            map.set(loc.id, { capacity: loc.capacity, occupied: loc.occupied ?? 0 });
+        });
+        inventory.forEach((item) => {
+            const entry = map.get(item.locationId);
+            if (entry) {
+                entry.occupied += item.quantity;
+            }
+        });
+        return map;
+    }, [locations, inventory]);
+
+    const locationScale = 0.5;
+
+    const routeLocationIds = useMemo(() => new Set(pickRoute?.waypoints?.map((wp) => wp.locationId) ?? []), [pickRoute]);
+
+    const routePoints = useMemo(() => {
+        if (!pickRoute?.waypoints?.length) {
+            return [];
+        }
+        const points = [[0, 0, 0]];
+        pickRoute.waypoints.forEach((wp) => {
+            points.push([wp.x * locationScale, wp.z * locationScale, wp.y * locationScale]);
+        });
+        return points;
+    }, [pickRoute, locationScale]);
+
+    const fetchForecast = async (productId) => {
+        try {
+            const response = await api.get(`/chrono2/inventory/${productId}/forecast`);
+            setForecast(response.data);
+        } catch (err) {
+            setError(err.message ?? "Vorhersage konnte nicht geladen werden");
+        }
+    };
+
+    const handleFormChange = (key, field, value) => {
+        setFormState((prev) => ({
+            ...prev,
+            [key]: { ...prev[key], [field]: value },
+        }));
+    };
+
+    const submitProduct = async (evt) => {
+        evt.preventDefault();
+        try {
+            const payload = {
+                ...formState.product,
+                costPrice: formState.product.costPrice ? Number(formState.product.costPrice) : undefined,
+                weightKg: formState.product.weightKg ? Number(formState.product.weightKg) : undefined,
+            };
+            const response = await api.post("/chrono2/products", payload);
+            setProducts((prev) => [response.data, ...prev.filter((p) => p.id !== response.data.id)]);
+            setFormState((prev) => ({ ...prev, product: initialForms.product }));
+        } catch (err) {
+            setError(err.message ?? "Produkt konnte nicht gespeichert werden");
+        }
+    };
+
+    const submitSlotting = async (evt) => {
+        evt.preventDefault();
+        try {
+            const payload = {
+                ...formState.slotting,
+                weightKg: Number(formState.slotting.weightKg),
+                volumeCubicM: Number(formState.slotting.volumeCubicM),
+                expectedTurnoverDays: Number(formState.slotting.expectedTurnoverDays),
+            };
+            const response = await api.post("/chrono2/slotting", payload);
+            setSlotting(response.data);
+        } catch (err) {
+            setError(err.message ?? "Smart Slotting fehlgeschlagen");
+        }
+    };
+
+    const submitSensor = async (evt) => {
+        evt.preventDefault();
+        try {
+            const payload = {
+                ...sensorForm,
+                temperature: Number(sensorForm.temperature),
+                humidity: Number(sensorForm.humidity),
+                weight: Number(sensorForm.weight),
+            };
+            await api.post("/chrono2/iot", payload);
+            const refreshed = await api.get(`/chrono2/iot/${payload.locationId}`);
+            setSensorData((prev) => ({ ...prev, [payload.locationId]: refreshed.data }));
+            setSensorForm({ ...initialForms.sensor });
+            setError(null);
+        } catch (err) {
+            setError(err.message ?? "IoT-Übermittlung fehlgeschlagen");
+        }
+    };
+
+    const submitSourcing = async (evt) => {
+        evt.preventDefault();
+        try {
+            const preferences = [defaultPreference("SUP-001"), defaultPreference("SUP-002"), defaultPreference("SUP-003")];
+            const response = await api.post("/chrono2/procurement/sourcing", {
+                ...formState.sourcing,
+                quantity: Number(formState.sourcing.quantity),
+                preferences,
+            });
+            setSourcing(response.data);
+        } catch (err) {
+            setError(err.message ?? "Smart Sourcing fehlgeschlagen");
+        }
+    };
+
+    const submitAccounting = async (evt) => {
+        evt.preventDefault();
+        try {
+            const response = await api.post("/chrono2/procurement/accounting", {
+                ...formState.accounting,
+                orderedAmount: Number(formState.accounting.orderedAmount),
+                receivedAmount: Number(formState.accounting.receivedAmount),
+                invoicedAmount: Number(formState.accounting.invoicedAmount),
+            });
+            setAccounting(response.data);
+        } catch (err) {
+            setError(err.message ?? "Autonomous Accounting fehlgeschlagen");
+        }
+    };
+
+    const submitInbound = async (evt) => {
+        evt.preventDefault();
+        try {
+            const response = await api.post("/chrono2/procurement/mobile-inbound", {
+                ...formState.inbound,
+                quantity: Number(formState.inbound.quantity),
+            });
+            setInbound(response.data);
+        } catch (err) {
+            setError(err.message ?? "Inbound Guidance fehlgeschlagen");
+        }
+    };
+
+    const submitPick = async (evt) => {
+        evt.preventDefault();
+        try {
+            const payload = {
+                items: formState.pick.items.map((item) => ({
+                    productId: item.productId,
+                    quantity: Number(item.quantity),
+                })),
+            };
+            const response = await api.post("/chrono2/outbound/pick-route", payload);
+            setPickRoute(response.data);
+        } catch (err) {
+            setError(err.message ?? "Pick-by-Vision Planung fehlgeschlagen");
+        }
+    };
+
+    const submitNlp = async (evt) => {
+        evt.preventDefault();
+        try {
+            const response = await api.post("/chrono2/analytics/nlp", { query: formState.nlp });
+            setNlpResponse(response.data);
+        } catch (err) {
+            setError(err.message ?? "NLP-Anfrage konnte nicht beantwortet werden");
+        }
+    };
+
+    const pickItems = formState.pick.items;
+
+    const updatePickItem = (index, field, value) => {
+        setFormState((prev) => {
+            const items = [...prev.pick.items];
+            items[index] = { ...items[index], [field]: value };
+            return { ...prev, pick: { items } };
+        });
+    };
+
+    const addPickItem = () => {
+        setFormState((prev) => ({
+            ...prev,
+            pick: { items: [...prev.pick.items, { productId: "", quantity: 1 }] },
+        }));
+    };
+
+    const removePickItem = (index) => {
+        setFormState((prev) => ({
+            ...prev,
+            pick: { items: prev.pick.items.filter((_, i) => i !== index) },
+        }));
+    };
+
+    const humanReadableKpis = Object.entries(kpis.kpis ?? {});
+    const kpiTrends = kpis.trends ?? {};
+
+    return (
+        <div className="chrono-two admin-page">
+            <header className="chrono-two__header">
+                <div className="chrono-two__title">
+                    <span className="chrono-two__pill">Release Candidate</span>
+                    <h1>Chrono 2.0 – Intelligente Lagersteuerung</h1>
+                    <p className="muted">KI, AR und Automatisierung nahtlos in einer Plattform.</p>
+                </div>
+                <div className="kpi-strip">
+                    {humanReadableKpis.map(([key, value]) => {
+                        const trend = typeof kpiTrends[key] === "number" ? kpiTrends[key] : undefined;
+                        const trendClass = trend > 0 ? "kpi-trend kpi-trend--up" : trend < 0 ? "kpi-trend kpi-trend--down" : "kpi-trend";
+                        const trendSymbol = trend > 0 ? "▲" : trend < 0 ? "▼" : "■";
+                        return (
+                            <div className="kpi" key={key}>
+                                <span className="kpi-label">{prettifyMetricKey(key)}</span>
+                                <span className="kpi-value">{value}</span>
+                                {trend !== undefined && (
+                                    <span className={trendClass}>
+                                        {trendSymbol} {Math.abs(trend).toFixed(1)}%
+                                    </span>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            </header>
+
+            {error && <div className="alert alert-error">{error}</div>}
+            {loading && <div className="loading">Chrono 2.0 Daten werden geladen …</div>}
+
+            <section className="grid grid-2">
+                <article className="card">
+                    <h2>3D-Lager-Zwilling</h2>
+                    <p className="muted">WebGL-Ansicht des Lagers mit Echtzeit-Auslastung.</p>
+                    <div className="three-wrapper">
+                        <Canvas camera={{ position: [5, 5, 8] }}>
+                            <ambientLight intensity={0.6} />
+                            <pointLight position={[10, 10, 10]} />
+                            {locations.map((loc) => {
+                                const occupancy = occupancyByLocation.get(loc.id);
+                                const ratio = occupancy ? Math.min(1, occupancy.occupied / Math.max(1, occupancy.capacity)) : 0;
+                                const height = Math.max(0.4, ratio * 1.6 + 0.2);
+                                return (
+                                    <LocationCube
+                                        key={loc.id}
+                                        position={[loc.x * locationScale, loc.z * locationScale + height / 2, loc.y * locationScale]}
+                                        occupancyRatio={ratio}
+                                        height={height}
+                                        highlight={routeLocationIds.has(loc.id)}
+                                    />
+                                );
+                            })}
+                            {routePoints.length > 1 && (
+                                <Line points={routePoints} color="#ff4757" lineWidth={2} dashed={false} />
+                            )}
+                            {pickRoute?.waypoints?.map((wp) => (
+                                <mesh key={`${wp.locationId}-${wp.productId}`} position={[wp.x * locationScale, wp.z * locationScale + 0.15, wp.y * locationScale]}>
+                                    <sphereGeometry args={[0.2, 16, 16]} />
+                                    <meshStandardMaterial color="#ff4757" />
+                                </mesh>
+                            ))}
+                            <OrbitControls enablePan enableRotate enableZoom />
+                        </Canvas>
+                    </div>
+                </article>
+
+                <article className="card">
+                    <h2>Stammdaten & KI-Datenanreicherung</h2>
+                    <form className="form-grid" onSubmit={submitProduct}>
+                        <label>
+                            Produktname
+                            <input
+                                type="text"
+                                value={formState.product.name}
+                                onChange={(e) => handleFormChange("product", "name", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Kategorie
+                            <input
+                                type="text"
+                                value={formState.product.category}
+                                onChange={(e) => handleFormChange("product", "category", e.target.value)}
+                            />
+                        </label>
+                        <label>
+                            Einstandspreis (CHF)
+                            <input
+                                type="number"
+                                step="0.01"
+                                value={formState.product.costPrice}
+                                onChange={(e) => handleFormChange("product", "costPrice", e.target.value)}
+                            />
+                        </label>
+                        <label>
+                            Gewicht (kg)
+                            <input
+                                type="number"
+                                step="0.1"
+                                value={formState.product.weightKg}
+                                onChange={(e) => handleFormChange("product", "weightKg", e.target.value)}
+                            />
+                        </label>
+                        <button className="btn primary" type="submit">Produkt anreichern</button>
+                    </form>
+                    <div className="table-wrapper">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Produkt</th>
+                                    <th>Kategorie</th>
+                                    <th>Gewicht</th>
+                                    <th>VK-Preis</th>
+                                    <th>Segment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {products.map((product) => (
+                                    <tr key={product.id} onClick={() => fetchForecast(product.id)}>
+                                        <td>{product.name}</td>
+                                        <td>{product.category}</td>
+                                        <td>{product.weightKg?.toFixed?.(2)} kg</td>
+                                        <td>{product.salesPrice} CHF</td>
+                                        <td>{product.demandSegment}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </article>
+            </section>
+
+            <section className="grid grid-3">
+                <article className="card">
+                    <h3>Smart Slotting</h3>
+                    <form className="form-grid" onSubmit={submitSlotting}>
+                        <label>
+                            Produkt-ID
+                            <input
+                                type="text"
+                                value={formState.slotting.productId}
+                                onChange={(e) => handleFormChange("slotting", "productId", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Gewicht (kg)
+                            <input
+                                type="number"
+                                value={formState.slotting.weightKg}
+                                onChange={(e) => handleFormChange("slotting", "weightKg", e.target.value)}
+                            />
+                        </label>
+                        <label>
+                            Volumen (m³)
+                            <input
+                                type="number"
+                                value={formState.slotting.volumeCubicM}
+                                onChange={(e) => handleFormChange("slotting", "volumeCubicM", e.target.value)}
+                            />
+                        </label>
+                        <label>
+                            Umschlagszeit (Tage)
+                            <input
+                                type="number"
+                                value={formState.slotting.expectedTurnoverDays}
+                                onChange={(e) => handleFormChange("slotting", "expectedTurnoverDays", e.target.value)}
+                            />
+                        </label>
+                        <button className="btn" type="submit">Optimale Position berechnen</button>
+                    </form>
+                    {slotting && (
+                        <div className="result">
+                            <strong>Lagerplatz:</strong> {slotting.locationId}<br />
+                            <strong>Confidence:</strong> {(slotting.confidence * 100).toFixed(1)} %<br />
+                            <strong>Grund:</strong> {slotting.reason}
+                        </div>
+                    )}
+                </article>
+
+                <article className="card">
+                    <h3>Predictive Inventory</h3>
+                    {forecast ? (
+                        <ul className="forecast-list">
+                            {Object.entries(forecast.forecast).map(([date, value]) => (
+                                <li key={date}>
+                                    <span>{date}</span>
+                                    <span>{value} Stk.</span>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="muted">Wähle ein Produkt, um die 6-Wochen-Vorhersage zu sehen.</p>
+                    )}
+                    {forecast && (
+                        <div className="alerts">
+                            {forecast.stockOutRisk && <span className="badge warning">Stock-Out Risiko</span>}
+                            {forecast.overstockRisk && <span className="badge info">Überbestand möglich</span>}
+                        </div>
+                    )}
+                </article>
+
+                <article className="card">
+                    <h3>IoT Monitoring</h3>
+                    <form className="form-grid" onSubmit={submitSensor}>
+                        <label>
+                            Lagerplatz
+                            <input
+                                type="text"
+                                value={sensorForm.locationId}
+                                onChange={(e) => setSensorForm((prev) => ({ ...prev, locationId: e.target.value }))}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Temperatur (°C)
+                            <input
+                                type="number"
+                                value={sensorForm.temperature}
+                                onChange={(e) => setSensorForm((prev) => ({ ...prev, temperature: e.target.value }))}
+                            />
+                        </label>
+                        <label>
+                            Luftfeuchte (%)
+                            <input
+                                type="number"
+                                value={sensorForm.humidity}
+                                onChange={(e) => setSensorForm((prev) => ({ ...prev, humidity: e.target.value }))}
+                            />
+                        </label>
+                        <label>
+                            Gewicht (kg)
+                            <input
+                                type="number"
+                                value={sensorForm.weight}
+                                onChange={(e) => setSensorForm((prev) => ({ ...prev, weight: e.target.value }))}
+                            />
+                        </label>
+                        <button className="btn" type="submit">Messwert senden</button>
+                    </form>
+                    <p className="muted">Werte werden revisionssicher dokumentiert.</p>
+                    {Object.entries(sensorData).length > 0 && (
+                        <ul className="ledger">
+                            {Object.entries(sensorData).map(([loc, readings]) => {
+                                const last = readings[readings.length - 1];
+                                if (!last) return null;
+                                return (
+                                    <li key={loc}>
+                                        {loc}: {last.temperature.toFixed?.(1)}°C · {last.humidity.toFixed?.(1)}% · {last.weight.toFixed?.(1)} kg
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </article>
+            </section>
+
+            <section className="grid grid-3">
+                <article className="card">
+                    <h3>Smart Sourcing</h3>
+                    <form className="form-grid" onSubmit={submitSourcing}>
+                        <label>
+                            Produkt-ID
+                            <input
+                                type="text"
+                                value={formState.sourcing.productId}
+                                onChange={(e) => handleFormChange("sourcing", "productId", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Menge
+                            <input
+                                type="number"
+                                value={formState.sourcing.quantity}
+                                onChange={(e) => handleFormChange("sourcing", "quantity", e.target.value)}
+                            />
+                        </label>
+                        <button className="btn" type="submit">Lieferanten bewerten</button>
+                    </form>
+                    {sourcing && (
+                        <div className="result">
+                            <strong>Empfehlung:</strong> {sourcing.recommended?.supplierName}<br />
+                            <strong>Score:</strong> {sourcing.recommended?.score.toFixed?.(2)}
+                            <ul className="muted">
+                                {sourcing.rankedSuppliers?.map((supplier) => (
+                                    <li key={supplier.supplierId}>
+                                        {supplier.supplierName} · Score {supplier.score.toFixed(2)} · {supplier.leadTimeDays} Tage
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </article>
+
+                <article className="card">
+                    <h3>Autonomous Accounting</h3>
+                    <form className="form-grid" onSubmit={submitAccounting}>
+                        <label>
+                            Bestellnummer
+                            <input
+                                type="text"
+                                value={formState.accounting.purchaseOrderId}
+                                onChange={(e) => handleFormChange("accounting", "purchaseOrderId", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Bestellt (CHF)
+                            <input
+                                type="number"
+                                value={formState.accounting.orderedAmount}
+                                onChange={(e) => handleFormChange("accounting", "orderedAmount", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Wareneingang (CHF)
+                            <input
+                                type="number"
+                                value={formState.accounting.receivedAmount}
+                                onChange={(e) => handleFormChange("accounting", "receivedAmount", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Rechnung (CHF)
+                            <input
+                                type="number"
+                                value={formState.accounting.invoicedAmount}
+                                onChange={(e) => handleFormChange("accounting", "invoicedAmount", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <button className="btn" type="submit">3-Wege-Abgleich prüfen</button>
+                    </form>
+                    {accounting && (
+                        <div className="result">
+                            <strong>Status:</strong> {accounting.autoApproved ? "Auto-Freigabe" : "Manuelle Prüfung"}<br />
+                            <strong>Abweichung:</strong> {accounting.deviation} CHF
+                        </div>
+                    )}
+                </article>
+
+                <article className="card">
+                    <h3>Mobile Inbound</h3>
+                    <form className="form-grid" onSubmit={submitInbound}>
+                        <label>
+                            Produkt-ID
+                            <input
+                                type="text"
+                                value={formState.inbound.productId}
+                                onChange={(e) => handleFormChange("inbound", "productId", e.target.value)}
+                                required
+                            />
+                        </label>
+                        <label>
+                            Menge
+                            <input
+                                type="number"
+                                value={formState.inbound.quantity}
+                                onChange={(e) => handleFormChange("inbound", "quantity", e.target.value)}
+                            />
+                        </label>
+                        <label>
+                            Rampe
+                            <input
+                                type="text"
+                                value={formState.inbound.dockLocationId}
+                                onChange={(e) => handleFormChange("inbound", "dockLocationId", e.target.value)}
+                            />
+                        </label>
+                        <button className="btn" type="submit">Route anzeigen</button>
+                    </form>
+                    {inbound && (
+                        <ul className="muted">
+                            <li>Slot: {inbound.assignedLocationId}</li>
+                            {inbound.navigation?.map((step, idx) => (
+                                <li key={`${step.from}-${idx}`}>
+                                    {step.from} ➜ {step.to} ({step.distanceMeters.toFixed(1)} m)
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </article>
+            </section>
+
+            <section className="grid grid-2">
+                <article className="card">
+                    <h3>Pick-by-Vision Routen</h3>
+                    <form className="form-grid" onSubmit={submitPick}>
+                        {pickItems.map((item, index) => (
+                            <div key={`pick-${index}`} className="pick-item">
+                                <label>
+                                    Produkt-ID
+                                    <input
+                                        type="text"
+                                        value={item.productId}
+                                        onChange={(e) => updatePickItem(index, "productId", e.target.value)}
+                                        required
+                                    />
+                                </label>
+                                <label>
+                                    Menge
+                                    <input
+                                        type="number"
+                                        value={item.quantity}
+                                        onChange={(e) => updatePickItem(index, "quantity", Number(e.target.value))}
+                                        min={1}
+                                    />
+                                </label>
+                                {pickItems.length > 1 && (
+                                    <button type="button" className="btn ghost" onClick={() => removePickItem(index)}>
+                                        Entfernen
+                                    </button>
+                                )}
+                            </div>
+                        ))}
+                        <div className="pick-actions">
+                            <button type="button" className="btn ghost" onClick={addPickItem}>Position hinzufügen</button>
+                            <button type="submit" className="btn">Route planen</button>
+                        </div>
+                    </form>
+                    {pickRoute && (
+                        <div className="result">
+                            <strong>Gesamtzeit:</strong> {pickRoute.estimatedDurationSeconds.toFixed?.(1)} s<br />
+                            <strong>Distanz:</strong> {pickRoute.totalDistance.toFixed?.(1)} m
+                            <ul>
+                                {pickRoute.waypoints?.map((wp, idx) => (
+                                    <li key={`${wp.locationId}-${idx}`}>
+                                        {wp.productId} · {wp.locationId} · ETA {wp.etaSeconds.toFixed(1)} s
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </article>
+
+                <article className="card">
+                    <h3>NLP Dashboard</h3>
+                    <form className="form-inline" onSubmit={submitNlp}>
+                        <input
+                            type="text"
+                            value={formState.nlp}
+                            onChange={(e) => setFormState((prev) => ({ ...prev, nlp: e.target.value }))}
+                            placeholder="Frag die Chrono-KI …"
+                        />
+                        <button className="btn" type="submit">Analysieren</button>
+                    </form>
+                    {nlpResponse && (
+                        <div className="result">
+                            <strong>{nlpResponse.interpretedMetric}</strong>
+                            <pre>{JSON.stringify(nlpResponse.data, null, 2)}</pre>
+                            <span className="muted">{nlpResponse.explanation}</span>
+                        </div>
+                    )}
+                </article>
+            </section>
+
+            <section className="grid grid-2">
+                <article className="card">
+                    <h3>Zirkuläre Logistik</h3>
+                    <ul>
+                        {returns.map((item) => (
+                            <li key={item.caseId}>
+                                <strong>{item.productId}</strong> – {item.reason} · Status {item.status}
+                            </li>
+                        ))}
+                    </ul>
+                </article>
+
+                <article className="card">
+                    <h3>Blockchain-Bewegungen</h3>
+                    <ul className="ledger">
+                        {movementLedger.map((entry) => (
+                            <li key={entry.id}>
+                                {entry.productId}: {entry.fromLocation ?? "Anlieferung"} ➜ {entry.toLocation} · {entry.quantity} Stk.
+                            </li>
+                        ))}
+                    </ul>
+                </article>
+            </section>
+        </div>
+    );
+};
+
+export default ChronoTwoDashboard;

--- a/Chrono-frontend/src/styles/ChronoTwoDashboard.css
+++ b/Chrono-frontend/src/styles/ChronoTwoDashboard.css
@@ -1,0 +1,466 @@
+:root {
+    --chrono-bg: #020617;
+    --chrono-gradient: linear-gradient(135deg, #0ea5e9 0%, #6366f1 38%, #8b5cf6 70%, #f43f5e 100%);
+    --chrono-panel: rgba(15, 23, 42, 0.78);
+    --chrono-border: rgba(148, 163, 184, 0.25);
+    --chrono-text: #e2e8f0;
+    --chrono-muted: #94a3b8;
+    --chrono-card: rgba(15, 23, 42, 0.75);
+    --chrono-highlight: rgba(14, 165, 233, 0.16);
+}
+
+.chrono-two {
+    position: relative;
+    padding: 2.5rem clamp(1.5rem, 3vw, 3rem);
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    color: var(--chrono-text);
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(99, 102, 241, 0.18) 0%, rgba(2, 6, 23, 0.95) 50%),
+        var(--chrono-bg);
+    overflow: hidden;
+}
+
+.chrono-two::before,
+.chrono-two::after {
+    content: "";
+    position: absolute;
+    inset: auto;
+    width: clamp(300px, 45vw, 640px);
+    height: clamp(300px, 45vw, 640px);
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(99, 102, 241, 0.22), transparent 70%);
+    filter: blur(0);
+    z-index: 0;
+}
+
+.chrono-two::before {
+    top: -20%;
+    right: -15%;
+}
+
+.chrono-two::after {
+    bottom: -25%;
+    left: -10%;
+    background: radial-gradient(circle, rgba(14, 165, 233, 0.18), transparent 70%);
+}
+
+.chrono-two > * {
+    position: relative;
+    z-index: 1;
+}
+
+.chrono-two__header {
+    display: flex;
+    justify-content: space-between;
+    gap: clamp(1.5rem, 2vw, 3rem);
+    align-items: flex-end;
+    padding: 1.75rem 2rem;
+    border-radius: 24px;
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.85) 0%, rgba(15, 23, 42, 0.55) 65%, rgba(59, 130, 246, 0.18) 100%);
+    border: 1px solid var(--chrono-border);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 24px 65px -35px rgba(15, 23, 42, 0.85);
+}
+
+.chrono-two__title h1 {
+    margin: 0;
+    font-size: clamp(2.1rem, 2.6vw, 2.8rem);
+    letter-spacing: -0.01em;
+}
+
+.chrono-two__pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(14, 165, 233, 0.15);
+    color: #38bdf8;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 0.75rem;
+}
+
+.chrono-two .muted {
+    color: var(--chrono-muted);
+}
+
+.kpi-strip {
+    display: flex;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+}
+
+.kpi {
+    min-width: 140px;
+    padding: 1rem 1.4rem;
+    border-radius: 18px;
+    background: linear-gradient(160deg, rgba(14, 165, 233, 0.16) 0%, rgba(148, 163, 184, 0.05) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    box-shadow: 0 18px 45px -30px rgba(14, 165, 233, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.kpi-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: var(--chrono-muted);
+}
+
+.kpi-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.kpi-trend {
+    font-size: 0.78rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.kpi-trend--up {
+    color: #4ade80;
+}
+
+.kpi-trend--down {
+    color: #f87171;
+}
+
+.grid {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.grid-2 {
+    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+}
+
+.grid-3 {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+    background: var(--chrono-card);
+    border-radius: 22px;
+    padding: 1.75rem;
+    box-shadow: 0 25px 60px -35px rgba(15, 23, 42, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    border: 1px solid var(--chrono-border);
+    backdrop-filter: blur(20px);
+    transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
+}
+
+.card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(94, 234, 212, 0.4);
+    box-shadow: 0 32px 90px -45px rgba(6, 182, 212, 0.65);
+}
+
+.card h2,
+.card h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    letter-spacing: -0.01em;
+}
+
+.card > p.muted {
+    margin-top: -0.4rem;
+}
+
+.three-wrapper {
+    height: 340px;
+    border-radius: 18px;
+    overflow: hidden;
+    background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.45), rgba(15, 23, 42, 0.85));
+    border: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.table-wrapper {
+    max-height: 260px;
+    overflow: auto;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.table-wrapper table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+    background: rgba(2, 6, 23, 0.5);
+}
+
+.table-wrapper thead {
+    position: sticky;
+    top: 0;
+    background: rgba(15, 23, 42, 0.92);
+    backdrop-filter: blur(6px);
+}
+
+.table-wrapper th,
+.table-wrapper td {
+    text-align: left;
+    padding: 0.65rem 0.85rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.table-wrapper tbody tr:nth-child(odd) {
+    background: rgba(15, 23, 42, 0.35);
+}
+
+.table-wrapper tbody tr:hover {
+    background: rgba(56, 189, 248, 0.12);
+    cursor: pointer;
+}
+
+.form-grid {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+}
+
+.form-grid input,
+.form-grid select,
+.form-inline input {
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    padding: 0.65rem 0.85rem;
+    font-size: 0.92rem;
+    background: rgba(2, 6, 23, 0.6);
+    color: var(--chrono-text);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-grid input:focus-visible,
+.form-grid select:focus-visible,
+.form-inline input:focus-visible {
+    outline: none;
+    border-color: rgba(56, 189, 248, 0.55);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+}
+
+.form-inline {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.btn {
+    padding: 0.7rem 1.35rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--chrono-gradient);
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.btn.primary {
+    background: linear-gradient(135deg, #6366f1, #8b5cf6, #a855f7);
+}
+
+.btn.ghost {
+    background: rgba(2, 6, 23, 0.35);
+    border: 1px dashed rgba(94, 234, 212, 0.4);
+    color: var(--chrono-text);
+}
+
+.btn:hover,
+.btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 40px -20px rgba(14, 165, 233, 0.85);
+}
+
+.btn:focus-visible {
+    outline: none;
+}
+
+.alert {
+    padding: 1.1rem 1.5rem;
+    border-radius: 14px;
+    border: 1px solid rgba(248, 113, 113, 0.35);
+    background: rgba(248, 113, 113, 0.12);
+    color: #fecaca;
+}
+
+.loading {
+    font-style: italic;
+    color: var(--chrono-muted);
+}
+
+.result {
+    background: rgba(15, 23, 42, 0.58);
+    padding: 1.1rem 1.25rem;
+    border-radius: 14px;
+    font-size: 0.92rem;
+    border-left: 3px solid rgba(94, 234, 212, 0.55);
+}
+
+.forecast-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.forecast-list li {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+}
+
+.badge {
+    display: inline-flex;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    margin-right: 0.5rem;
+    background: rgba(2, 6, 23, 0.55);
+    border: 1px solid rgba(94, 234, 212, 0.3);
+}
+
+.badge.warning {
+    background: rgba(250, 204, 21, 0.18);
+    color: #facc15;
+}
+
+.badge.info {
+    background: rgba(56, 189, 248, 0.18);
+    color: #38bdf8;
+}
+
+.pick-item {
+    display: grid;
+    gap: 0.7rem;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    align-items: end;
+}
+
+.pick-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.85rem;
+    flex-wrap: wrap;
+}
+
+.ledger {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    max-height: 220px;
+    overflow: auto;
+    font-size: 0.86rem;
+    padding-right: 0.4rem;
+}
+
+.ledger li {
+    padding: 0.4rem 0.2rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.ledger li:last-child {
+    border-bottom: none;
+}
+
+.chrono-two section {
+    position: relative;
+    z-index: 1;
+}
+
+.chrono-two section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 24px;
+    background: linear-gradient(120deg, rgba(14, 165, 233, 0.12), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    z-index: -1;
+}
+
+.chrono-two section:hover::before {
+    opacity: 1;
+}
+
+.chrono-two ul {
+    margin: 0;
+    padding-left: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.chrono-two li {
+    list-style: none;
+    position: relative;
+    padding-left: 1.1rem;
+}
+
+.chrono-two li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55rem;
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: rgba(94, 234, 212, 0.55);
+}
+
+.chrono-two pre {
+    background: rgba(2, 6, 23, 0.6);
+    padding: 0.75rem;
+    border-radius: 10px;
+    overflow-x: auto;
+}
+
+.chrono-two ::-webkit-scrollbar {
+    width: 8px;
+}
+
+.chrono-two ::-webkit-scrollbar-track {
+    background: rgba(15, 23, 42, 0.35);
+}
+
+.chrono-two ::-webkit-scrollbar-thumb {
+    background: rgba(14, 165, 233, 0.45);
+    border-radius: 999px;
+}
+
+@media (max-width: 960px) {
+    .chrono-two__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .kpi-strip {
+        width: 100%;
+    }
+}
+
+@media (max-width: 640px) {
+    .chrono-two {
+        padding: 1.5rem 1.1rem 2.5rem;
+    }
+
+    .grid-2,
+    .grid-3 {
+        grid-template-columns: 1fr;
+    }
+}

--- a/Chrono-frontend/src/test/ChronoTwoDashboard.test.jsx
+++ b/Chrono-frontend/src/test/ChronoTwoDashboard.test.jsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+
+vi.mock("@react-three/fiber", () => ({
+    Canvas: () => <div data-testid="three-canvas" />,
+}));
+
+vi.mock("@react-three/drei", () => ({
+    Line: () => null,
+    OrbitControls: () => null,
+}));
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock("../utils/api.js", () => ({
+    default: {
+        get: (...args) => mockGet(...args),
+        post: (...args) => mockPost(...args),
+    },
+}));
+
+import ChronoTwoDashboard from "../pages/ChronoTwo/ChronoTwoDashboard.jsx";
+
+const products = [
+    {
+        id: "SKU-AR-01",
+        name: "Chrono Vision Bot",
+        category: "Robotics",
+        weightKg: 18.5,
+        salesPrice: 1799,
+        demandSegment: "A",
+    },
+];
+
+const locations = [
+    { id: "A-01-01", zone: "A", x: 2, y: 4, z: 1, capacity: 80, occupied: 24 },
+    { id: "B-01-02", zone: "B", x: 10, y: 3, z: 2, capacity: 70, occupied: 40 },
+];
+
+const inventory = [
+    { productId: "SKU-AR-01", locationId: "A-01-01", quantity: 24 },
+];
+
+const kpis = {
+    kpis: { pick_rate: 318, inventory_turnover: 8.6 },
+    trends: { pick_rate: 4.2, inventory_turnover: 1.1 },
+};
+
+const returnsData = [
+    { caseId: "RET-1", productId: "SKU-AR-GLV", reason: "Defekt", status: "inspection" },
+];
+
+const ledger = [
+    {
+        id: "MOV-1",
+        productId: "SKU-AR-01",
+        fromLocation: "A-01-01",
+        toLocation: "B-01-02",
+        quantity: 5,
+    },
+];
+
+const forecast = {
+    productId: "SKU-AR-01",
+    forecast: { "2025-01-01": 120 },
+    stockOutRisk: false,
+    overstockRisk: false,
+};
+
+const pickRouteResponse = {
+    waypoints: [
+        { locationId: "A-01-01", productId: "SKU-AR-01", x: 2, y: 4, z: 1, etaSeconds: 12.5 },
+        { locationId: "B-01-02", productId: "SKU-AR-01", x: 10, y: 3, z: 2, etaSeconds: 34.8 },
+    ],
+    totalDistance: 18.2,
+    estimatedDurationSeconds: 52.6,
+};
+
+beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+
+    mockGet.mockImplementation((url) => {
+        switch (url) {
+            case "/chrono2/products":
+                return Promise.resolve({ data: products });
+            case "/chrono2/locations":
+                return Promise.resolve({ data: locations });
+            case "/chrono2/inventory":
+                return Promise.resolve({ data: inventory });
+            case "/chrono2/analytics/kpis":
+                return Promise.resolve({ data: kpis });
+            case "/chrono2/outbound/returns":
+                return Promise.resolve({ data: returnsData });
+            case "/chrono2/blockchain/movement":
+                return Promise.resolve({ data: ledger });
+            default:
+                if (url.startsWith("/chrono2/inventory/") && url.endsWith("/forecast")) {
+                    return Promise.resolve({ data: forecast });
+                }
+                return Promise.resolve({ data: {} });
+        }
+    });
+
+    mockPost.mockImplementation((url, payload) => {
+        if (url === "/chrono2/outbound/pick-route") {
+            return Promise.resolve({ data: pickRouteResponse });
+        }
+        return Promise.resolve({ data: payload });
+    });
+});
+
+describe("ChronoTwoDashboard", () => {
+    it("renders data and submits pick route payload", async () => {
+        render(<ChronoTwoDashboard />);
+
+        expect(await screen.findByText("Chrono Vision Bot")).toBeInTheDocument();
+
+        const pickCard = screen.getByText("Pick-by-Vision Routen").closest("article");
+        const productInput = within(pickCard).getByLabelText("Produkt-ID");
+        fireEvent.change(productInput, { target: { value: "SKU-AR-01" } });
+
+        const quantityInput = within(pickCard).getByLabelText("Menge");
+        fireEvent.change(quantityInput, { target: { value: "3" } });
+
+        const submitButton = within(pickCard).getByRole("button", { name: "Route planen" });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(mockPost).toHaveBeenCalledWith("/chrono2/outbound/pick-route", {
+                items: [{ productId: "SKU-AR-01", quantity: 3 }],
+            });
+        });
+
+        expect(await within(pickCard).findByText(/Gesamtzeit:/)).toBeInTheDocument();
+        const skuMentions = await within(pickCard).findAllByText(/SKU-AR-01/);
+        expect(skuMentions.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary
- restyle the Chrono 2.0 dashboard with a gradient theme, KPI trend badges and richer glassmorphism panels
- add focused Vitest coverage for the ChronoTwo dashboard interactions and JUnit coverage for core warehouse intelligence flows

## Testing
- mvn -f Chrono-backend/pom.xml test
- npm test --prefix Chrono-frontend -- --run src/test/ChronoTwoDashboard.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68e43fc5bb348325bf6340e1a22266ed