### PR TITLE
Complete enterprise PMS source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: "21"
           cache: maven
       - name: Backend tests and package
-        run: ./mvnw -B clean verify
+        run: mvn -B clean verify
 
   frontend:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
           cache: maven
       - name: Verify fresh and legacy MySQL migrations
         run: >-
-          ./mvnw -B
+          mvn -B
           -Dchrono.test.mysql.url=jdbc:mysql://127.0.0.1:3306/chrono_migration_test?allowPublicKeyRetrieval=true\&useSSL=false
           -Dchrono.test.mysql.username=root
           -Dchrono.test.mysql.password=chrono-ci-root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: Chrono-frontend/package-lock.json
+      - name: Install smart-card build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libpcsclite-dev libusb-1.0-0-dev libudev-dev pcscd
       - run: npm ci --legacy-peer-deps
       - run: npm run audit:prod
       - run: npm test
@@ -161,6 +165,10 @@ jobs:
           node-version: "20"
           cache: npm
           cache-dependency-path: Chrono-frontend/package-lock.json
+      - name: Install smart-card build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libpcsclite-dev libusb-1.0-0-dev libudev-dev pcscd
       - run: npm ci --legacy-peer-deps
       - run: npx playwright install --with-deps chromium
       - name: Run PMS browser journeys

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,11 +21,11 @@ jobs:
         language: [java-kotlin, javascript-typescript]
     steps:
       - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4
 
   dependency-review:
     if: github.event_name == 'pull_request'
@@ -64,10 +64,11 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-backend.sarif
+          category: trivy-backend
       - id: frontend_trivy
         continue-on-error: true
         uses: aquasecurity/trivy-action@v0.36.0
@@ -78,10 +79,11 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "1"
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trivy-frontend.sarif
+          category: trivy-frontend
       - name: Enforce container scan gate
         if: always()
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,6 +63,7 @@ jobs:
           output: trivy-backend.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+          limit-severities-for-sarif: true
           exit-code: "1"
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -78,6 +79,7 @@ jobs:
           output: trivy-frontend.sarif
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+          limit-severities-for-sarif: true
           exit-code: "1"
       - uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,7 @@ jobs:
         run: docker build -t chrono-frontend:scan Chrono-frontend
       - id: backend_trivy
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: chrono-backend:scan
           format: sarif
@@ -70,7 +70,7 @@ jobs:
           sarif_file: trivy-backend.sarif
       - id: frontend_trivy
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: chrono-frontend:scan
           format: sarif

--- a/Chrono-backend/Dockerfile
+++ b/Chrono-backend/Dockerfile
@@ -7,7 +7,7 @@ RUN mvn dependency:go-offline
 COPY src ./src
 RUN mvn -B clean verify
 
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM gcr.io/distroless/java21-debian13:nonroot
 WORKDIR /app
 
 COPY --from=builder /app/target/*.jar app.jar

--- a/Chrono-backend/pom.xml
+++ b/Chrono-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
 
@@ -18,6 +18,7 @@
     <properties>
         <java.version>17</java.version>
         <lombok.version>1.18.36</lombok.version>
+        <poi.version>5.5.1</poi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -56,11 +57,11 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>5.2.3</version> </dependency>
+            <version>${poi.version}</version> </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
-            <version>5.2.3</version> </dependency>
+            <version>${poi.version}</version> </dependency>
 
         <dependency>
             <groupId>commons-logging</groupId>
@@ -153,7 +154,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
-            <version>3.4.2</version>
         </dependency>
 
         <dependency>
@@ -196,7 +196,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.4.2</version>
                 <configuration>
                     <image>
                         <name>chrisubuntu1/chrono-backend:latest</name>

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/pms/PmsExtensionsController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/pms/PmsExtensionsController.java
@@ -1,0 +1,115 @@
+package com.chrono.chrono.controller.pms;
+
+import com.chrono.chrono.dto.pms.PmsExtensionsRequests;
+import com.chrono.chrono.dto.pms.PmsExtensionsResponse;
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.UserPermissionService;
+import com.chrono.chrono.services.pms.PmsExtensionsService;
+import jakarta.validation.Valid;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/pms")
+public class PmsExtensionsController {
+    private final PmsExtensionsService service;
+    private final UserRepository userRepository;
+    private final UserPermissionService userPermissionService;
+
+    public PmsExtensionsController(PmsExtensionsService service, UserRepository userRepository,
+                                   UserPermissionService userPermissionService) {
+        this.service = service;
+        this.userRepository = userRepository;
+        this.userPermissionService = userPermissionService;
+    }
+
+    @GetMapping("/extensions")
+    public PmsExtensionsResponse get(@RequestParam Long propertyId, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_VIEW);
+        return service.get(context.company(), propertyId);
+    }
+
+    @PutMapping("/properties/{propertyId}/booking-engine")
+    public PmsExtensionsResponse updateBookingEngine(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.BookingSettings request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.updateBookingSettings(context.company(), propertyId, request);
+    }
+
+    @PutMapping("/properties/{propertyId}/tourism-tax")
+    public PmsExtensionsResponse updateTourismTax(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.TourismTaxRuleRequest request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.updateTourismTax(context.company(), propertyId, request);
+    }
+
+    @PostMapping("/properties/{propertyId}/tourism-tax/postings")
+    public PmsExtensionsResponse postTourismTax(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.PostTourismTax request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.postTourismTax(context.company(), propertyId, request, context.username());
+    }
+
+    @PostMapping("/properties/{propertyId}/pos/tickets")
+    public PmsExtensionsResponse createPosTicket(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.CreatePosTicket request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.createPosTicket(context.company(), propertyId, request, context.username());
+    }
+
+    @PostMapping("/properties/{propertyId}/access-credentials")
+    public PmsExtensionsResponse issueAccessCredential(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.IssueAccessCredential request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.issueAccessCredential(context.company(), propertyId, request, context.username());
+    }
+
+    @PostMapping("/properties/{propertyId}/access-credentials/{credentialId}/revoke")
+    public PmsExtensionsResponse revokeAccessCredential(@PathVariable Long propertyId,
+            @PathVariable Long credentialId, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.revokeAccessCredential(context.company(), propertyId, credentialId, context.username());
+    }
+
+    @PostMapping("/properties/{propertyId}/migration-batches")
+    public PmsExtensionsResponse importMigration(@PathVariable Long propertyId,
+            @Valid @RequestBody PmsExtensionsRequests.MigrationImport request, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_MANAGE);
+        return service.importMigration(context.company(), propertyId, request, context.username());
+    }
+
+    @GetMapping("/properties/{propertyId}/accounting-export.csv")
+    public ResponseEntity<byte[]> accountingExport(@PathVariable Long propertyId,
+            @RequestParam LocalDate from, @RequestParam LocalDate toExclusive, Principal principal) {
+        AccessContext context = requireContext(principal, UserPermissionService.ACCESS_VIEW);
+        byte[] content = service.accountingExport(context.company(), propertyId, from, toExclusive);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/csv;charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename("chrono-pms-accounting-" + from + ".csv").build().toString())
+                .body(content);
+    }
+
+    private AccessContext requireContext(Principal principal, String accessLevel) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentifizierung erforderlich.");
+        }
+        User user = userRepository.findByUsernameWithPermissionContext(principal.getName())
+                .filter(candidate -> !candidate.isDeleted())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Benutzer nicht gefunden."));
+        userPermissionService.assertPageAccess(user, UserPermissionService.PAGE_PMS, accessLevel,
+                "Die erforderliche PMS-Berechtigung fehlt.");
+        if (user.getCompany() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Eine Firmenzuordnung ist erforderlich.");
+        }
+        return new AccessContext(user.getCompany(), user.getUsername());
+    }
+
+    private record AccessContext(Company company, String username) {}
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/controller/pms/PmsPublicBookingController.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/controller/pms/PmsPublicBookingController.java
@@ -1,0 +1,66 @@
+package com.chrono.chrono.controller.pms;
+
+import com.chrono.chrono.dto.pms.AvailabilityResponse;
+import com.chrono.chrono.dto.pms.PmsExtensionsRequests;
+import com.chrono.chrono.dto.pms.PublicBookingResponse;
+import com.chrono.chrono.dto.pms.PublicBookingConfigurationResponse;
+import com.chrono.chrono.services.pms.PmsExtensionsService;
+import com.chrono.chrono.services.pms.PmsPublicRateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/public/pms/booking")
+public class PmsPublicBookingController {
+    private final PmsExtensionsService service;
+    private final PmsPublicRateLimiter rateLimiter;
+
+    public PmsPublicBookingController(PmsExtensionsService service, PmsPublicRateLimiter rateLimiter) {
+        this.service = service;
+        this.rateLimiter = rateLimiter;
+    }
+
+    @GetMapping("/{propertyCode}/availability")
+    public ResponseEntity<AvailabilityResponse> availability(@PathVariable String propertyCode,
+            @RequestParam LocalDate arrival, @RequestParam LocalDate departure, HttpServletRequest servletRequest) {
+        PmsPublicRateLimiter.Decision decision = rateLimiter.check(servletRequest.getRemoteAddr(), "booking-read");
+        if (!decision.allowed()) return limited(decision);
+        return ResponseEntity.ok(service.publicAvailability(propertyCode, arrival, departure));
+    }
+
+    @GetMapping("/{propertyCode}")
+    public ResponseEntity<PublicBookingConfigurationResponse> configuration(@PathVariable String propertyCode,
+            HttpServletRequest servletRequest) {
+        PmsPublicRateLimiter.Decision decision = rateLimiter.check(servletRequest.getRemoteAddr(), "booking-config");
+        if (!decision.allowed()) return limited(decision);
+        return ResponseEntity.ok(service.publicConfiguration(propertyCode));
+    }
+
+    @PostMapping("/{propertyCode}/reservations")
+    public ResponseEntity<PublicBookingResponse> book(@PathVariable String propertyCode,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @Valid @RequestBody PmsExtensionsRequests.PublicBooking request, HttpServletRequest servletRequest) {
+        PmsPublicRateLimiter.Decision decision = rateLimiter.check(servletRequest.getRemoteAddr(), "booking-create");
+        if (!decision.allowed()) return limited(decision);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(service.createPublicBooking(propertyCode, idempotencyKey, request));
+    }
+
+    @PostMapping("/{propertyCode}/verify")
+    public ResponseEntity<PublicBookingResponse> verify(@PathVariable String propertyCode,
+            @Valid @RequestBody PmsExtensionsRequests.VerifyPublicBooking request,
+            HttpServletRequest servletRequest) {
+        PmsPublicRateLimiter.Decision decision = rateLimiter.check(servletRequest.getRemoteAddr(), "booking-verify");
+        if (!decision.allowed()) return limited(decision);
+        return ResponseEntity.ok(service.verifyPublicBooking(propertyCode, request.token()));
+    }
+
+    private <T> ResponseEntity<T> limited(PmsPublicRateLimiter.Decision decision) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header(HttpHeaders.RETRY_AFTER, String.valueOf(decision.retryAfterSeconds())).build();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/ChannelWebhookResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/ChannelWebhookResponse.java
@@ -1,0 +1,8 @@
+package com.chrono.chrono.dto.pms;
+
+public record ChannelWebhookResponse(
+        String status,
+        String externalId,
+        Long reservationId,
+        String confirmationCode
+) {}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PmsExtensionsRequests.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PmsExtensionsRequests.java
@@ -1,0 +1,101 @@
+package com.chrono.chrono.dto.pms;
+
+import com.chrono.chrono.entities.pms.PaymentMethod;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class PmsExtensionsRequests {
+    private PmsExtensionsRequests() {}
+
+    public record BookingSettings(
+            @NotBlank @Pattern(regexp = "^[a-z0-9](?:[a-z0-9-]{1,118}[a-z0-9])?$") String publicSlug,
+            boolean enabled,
+            boolean requireGuarantee,
+            @Size(max = 500) String termsUrl,
+            @Size(max = 500) String privacyUrl,
+            @Size(max = 1000) String confirmationMessage
+    ) {}
+
+    public record TourismTaxRuleRequest(
+            boolean enabled,
+            @NotBlank @Size(max = 120) String name,
+            @NotNull @DecimalMin("0.00") BigDecimal adultRate,
+            @NotNull @DecimalMin("0.00") BigDecimal childRate,
+            @Min(0) @Max(21) int childFreeUnder,
+            @Min(1) @Max(365) Integer maximumNights
+    ) {}
+
+    public record PosLine(
+            @NotBlank @Size(max = 240) String description,
+            @NotNull @DecimalMin("0.01") BigDecimal quantity,
+            @NotNull @DecimalMin("0.00") BigDecimal unitPrice,
+            @NotNull @DecimalMin("0.00") @DecimalMax("100.00") BigDecimal taxRate
+    ) {}
+
+    public record CreatePosTicket(
+            Long folioId,
+            @NotBlank @Size(max = 32) String outletCode,
+            @Size(max = 60) String tableReference,
+            @NotNull LocalDate serviceDate,
+            PaymentMethod paymentMethod,
+            @NotEmpty @Size(max = 100) List<@Valid PosLine> lines
+    ) {}
+
+    public record IssueAccessCredential(
+            @NotNull Long reservationId,
+            @NotBlank @Size(max = 50) String providerCode,
+            @NotBlank @Size(max = 160) String externalReference,
+            @NotNull LocalDateTime validFrom,
+            @NotNull LocalDateTime validUntil
+    ) {}
+
+    public record PostTourismTax(
+            @NotNull Long reservationId,
+            @Min(0) @Max(20) int chargeableChildren
+    ) {}
+
+    public record PublicBooking(
+            @NotNull LocalDate arrivalDate,
+            @NotNull LocalDate departureDate,
+            @NotNull Long ratePlanId,
+            @Min(1) @Max(20) int adults,
+            @Min(0) @Max(20) int children,
+            @NotBlank @Size(max = 100) String firstName,
+            @NotBlank @Size(max = 100) String lastName,
+            @Email @NotBlank @Size(max = 190) String email,
+            @Size(max = 60) String phone,
+            @AssertTrue boolean termsAccepted,
+            @AssertTrue boolean privacyAccepted
+    ) {}
+
+    public record VerifyPublicBooking(
+            @NotBlank @Size(min = 32, max = 200) String token
+    ) {}
+
+    public record MigrationReservation(
+            @NotBlank @Size(max = 100) String externalReference,
+            @NotBlank @Size(max = 100) String firstName,
+            @NotBlank @Size(max = 100) String lastName,
+            @Email @Size(max = 190) String email,
+            @Size(max = 60) String phone,
+            @NotNull Long roomTypeId,
+            @NotNull Long ratePlanId,
+            @NotNull LocalDate arrivalDate,
+            @NotNull LocalDate departureDate,
+            @Min(1) @Max(20) int adults,
+            @Min(0) @Max(20) int children,
+            @NotNull @DecimalMin("0.00") BigDecimal expectedGrossAmount,
+            @NotNull @DecimalMin("0.00") BigDecimal depositAmount
+    ) {}
+
+    public record MigrationImport(
+            @NotBlank @Size(max = 120) String idempotencyKey,
+            @NotBlank @Size(max = 100) String sourceSystem,
+            @NotEmpty @Size(max = 5000) List<@Valid MigrationReservation> reservations
+    ) {}
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PmsExtensionsResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PmsExtensionsResponse.java
@@ -1,0 +1,33 @@
+package com.chrono.chrono.dto.pms;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.List;
+
+public record PmsExtensionsResponse(
+        BookingSettingsView bookingEngine,
+        TourismTaxRuleView tourismTax,
+        List<PosTicketView> posTickets,
+        List<AccessCredentialView> accessCredentials,
+        List<MigrationBatchView> migrationBatches
+) {
+    public record BookingSettingsView(Long id, String publicSlug, boolean enabled, boolean requireGuarantee,
+                                      String termsUrl, String privacyUrl, String confirmationMessage) {}
+    public record TourismTaxRuleView(Long id, boolean enabled, String name, BigDecimal adultRate,
+                                     BigDecimal childRate, int childFreeUnder, Integer maximumNights) {}
+    public record PosLineView(String description, BigDecimal quantity, BigDecimal unitPrice,
+                              BigDecimal taxRate, BigDecimal grossAmount) {}
+    public record PosTicketView(Long id, String ticketNumber, String outletCode, String tableReference,
+                                LocalDate serviceDate, String status, String paymentMethod, Long folioId, String guestName,
+                                String currencyCode, BigDecimal netAmount, BigDecimal taxAmount,
+                                BigDecimal grossAmount, LocalDateTime createdAt, List<PosLineView> lines) {}
+    public record AccessCredentialView(Long id, Long reservationId, String confirmationCode,
+                                       String guestName, String roomNumber, String providerCode,
+                                       String externalReference, String status, LocalDateTime validFrom,
+                                       LocalDateTime validUntil, LocalDateTime issuedAt) {}
+    public record MigrationBatchView(Long id, String idempotencyKey, String sourceSystem, String status,
+                                     int importedGuests, int importedReservations, int importedPayments,
+                                     BigDecimal totalOpeningBalance, String reconciliationMessage,
+                                     LocalDateTime createdAt, LocalDateTime completedAt) {}
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PublicBookingConfigurationResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PublicBookingConfigurationResponse.java
@@ -1,0 +1,11 @@
+package com.chrono.chrono.dto.pms;
+
+public record PublicBookingConfigurationResponse(
+        String propertyCode,
+        String hotelName,
+        String city,
+        String currencyCode,
+        String termsUrl,
+        String privacyUrl,
+        boolean requireGuarantee
+) {}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PublicBookingResponse.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/dto/pms/PublicBookingResponse.java
@@ -1,0 +1,17 @@
+package com.chrono.chrono.dto.pms;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PublicBookingResponse(
+        String confirmationCode,
+        String hotelName,
+        String roomTypeName,
+        String rateName,
+        String currencyCode,
+        BigDecimal totalAmount,
+        String confirmationMessage,
+        String status,
+        boolean verificationRequired,
+        LocalDateTime holdUntil
+) {}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
@@ -4,6 +4,7 @@ import com.chrono.chrono.entities.User;
 import com.chrono.chrono.entities.UserAudit;
 import com.chrono.chrono.repositories.UserAuditRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
 import jakarta.persistence.PostLoad;
@@ -18,11 +19,11 @@ public class UserAuditListener {
     private static final Map<User, User> PREVIOUS =
             Collections.synchronizedMap(new WeakHashMap<>());
 
-    private static UserAuditRepository repo;
+    private final ObjectProvider<UserAuditRepository> repositoryProvider;
 
     @Autowired
-    public void init(UserAuditRepository r) {
-        repo = r;
+    public UserAuditListener(ObjectProvider<UserAuditRepository> repositoryProvider) {
+        this.repositoryProvider = repositoryProvider;
     }
 
     @PostLoad
@@ -34,6 +35,7 @@ public class UserAuditListener {
     public void preUpdate(User user) {
         User old = PREVIOUS.get(user);
         if (old != null) {
+            UserAuditRepository repo = repositoryProvider.getObject();
             if (diff(old.getBankAccount(), user.getBankAccount())) {
                 repo.save(new UserAudit(user, "bankAccount", old.getBankAccount(), user.getBankAccount()));
             }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/listeners/UserAuditListener.java
@@ -7,13 +7,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostRemove;
 import jakarta.persistence.PreUpdate;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 @Component
 public class UserAuditListener {
-    private static final Map<Long, User> PREVIOUS = new HashMap<>();
+    private static final Map<User, User> PREVIOUS =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     private static UserAuditRepository repo;
 
@@ -24,12 +27,12 @@ public class UserAuditListener {
 
     @PostLoad
     public void postLoad(User user) {
-        PREVIOUS.put(user.getId(), copy(user));
+        PREVIOUS.put(user, copy(user));
     }
 
     @PreUpdate
     public void preUpdate(User user) {
-        User old = PREVIOUS.get(user.getId());
+        User old = PREVIOUS.get(user);
         if (old != null) {
             if (diff(old.getBankAccount(), user.getBankAccount())) {
                 repo.save(new UserAudit(user, "bankAccount", old.getBankAccount(), user.getBankAccount()));
@@ -41,7 +44,12 @@ public class UserAuditListener {
                 repo.save(new UserAudit(user, "email", old.getEmail(), user.getEmail()));
             }
         }
-        PREVIOUS.put(user.getId(), copy(user));
+        PREVIOUS.put(user, copy(user));
+    }
+
+    @PostRemove
+    public void postRemove(User user) {
+        PREVIOUS.remove(user);
     }
 
     private boolean diff(String a, String b) {

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/AccessCredential.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/AccessCredential.java
@@ -1,0 +1,43 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_access_credentials", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_access_provider_ref", columnNames = {"property_id", "provider_code", "external_reference"}))
+public class AccessCredential {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+    @Column(name = "provider_code", nullable = false, length = 50)
+    private String providerCode;
+    @Column(name = "external_reference", nullable = false, length = 160)
+    private String externalReference;
+    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 20)
+    private AccessCredentialStatus status = AccessCredentialStatus.ACTIVE;
+    @Column(name = "valid_from", nullable = false)
+    private LocalDateTime validFrom;
+    @Column(name = "valid_until", nullable = false)
+    private LocalDateTime validUntil;
+    @Column(name = "issued_by", nullable = false, length = 120)
+    private String issuedBy;
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+    @Column(name = "revoked_by", length = 120)
+    private String revokedBy;
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @PrePersist void prePersist() { issuedAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/AccessCredentialStatus.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/AccessCredentialStatus.java
@@ -1,0 +1,3 @@
+package com.chrono.chrono.entities.pms;
+
+public enum AccessCredentialStatus { ACTIVE, REVOKED, EXPIRED }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/BookingEngineSettings.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/BookingEngineSettings.java
@@ -1,0 +1,39 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_booking_engine_settings", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_booking_engine_property", columnNames = "property_id"))
+public class BookingEngineSettings {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @Column(name = "public_slug", nullable = false, length = 120, unique = true)
+    private String publicSlug;
+    @Column(nullable = false)
+    private boolean enabled;
+    @Column(name = "require_guarantee", nullable = false)
+    private boolean requireGuarantee;
+    @Column(name = "terms_url", length = 500)
+    private String termsUrl;
+    @Column(name = "privacy_url", length = 500)
+    private String privacyUrl;
+    @Column(name = "confirmation_message", length = 1000)
+    private String confirmationMessage;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist void prePersist() { createdAt = updatedAt = LocalDateTime.now(); }
+    @PreUpdate void preUpdate() { updatedAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/MigrationBatch.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/MigrationBatch.java
@@ -1,0 +1,44 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_migration_batches", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_migration_batch_key", columnNames = {"property_id", "idempotency_key"}))
+public class MigrationBatch {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @Column(name = "idempotency_key", nullable = false, length = 120)
+    private String idempotencyKey;
+    @Column(name = "source_system", nullable = false, length = 100)
+    private String sourceSystem;
+    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 30)
+    private MigrationBatchStatus status;
+    @Column(name = "imported_guests", nullable = false)
+    private int importedGuests;
+    @Column(name = "imported_reservations", nullable = false)
+    private int importedReservations;
+    @Column(name = "imported_payments", nullable = false)
+    private int importedPayments;
+    @Column(name = "total_opening_balance", nullable = false, precision = 14, scale = 2)
+    private BigDecimal totalOpeningBalance = BigDecimal.ZERO;
+    @Column(name = "reconciliation_message", length = 1000)
+    private String reconciliationMessage;
+    @Column(name = "created_by", nullable = false, length = 120)
+    private String createdBy;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @PrePersist void prePersist() { createdAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/MigrationBatchStatus.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/MigrationBatchStatus.java
@@ -1,0 +1,3 @@
+package com.chrono.chrono.entities.pms;
+
+public enum MigrationBatchStatus { COMPLETED, RECONCILIATION_REQUIRED, FAILED }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicket.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicket.java
@@ -1,0 +1,55 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_pos_tickets", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_pos_ticket_number", columnNames = {"property_id", "ticket_number"}))
+public class PosTicket {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "folio_id")
+    private Folio folio;
+    @Column(name = "ticket_number", nullable = false, length = 50)
+    private String ticketNumber;
+    @Column(name = "outlet_code", nullable = false, length = 32)
+    private String outletCode;
+    @Column(name = "table_reference", length = 60)
+    private String tableReference;
+    @Column(name = "service_date", nullable = false)
+    private LocalDate serviceDate;
+    @Enumerated(EnumType.STRING) @Column(nullable = false, length = 20)
+    private PosTicketStatus status = PosTicketStatus.OPEN;
+    @Enumerated(EnumType.STRING) @Column(name = "payment_method", length = 24)
+    private PaymentMethod paymentMethod;
+    @Column(name = "currency_code", nullable = false, length = 3)
+    private String currencyCode;
+    @Column(name = "net_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal netAmount = BigDecimal.ZERO;
+    @Column(name = "tax_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal taxAmount = BigDecimal.ZERO;
+    @Column(name = "gross_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal grossAmount = BigDecimal.ZERO;
+    @Column(name = "created_by", nullable = false, length = 120)
+    private String createdBy;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Column(name = "settled_at")
+    private LocalDateTime settledAt;
+    @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PosTicketLine> lines = new ArrayList<>();
+
+    @PrePersist void prePersist() { createdAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicketLine.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicketLine.java
@@ -1,0 +1,32 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_pos_ticket_lines")
+public class PosTicketLine {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "ticket_id", nullable = false)
+    private PosTicket ticket;
+    @Column(nullable = false, length = 240)
+    private String description;
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal quantity;
+    @Column(name = "unit_price", nullable = false, precision = 12, scale = 2)
+    private BigDecimal unitPrice;
+    @Column(name = "tax_rate", nullable = false, precision = 5, scale = 2)
+    private BigDecimal taxRate;
+    @Column(name = "net_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal netAmount;
+    @Column(name = "tax_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal taxAmount;
+    @Column(name = "gross_amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal grossAmount;
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicketStatus.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PosTicketStatus.java
@@ -1,0 +1,3 @@
+package com.chrono.chrono.entities.pms;
+
+public enum PosTicketStatus { OPEN, SETTLED, VOIDED }

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicBookingRequest.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicBookingRequest.java
@@ -1,0 +1,41 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_public_booking_requests", uniqueConstraints = @UniqueConstraint(
+        name = "uk_pms_public_booking_request", columnNames = {"property_id", "idempotency_key"}
+))
+public class PublicBookingRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+
+    @Column(name = "idempotency_key", nullable = false, length = 80)
+    private String idempotencyKey;
+
+    @Column(name = "request_fingerprint", nullable = false, length = 64)
+    private String requestFingerprint;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicBookingVerification.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicBookingVerification.java
@@ -1,0 +1,30 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_public_booking_verifications")
+public class PublicBookingVerification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "booking_request_id", nullable = false, unique = true)
+    private PublicBookingRequest bookingRequest;
+
+    @Column(name = "token_hash", nullable = false, length = 64, unique = true)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicRateLimit.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/PublicRateLimit.java
@@ -1,0 +1,29 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_public_rate_limits")
+public class PublicRateLimit {
+    @Id
+    @Column(name = "rate_key", nullable = false, length = 64)
+    private String rateKey;
+
+    @Column(name = "window_started_at", nullable = false)
+    private LocalDateTime windowStartedAt;
+
+    @Column(name = "request_count", nullable = false)
+    private int requestCount;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/TourismTaxPosting.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/TourismTaxPosting.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_tourism_tax_postings", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_tourism_tax_reservation", columnNames = "reservation_id"))
+public class TourismTaxPosting {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @OneToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "folio_id", nullable = false)
+    private Folio folio;
+    @OneToOne(fetch = FetchType.LAZY, optional = false) @JoinColumn(name = "folio_item_id", nullable = false)
+    private FolioItem folioItem;
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+    @Column(nullable = false)
+    private int nights;
+    @Column(name = "posted_at", nullable = false)
+    private LocalDateTime postedAt;
+    @Column(name = "posted_by", nullable = false, length = 120)
+    private String postedBy;
+
+    @PrePersist void prePersist() { if (postedAt == null) postedAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/TourismTaxRule.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/TourismTaxRule.java
@@ -1,0 +1,40 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_tourism_tax_rules", uniqueConstraints =
+        @UniqueConstraint(name = "uk_pms_tourism_tax_property", columnNames = "property_id"))
+public class TourismTaxRule {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "property_id", nullable = false)
+    private HotelProperty property;
+    @Column(nullable = false)
+    private boolean enabled;
+    @Column(nullable = false, length = 120)
+    private String name = "Kurtaxe";
+    @Column(name = "adult_rate", nullable = false, precision = 12, scale = 2)
+    private BigDecimal adultRate = BigDecimal.ZERO;
+    @Column(name = "child_rate", nullable = false, precision = 12, scale = 2)
+    private BigDecimal childRate = BigDecimal.ZERO;
+    @Column(name = "child_free_under", nullable = false)
+    private int childFreeUnder = 16;
+    @Column(name = "maximum_nights")
+    private Integer maximumNights;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist void prePersist() { createdAt = updatedAt = LocalDateTime.now(); }
+    @PreUpdate void preUpdate() { updatedAt = LocalDateTime.now(); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/WebhookDelivery.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/entities/pms/WebhookDelivery.java
@@ -1,0 +1,34 @@
+package com.chrono.chrono.entities.pms;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "pms_webhook_deliveries", uniqueConstraints = @UniqueConstraint(
+        name = "uk_pms_webhook_delivery", columnNames = {"connection_id", "delivery_id"}
+))
+public class WebhookDelivery {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "connection_id", nullable = false)
+    private ChannelConnection connection;
+
+    @Column(name = "delivery_id", nullable = false, length = 100)
+    private String deliveryId;
+
+    @Column(name = "received_at", nullable = false)
+    private LocalDateTime receivedAt;
+
+    @PrePersist
+    void prePersist() {
+        receivedAt = LocalDateTime.now();
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/AccessCredentialRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/AccessCredentialRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.AccessCredential;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AccessCredentialRepository extends JpaRepository<AccessCredential, Long> {
+    List<AccessCredential> findAllByProperty_IdOrderByIssuedAtDesc(Long propertyId);
+    Optional<AccessCredential> findByIdAndProperty_Company_Id(Long id, Long companyId);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/BookingEngineSettingsRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/BookingEngineSettingsRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.BookingEngineSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookingEngineSettingsRepository extends JpaRepository<BookingEngineSettings, Long> {
+    Optional<BookingEngineSettings> findByProperty_Id(Long propertyId);
+    Optional<BookingEngineSettings> findByPublicSlugIgnoreCaseAndEnabledTrue(String publicSlug);
+    boolean existsByPublicSlugIgnoreCaseAndProperty_IdNot(String publicSlug, Long propertyId);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/MigrationBatchRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/MigrationBatchRepository.java
@@ -1,0 +1,12 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.MigrationBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MigrationBatchRepository extends JpaRepository<MigrationBatch, Long> {
+    List<MigrationBatch> findAllByProperty_IdOrderByCreatedAtDesc(Long propertyId);
+    Optional<MigrationBatch> findByProperty_IdAndIdempotencyKey(Long propertyId, String idempotencyKey);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PosTicketRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PosTicketRepository.java
@@ -1,0 +1,14 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.PosTicket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.time.LocalDate;
+
+public interface PosTicketRepository extends JpaRepository<PosTicket, Long> {
+    List<PosTicket> findAllByProperty_IdOrderByCreatedAtDesc(Long propertyId);
+    boolean existsByProperty_IdAndTicketNumberIgnoreCase(Long propertyId, String ticketNumber);
+    List<PosTicket> findAllByProperty_IdAndServiceDateGreaterThanEqualAndServiceDateLessThanOrderByServiceDateAscCreatedAtAsc(
+            Long propertyId, LocalDate from, LocalDate toExclusive);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicBookingRequestRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicBookingRequestRepository.java
@@ -1,0 +1,10 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.PublicBookingRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PublicBookingRequestRepository extends JpaRepository<PublicBookingRequest, Long> {
+    Optional<PublicBookingRequest> findByProperty_IdAndIdempotencyKey(Long propertyId, String idempotencyKey);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicBookingVerificationRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicBookingVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.PublicBookingVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PublicBookingVerificationRepository extends JpaRepository<PublicBookingVerification, Long> {
+    Optional<PublicBookingVerification> findByTokenHash(String tokenHash);
+    Optional<PublicBookingVerification> findByBookingRequest_Id(Long bookingRequestId);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicRateLimitRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/PublicRateLimitRepository.java
@@ -1,0 +1,22 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.PublicRateLimit;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface PublicRateLimitRepository extends JpaRepository<PublicRateLimit, String> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select quota from PublicRateLimit quota where quota.rateKey = :rateKey")
+    Optional<PublicRateLimit> findByRateKeyForUpdate(@Param("rateKey") String rateKey);
+
+    @Modifying
+    @Query("delete from PublicRateLimit quota where quota.updatedAt < :cutoff")
+    int deleteStale(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/TourismTaxPostingRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/TourismTaxPostingRepository.java
@@ -1,0 +1,14 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.TourismTaxPosting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.time.LocalDateTime;
+
+public interface TourismTaxPostingRepository extends JpaRepository<TourismTaxPosting, Long> {
+    boolean existsByReservation_Id(Long reservationId);
+    List<TourismTaxPosting> findAllByProperty_IdOrderByPostedAtDesc(Long propertyId);
+    List<TourismTaxPosting> findAllByProperty_IdAndPostedAtGreaterThanEqualAndPostedAtLessThanOrderByPostedAtAsc(
+            Long propertyId, LocalDateTime from, LocalDateTime toExclusive);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/TourismTaxRuleRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/TourismTaxRuleRepository.java
@@ -1,0 +1,10 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.TourismTaxRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TourismTaxRuleRepository extends JpaRepository<TourismTaxRule, Long> {
+    Optional<TourismTaxRule> findByProperty_Id(Long propertyId);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/WebhookDeliveryRepository.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/repositories/pms/WebhookDeliveryRepository.java
@@ -1,0 +1,17 @@
+package com.chrono.chrono.repositories.pms;
+
+import com.chrono.chrono.entities.pms.WebhookDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface WebhookDeliveryRepository extends JpaRepository<WebhookDelivery, Long> {
+    boolean existsByConnection_IdAndDeliveryId(Long connectionId, String deliveryId);
+
+    @Modifying
+    @Query("delete from WebhookDelivery delivery where delivery.receivedAt < :cutoff")
+    int deleteOlderThan(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsDocumentFingerprintService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsDocumentFingerprintService.java
@@ -1,0 +1,36 @@
+package com.chrono.chrono.services.pms;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+@Service
+public class PmsDocumentFingerprintService {
+    private final byte[] key;
+
+    public PmsDocumentFingerprintService(
+            @Value("${app.pms.document-hmac-key:}") String configuredKey,
+            @Value("${app.production:false}") boolean production) {
+        if (configuredKey == null || configuredKey.isBlank()) {
+            if (production) {
+                throw new IllegalStateException("APP_PMS_DOCUMENT_HMAC_KEY is required in production");
+            }
+            configuredKey = "local-development-document-hmac-key-only";
+        }
+        this.key = configuredKey.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String fingerprint(String documentNumber) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(documentNumber.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new IllegalStateException("HMAC-SHA256 is not available", exception);
+        }
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsExtensionsService.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsExtensionsService.java
@@ -1,0 +1,765 @@
+package com.chrono.chrono.services.pms;
+
+import com.chrono.chrono.dto.pms.*;
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.pms.*;
+import com.chrono.chrono.repositories.pms.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@Service
+public class PmsExtensionsService {
+    private final HotelPropertyRepository propertyRepository;
+    private final BookingEngineSettingsRepository bookingSettingsRepository;
+    private final TourismTaxRuleRepository tourismTaxRuleRepository;
+    private final TourismTaxPostingRepository tourismTaxPostingRepository;
+    private final PosTicketRepository posTicketRepository;
+    private final AccessCredentialRepository accessCredentialRepository;
+    private final MigrationBatchRepository migrationBatchRepository;
+    private final PublicBookingRequestRepository publicBookingRequestRepository;
+    private final PublicBookingVerificationRepository publicBookingVerificationRepository;
+    private final ReservationRepository reservationRepository;
+    private final RatePlanRepository ratePlanRepository;
+    private final GuestProfileRepository guestRepository;
+    private final FolioRepository folioRepository;
+    private final FolioItemRepository folioItemRepository;
+    private final PaymentRepository paymentRepository;
+    private final ExternalBookingReferenceRepository externalBookingReferenceRepository;
+    private final IntegrationOutboxRepository outboxRepository;
+    private final PmsOperationsService operationsService;
+    private final PmsAuditWriter auditWriter;
+    private final ApplicationEventPublisher eventPublisher;
+    private final Duration verificationTtl;
+    private final int publicMaxStayNights;
+
+    public PmsExtensionsService(
+            HotelPropertyRepository propertyRepository,
+            BookingEngineSettingsRepository bookingSettingsRepository,
+            TourismTaxRuleRepository tourismTaxRuleRepository,
+            TourismTaxPostingRepository tourismTaxPostingRepository,
+            PosTicketRepository posTicketRepository,
+            AccessCredentialRepository accessCredentialRepository,
+            MigrationBatchRepository migrationBatchRepository,
+            PublicBookingRequestRepository publicBookingRequestRepository,
+            PublicBookingVerificationRepository publicBookingVerificationRepository,
+            ReservationRepository reservationRepository,
+            RatePlanRepository ratePlanRepository,
+            GuestProfileRepository guestRepository,
+            FolioRepository folioRepository,
+            FolioItemRepository folioItemRepository,
+            PaymentRepository paymentRepository,
+            ExternalBookingReferenceRepository externalBookingReferenceRepository,
+            IntegrationOutboxRepository outboxRepository,
+            PmsOperationsService operationsService,
+            PmsAuditWriter auditWriter,
+            ApplicationEventPublisher eventPublisher,
+            @Value("${app.pms.booking-verification.ttl:PT15M}") Duration verificationTtl,
+            @Value("${app.pms.public-booking.max-stay-nights:30}") int publicMaxStayNights) {
+        this.propertyRepository = propertyRepository;
+        this.bookingSettingsRepository = bookingSettingsRepository;
+        this.tourismTaxRuleRepository = tourismTaxRuleRepository;
+        this.tourismTaxPostingRepository = tourismTaxPostingRepository;
+        this.posTicketRepository = posTicketRepository;
+        this.accessCredentialRepository = accessCredentialRepository;
+        this.migrationBatchRepository = migrationBatchRepository;
+        this.publicBookingRequestRepository = publicBookingRequestRepository;
+        this.publicBookingVerificationRepository = publicBookingVerificationRepository;
+        this.reservationRepository = reservationRepository;
+        this.ratePlanRepository = ratePlanRepository;
+        this.guestRepository = guestRepository;
+        this.folioRepository = folioRepository;
+        this.folioItemRepository = folioItemRepository;
+        this.paymentRepository = paymentRepository;
+        this.externalBookingReferenceRepository = externalBookingReferenceRepository;
+        this.outboxRepository = outboxRepository;
+        this.operationsService = operationsService;
+        this.auditWriter = auditWriter;
+        this.eventPublisher = eventPublisher;
+        this.verificationTtl = verificationTtl;
+        this.publicMaxStayNights = publicMaxStayNights;
+    }
+
+    @Transactional(readOnly = true)
+    public PmsExtensionsResponse get(Company company, Long propertyId) {
+        HotelProperty property = requireProperty(company, propertyId);
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse updateBookingSettings(Company company, Long propertyId,
+                                                        PmsExtensionsRequests.BookingSettings request) {
+        HotelProperty property = requireProperty(company, propertyId);
+        validatePublicUrl(request.termsUrl(), "AGB-Adresse");
+        validatePublicUrl(request.privacyUrl(), "Datenschutz-Adresse");
+        BookingEngineSettings settings = bookingSettingsRepository.findByProperty_Id(propertyId)
+                .orElseGet(BookingEngineSettings::new);
+        String publicSlug = required(request.publicSlug()).toLowerCase(Locale.ROOT);
+        if (bookingSettingsRepository.existsByPublicSlugIgnoreCaseAndProperty_IdNot(publicSlug, propertyId)) {
+            throw conflict("Dieser öffentliche Buchungsname ist bereits vergeben.");
+        }
+        settings.setProperty(property);
+        settings.setPublicSlug(publicSlug);
+        settings.setEnabled(request.enabled());
+        settings.setRequireGuarantee(request.requireGuarantee());
+        settings.setTermsUrl(clean(request.termsUrl()));
+        settings.setPrivacyUrl(clean(request.privacyUrl()));
+        settings.setConfirmationMessage(clean(request.confirmationMessage()));
+        bookingSettingsRepository.save(settings);
+        auditWriter.append(property, "booking_engine.settings_updated", "booking_engine",
+                String.valueOf(settings.getId()), "{\"enabled\":" + settings.isEnabled() + "}");
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse updateTourismTax(Company company, Long propertyId,
+                                                  PmsExtensionsRequests.TourismTaxRuleRequest request) {
+        HotelProperty property = requireProperty(company, propertyId);
+        TourismTaxRule rule = tourismTaxRuleRepository.findByProperty_Id(propertyId)
+                .orElseGet(TourismTaxRule::new);
+        rule.setProperty(property);
+        rule.setEnabled(request.enabled());
+        rule.setName(required(request.name()));
+        rule.setAdultRate(money(request.adultRate()));
+        rule.setChildRate(money(request.childRate()));
+        rule.setChildFreeUnder(request.childFreeUnder());
+        rule.setMaximumNights(request.maximumNights());
+        tourismTaxRuleRepository.save(rule);
+        auditWriter.append(property, "tourism_tax.settings_updated", "tourism_tax_rule",
+                String.valueOf(rule.getId()), "{\"enabled\":" + rule.isEnabled() + "}");
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse postTourismTax(Company company, Long propertyId,
+                                                PmsExtensionsRequests.PostTourismTax request,
+                                                String username) {
+        HotelProperty property = requireProperty(company, propertyId);
+        TourismTaxRule rule = tourismTaxRuleRepository.findByProperty_Id(propertyId)
+                .filter(TourismTaxRule::isEnabled)
+                .orElseThrow(() -> conflict("Die Kurtaxe ist für dieses Hotel nicht aktiviert."));
+        Reservation reservation = requireReservation(company, propertyId, request.reservationId());
+        if (tourismTaxPostingRepository.existsByReservation_Id(reservation.getId())) {
+            throw conflict("Die Kurtaxe wurde für diese Reservierung bereits verbucht.");
+        }
+        if (request.chargeableChildren() > reservation.getChildren()) {
+            throw badRequest("Es können nicht mehr steuerpflichtige Kinder als gebuchte Kinder erfasst werden.");
+        }
+        long stayNights = ChronoUnit.DAYS.between(reservation.getArrivalDate(), reservation.getDepartureDate());
+        int nights = (int) Math.min(stayNights,
+                rule.getMaximumNights() == null ? stayNights : rule.getMaximumNights());
+        BigDecimal perNight = rule.getAdultRate().multiply(BigDecimal.valueOf(reservation.getAdults()))
+                .add(rule.getChildRate().multiply(BigDecimal.valueOf(request.chargeableChildren())));
+        BigDecimal amount = money(perNight.multiply(BigDecimal.valueOf(nights)));
+        if (amount.signum() <= 0) {
+            throw badRequest("Der berechnete Kurtaxenbetrag ist null.");
+        }
+        Folio folio = folioRepository.findFirstByReservation_IdOrderByIdAsc(reservation.getId())
+                .filter(value -> value.getStatus() == FolioStatus.OPEN)
+                .orElseThrow(() -> conflict("Für die Kurtaxe wird ein offenes Gastkonto benötigt."));
+        FolioItem item = new FolioItem();
+        item.setFolio(folio);
+        item.setServiceDate(reservation.getArrivalDate());
+        item.setType(FolioItemType.TAX);
+        item.setDescription(rule.getName() + " · " + nights + " Nächte");
+        item.setQuantity(BigDecimal.ONE);
+        item.setUnitPrice(amount);
+        item.setTotalAmount(amount);
+        folioItemRepository.save(item);
+        TourismTaxPosting posting = new TourismTaxPosting();
+        posting.setProperty(property);
+        posting.setReservation(reservation);
+        posting.setFolio(folio);
+        posting.setFolioItem(item);
+        posting.setAmount(amount);
+        posting.setNights(nights);
+        posting.setPostedBy(actor(username));
+        tourismTaxPostingRepository.save(posting);
+        auditWriter.append(property, "tourism_tax.posted", "reservation",
+                reservation.getId().toString(), "{\"amount\":" + amount.toPlainString() + "}");
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse createPosTicket(Company company, Long propertyId,
+                                                  PmsExtensionsRequests.CreatePosTicket request,
+                                                  String username) {
+        HotelProperty property = requireProperty(company, propertyId);
+        Folio folio = null;
+        if (request.folioId() != null) {
+            folio = folioRepository.findByIdAndReservation_Property_Company_Id(request.folioId(), company.getId())
+                    .filter(value -> value.getReservation().getProperty().getId().equals(propertyId))
+                    .filter(value -> value.getStatus() == FolioStatus.OPEN)
+                    .orElseThrow(() -> notFound("Offenes Gastkonto nicht gefunden."));
+        } else if (request.paymentMethod() == null) {
+            throw badRequest("Ein direkt bezahlter POS-Beleg benötigt eine Zahlungsart.");
+        }
+        PosTicket ticket = new PosTicket();
+        ticket.setProperty(property);
+        ticket.setFolio(folio);
+        ticket.setTicketNumber(nextTicketNumber(propertyId));
+        ticket.setOutletCode(required(request.outletCode()).toUpperCase(Locale.ROOT));
+        ticket.setTableReference(clean(request.tableReference()));
+        ticket.setServiceDate(request.serviceDate());
+        ticket.setCurrencyCode(property.getCurrencyCode());
+        ticket.setCreatedBy(actor(username));
+        ticket.setPaymentMethod(folio == null ? request.paymentMethod() : null);
+
+        BigDecimal netTotal = BigDecimal.ZERO;
+        BigDecimal taxTotal = BigDecimal.ZERO;
+        for (PmsExtensionsRequests.PosLine input : request.lines()) {
+            PosTicketLine line = new PosTicketLine();
+            line.setTicket(ticket);
+            line.setDescription(required(input.description()));
+            line.setQuantity(input.quantity().setScale(2, RoundingMode.HALF_UP));
+            line.setUnitPrice(money(input.unitPrice()));
+            line.setTaxRate(input.taxRate().setScale(2, RoundingMode.HALF_UP));
+            BigDecimal net = money(line.getQuantity().multiply(line.getUnitPrice()));
+            BigDecimal tax = money(net.multiply(line.getTaxRate()).divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP));
+            line.setNetAmount(net);
+            line.setTaxAmount(tax);
+            line.setGrossAmount(net.add(tax));
+            ticket.getLines().add(line);
+            netTotal = netTotal.add(net);
+            taxTotal = taxTotal.add(tax);
+        }
+        ticket.setNetAmount(money(netTotal));
+        ticket.setTaxAmount(money(taxTotal));
+        ticket.setGrossAmount(money(netTotal.add(taxTotal)));
+        ticket.setStatus(PosTicketStatus.SETTLED);
+        ticket.setSettledAt(LocalDateTime.now());
+        posTicketRepository.save(ticket);
+
+        if (folio != null) {
+            FolioItem item = new FolioItem();
+            item.setFolio(folio);
+            item.setServiceDate(request.serviceDate());
+            item.setType(FolioItemType.SERVICE);
+            item.setDescription("POS " + ticket.getOutletCode() + " · " + ticket.getTicketNumber());
+            item.setQuantity(BigDecimal.ONE);
+            item.setUnitPrice(ticket.getGrossAmount());
+            item.setTotalAmount(ticket.getGrossAmount());
+            folioItemRepository.save(item);
+        }
+        auditWriter.append(property, "pos.ticket_settled", "pos_ticket", ticket.getId().toString(),
+                "{\"gross\":" + ticket.getGrossAmount().toPlainString() + "}");
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse issueAccessCredential(Company company, Long propertyId,
+                                                        PmsExtensionsRequests.IssueAccessCredential request,
+                                                        String username) {
+        HotelProperty property = requireProperty(company, propertyId);
+        Reservation reservation = requireReservation(company, propertyId, request.reservationId());
+        if (reservation.getRoom() == null) {
+            throw conflict("Vor dem Ausstellen eines digitalen Schlüssels muss ein Zimmer zugewiesen sein.");
+        }
+        if (!request.validUntil().isAfter(request.validFrom())) {
+            throw badRequest("Das Ende der Schlüsselgültigkeit muss nach dem Beginn liegen.");
+        }
+        AccessCredential credential = new AccessCredential();
+        credential.setProperty(property);
+        credential.setReservation(reservation);
+        credential.setRoom(reservation.getRoom());
+        credential.setProviderCode(required(request.providerCode()).toUpperCase(Locale.ROOT));
+        credential.setExternalReference(required(request.externalReference()));
+        credential.setValidFrom(request.validFrom());
+        credential.setValidUntil(request.validUntil());
+        credential.setStatus(AccessCredentialStatus.ACTIVE);
+        credential.setIssuedBy(actor(username));
+        accessCredentialRepository.save(credential);
+        emit(property, "access_credential.issue_requested", "access_credential", credential.getId().toString(),
+                "{\"providerCode\":\"" + json(credential.getProviderCode()) + "\",\"roomId\":"
+                        + reservation.getRoom().getId() + ",\"externalReference\":\""
+                        + json(credential.getExternalReference()) + "\"}");
+        auditWriter.append(property, "access_credential.issued", "access_credential",
+                credential.getId().toString(), "{\"roomId\":" + reservation.getRoom().getId() + "}");
+        return response(property);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse revokeAccessCredential(Company company, Long propertyId, Long credentialId,
+                                                         String username) {
+        HotelProperty property = requireProperty(company, propertyId);
+        AccessCredential credential = accessCredentialRepository
+                .findByIdAndProperty_Company_Id(credentialId, company.getId())
+                .filter(value -> value.getProperty().getId().equals(propertyId))
+                .orElseThrow(() -> notFound("Digitaler Schlüssel nicht gefunden."));
+        if (credential.getStatus() != AccessCredentialStatus.ACTIVE) {
+            throw conflict("Der digitale Schlüssel ist nicht mehr aktiv.");
+        }
+        credential.setStatus(AccessCredentialStatus.REVOKED);
+        credential.setRevokedAt(LocalDateTime.now());
+        credential.setRevokedBy(actor(username));
+        accessCredentialRepository.save(credential);
+        emit(property, "access_credential.revoke_requested", "access_credential", credential.getId().toString(),
+                "{\"providerCode\":\"" + json(credential.getProviderCode()) + "\",\"externalReference\":\""
+                        + json(credential.getExternalReference()) + "\"}");
+        auditWriter.append(property, "access_credential.revoked", "access_credential",
+                credential.getId().toString(), "{}");
+        return response(property);
+    }
+
+    @Transactional(readOnly = true)
+    public PublicBookingConfigurationResponse publicConfiguration(String propertyCode) {
+        HotelProperty property = requirePublicProperty(propertyCode);
+        BookingEngineSettings settings = bookingSettingsRepository.findByProperty_Id(property.getId()).orElseThrow();
+        return new PublicBookingConfigurationResponse(settings.getPublicSlug(), property.getName(), property.getCity(),
+                property.getCurrencyCode(), settings.getTermsUrl(), settings.getPrivacyUrl(),
+                settings.isRequireGuarantee());
+    }
+
+    @Transactional(readOnly = true)
+    public AvailabilityResponse publicAvailability(String propertyCode, LocalDate arrival, LocalDate departure) {
+        HotelProperty property = requirePublicProperty(propertyCode);
+        validatePublicStay(arrival, departure);
+        return operationsService.getAvailability(property.getCompany(), property.getId(), arrival, departure);
+    }
+
+    @Transactional
+    public PublicBookingResponse createPublicBooking(String propertyCode,
+                                                      String idempotencyKey,
+                                                      PmsExtensionsRequests.PublicBooking request) {
+        HotelProperty publicProperty = requirePublicProperty(propertyCode);
+        validatePublicStay(request.arrivalDate(), request.departureDate());
+        HotelProperty property = propertyRepository.findByIdAndCompany_IdForUpdate(
+                        publicProperty.getId(), publicProperty.getCompany().getId())
+                .orElseThrow(() -> notFound("Hotel nicht gefunden."));
+        String key = validateIdempotencyKey(idempotencyKey);
+        String fingerprint = publicBookingFingerprint(request);
+        BookingEngineSettings settings = bookingSettingsRepository.findByProperty_Id(property.getId()).orElseThrow();
+        PublicBookingRequest existing = publicBookingRequestRepository
+                .findByProperty_IdAndIdempotencyKey(property.getId(), key).orElse(null);
+        if (existing != null) {
+            if (!existing.getRequestFingerprint().equals(fingerprint)) {
+                throw conflict("Der Idempotency-Key wurde bereits für eine andere Buchung verwendet.");
+            }
+            return publicBookingResponse(existing.getReservation(), settings,
+                    publicBookingVerificationRepository.findByBookingRequest_Id(existing.getId())
+                            .map(value -> value.getVerifiedAt() == null).orElse(false));
+        }
+        AvailabilityResponse availability = operationsService.getAvailability(
+                property.getCompany(), property.getId(), request.arrivalDate(), request.departureDate());
+        AvailabilityResponse.RateOption option = availability.roomTypes().stream()
+                .flatMap(roomType -> roomType.rates().stream())
+                .filter(rate -> rate.ratePlanId().equals(request.ratePlanId()))
+                .findFirst().filter(AvailabilityResponse.RateOption::available)
+                .orElseThrow(() -> conflict("Die gewählte Rate ist für diesen Zeitraum nicht mehr buchbar."));
+        RatePlan ratePlan = ratePlanRepository.findByIdAndProperty_Company_Id(request.ratePlanId(), property.getCompany().getId())
+                .filter(value -> value.getProperty().getId().equals(property.getId()))
+                .orElseThrow(() -> notFound("Ratenplan nicht gefunden."));
+        if (request.adults() + request.children() > ratePlan.getRoomType().getMaxOccupancy()) {
+            throw badRequest("Die gewählte Belegung überschreitet die maximale Zimmerbelegung.");
+        }
+        GuestProfile guest = new GuestProfile();
+        guest.setCompany(property.getCompany());
+        guest.setFirstName(required(request.firstName()));
+        guest.setLastName(required(request.lastName()));
+        guest.setEmail(required(request.email()).toLowerCase(Locale.ROOT));
+        guest.setPhone(clean(request.phone()));
+        guest.setLanguageCode("de");
+        guestRepository.save(guest);
+        Reservation reservation = operationsService.createReservationRecord(property.getCompany(),
+                new UpsertReservationRequest(property.getId(), guest.getId(), ratePlan.getRoomType().getId(), null,
+                        ratePlan.getId(), request.arrivalDate(), request.departureDate(), request.adults(),
+                        request.children(), ReservationStatus.TENTATIVE, ReservationSource.BOOKING_ENGINE,
+                        "Onlinebuchung", settings.isRequireGuarantee()
+                        ? ReservationGuaranteeStatus.DEPOSIT_REQUIRED : ReservationGuaranteeStatus.UNGUARANTEED,
+                        LocalDateTime.now().plus(verificationTtl)),
+                "booking-engine");
+        PublicBookingRequest bookingRequest = new PublicBookingRequest();
+        bookingRequest.setProperty(property);
+        bookingRequest.setReservation(reservation);
+        bookingRequest.setIdempotencyKey(key);
+        bookingRequest.setRequestFingerprint(fingerprint);
+        publicBookingRequestRepository.saveAndFlush(bookingRequest);
+        byte[] random = new byte[32];
+        new SecureRandom().nextBytes(random);
+        String verificationToken = Base64.getUrlEncoder().withoutPadding().encodeToString(random);
+        PublicBookingVerification verification = new PublicBookingVerification();
+        verification.setBookingRequest(bookingRequest);
+        verification.setTokenHash(sha256(verificationToken));
+        verification.setExpiresAt(LocalDateTime.now().plus(verificationTtl));
+        publicBookingVerificationRepository.save(verification);
+        eventPublisher.publishEvent(new PublicBookingVerificationRequested(
+                guest.getEmail(), property.getName(), settings.getPublicSlug(),
+                reservation.getConfirmationCode(), verificationToken));
+        return new PublicBookingResponse(reservation.getConfirmationCode(), property.getName(),
+                ratePlan.getRoomType().getName(), ratePlan.getName(), option.currencyCode(),
+                reservation.getTotalAmount(), clean(settings.getConfirmationMessage()),
+                reservation.getStatus().name(), true, reservation.getHoldUntil());
+    }
+
+    @Transactional
+    public PublicBookingResponse verifyPublicBooking(String propertyCode, String token) {
+        HotelProperty publicProperty = requirePublicProperty(propertyCode);
+        propertyRepository.findByIdAndCompany_IdForUpdate(
+                        publicProperty.getId(), publicProperty.getCompany().getId())
+                .orElseThrow(() -> notFound("Hotel nicht gefunden."));
+        PublicBookingVerification verification = publicBookingVerificationRepository
+                .findByTokenHash(sha256(required(token)))
+                .filter(value -> value.getBookingRequest().getProperty().getId().equals(publicProperty.getId()))
+                .orElseThrow(() -> notFound("Buchungsbestätigung nicht gefunden."));
+        Reservation reservation = verification.getBookingRequest().getReservation();
+        if (verification.getVerifiedAt() == null && verification.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw conflict("Der Bestätigungslink ist abgelaufen.");
+        }
+        BookingEngineSettings settings = bookingSettingsRepository.findByProperty_Id(publicProperty.getId()).orElseThrow();
+        if (verification.getVerifiedAt() == null) {
+            reservation = operationsService.verifyPublicBookingRecord(
+                    publicProperty.getCompany(), reservation.getId(), settings.isRequireGuarantee());
+            verification.setVerifiedAt(LocalDateTime.now());
+            publicBookingVerificationRepository.save(verification);
+        }
+        return publicBookingResponse(reservation, settings, false);
+    }
+
+    @Transactional
+    public PmsExtensionsResponse importMigration(Company company, Long propertyId,
+                                                 PmsExtensionsRequests.MigrationImport request,
+                                                 String username) {
+        HotelProperty property = requireProperty(company, propertyId);
+        String key = required(request.idempotencyKey());
+        if (migrationBatchRepository.findByProperty_IdAndIdempotencyKey(propertyId, key).isPresent()) {
+            return response(property);
+        }
+        String sourceCode = required(request.sourceSystem()).toUpperCase(Locale.ROOT);
+        sourceCode = sourceCode.substring(0, Math.min(50, sourceCode.length()));
+        int guests = 0;
+        int reservations = 0;
+        int payments = 0;
+        BigDecimal openingBalance = BigDecimal.ZERO;
+        List<String> differences = new ArrayList<>();
+        for (PmsExtensionsRequests.MigrationReservation row : request.reservations()) {
+            if (externalBookingReferenceRepository.findByProperty_IdAndChannelCodeIgnoreCaseAndExternalId(
+                    propertyId, sourceCode, required(row.externalReference())).isPresent()) {
+                continue;
+            }
+            GuestProfile guest = new GuestProfile();
+            guest.setCompany(company);
+            guest.setFirstName(required(row.firstName()));
+            guest.setLastName(required(row.lastName()));
+            guest.setEmail(clean(row.email()));
+            guest.setPhone(clean(row.phone()));
+            guest.setLanguageCode("de");
+            guest.setNotes("Import aus " + request.sourceSystem() + " · " + row.externalReference());
+            guestRepository.save(guest);
+            guests++;
+            Reservation reservation = operationsService.createReservationRecord(company,
+                    new UpsertReservationRequest(propertyId, guest.getId(), row.roomTypeId(), null,
+                            row.ratePlanId(), row.arrivalDate(), row.departureDate(), row.adults(), row.children(),
+                            ReservationStatus.CONFIRMED, ReservationSource.CHANNEL_MANAGER,
+                            "Migration " + row.externalReference(), row.depositAmount().signum() > 0
+                            ? ReservationGuaranteeStatus.DEPOSIT_PAID : ReservationGuaranteeStatus.UNGUARANTEED, null),
+                    actor(username));
+            reservations++;
+            ExternalBookingReference reference = new ExternalBookingReference();
+            reference.setProperty(property);
+            reference.setReservation(reservation);
+            reference.setChannelCode(sourceCode);
+            reference.setExternalId(required(row.externalReference()));
+            externalBookingReferenceRepository.save(reference);
+            if (reservation.getTotalAmount().compareTo(money(row.expectedGrossAmount())) != 0) {
+                differences.add(row.externalReference() + ": erwartet " + money(row.expectedGrossAmount())
+                        + ", berechnet " + reservation.getTotalAmount());
+            }
+            Folio folio = folioRepository.findFirstByReservation_IdOrderByIdAsc(reservation.getId()).orElseThrow();
+            if (row.depositAmount().signum() > 0) {
+                if (row.depositAmount().compareTo(reservation.getTotalAmount()) > 0) {
+                    throw badRequest("Die Anzahlung für " + row.externalReference() + " übersteigt den Aufenthaltspreis.");
+                }
+                Payment payment = new Payment();
+                payment.setFolio(folio);
+                payment.setAmount(money(row.depositAmount()));
+                payment.setMethod(PaymentMethod.BANK_TRANSFER);
+                payment.setStatus(PaymentStatus.POSTED);
+                payment.setKind(PaymentKind.PAYMENT);
+                payment.setReference("MIGRATION-" + row.externalReference());
+                payment.setCreatedBy(actor(username));
+                paymentRepository.save(payment);
+                payments++;
+            }
+            openingBalance = openingBalance.add(money(row.expectedGrossAmount()).subtract(money(row.depositAmount())));
+        }
+        MigrationBatch batch = new MigrationBatch();
+        batch.setProperty(property);
+        batch.setIdempotencyKey(key);
+        batch.setSourceSystem(required(request.sourceSystem()));
+        batch.setImportedGuests(guests);
+        batch.setImportedReservations(reservations);
+        batch.setImportedPayments(payments);
+        batch.setTotalOpeningBalance(money(openingBalance));
+        batch.setStatus(differences.isEmpty() ? MigrationBatchStatus.COMPLETED
+                : MigrationBatchStatus.RECONCILIATION_REQUIRED);
+        batch.setReconciliationMessage(differences.isEmpty() ? "Counts und Eröffnungssalden stimmen."
+                : String.join("; ", differences).substring(0, Math.min(1000, String.join("; ", differences).length())));
+        batch.setCreatedBy(actor(username));
+        batch.setCompletedAt(LocalDateTime.now());
+        migrationBatchRepository.save(batch);
+        auditWriter.append(property, "migration.batch_completed", "migration_batch", batch.getId().toString(),
+                "{\"reservations\":" + reservations + ",\"status\":\"" + batch.getStatus() + "\"}");
+        return response(property);
+    }
+
+    @Transactional(readOnly = true)
+    public byte[] accountingExport(Company company, Long propertyId, LocalDate from, LocalDate toExclusive) {
+        HotelProperty property = requireProperty(company, propertyId);
+        if (from == null || toExclusive == null || !toExclusive.isAfter(from)) {
+            throw badRequest("Der Exportzeitraum ist ungültig.");
+        }
+        StringBuilder csv = new StringBuilder("date;document;debitAccount;creditAccount;description;debitAmount;creditAmount;currency;taxRate\n");
+        folioItemRepository
+                .findAllByFolio_Reservation_Property_IdAndServiceDateGreaterThanEqualAndServiceDateLessThanOrderByServiceDateAscIdAsc(
+                        propertyId, from, toExclusive)
+                .forEach(item -> appendPosting(csv, item.getServiceDate().toString(), "FOLIO-" + item.getFolio().getId()
+                                + "-" + item.getId(), "1100", revenueAccount(item.getType()), item.getDescription(),
+                        item.getTotalAmount(), property.getCurrencyCode(), BigDecimal.ZERO));
+        paymentRepository
+                .findAllByFolio_Reservation_Property_IdAndReceivedAtGreaterThanEqualAndReceivedAtLessThanOrderByReceivedAtAsc(
+                        propertyId, from.atStartOfDay(), toExclusive.atStartOfDay())
+                .stream().filter(payment -> payment.getStatus() == PaymentStatus.POSTED)
+                .forEach(payment -> appendPosting(csv, payment.getReceivedAt().toLocalDate().toString(),
+                        "PAY-" + payment.getId(), paymentAccount(payment.getMethod()), "1100",
+                        "Zahlung " + payment.getFolio().getReservation().getConfirmationCode(),
+                        payment.getAmount(), property.getCurrencyCode(), BigDecimal.ZERO));
+        posTicketRepository
+                .findAllByProperty_IdAndServiceDateGreaterThanEqualAndServiceDateLessThanOrderByServiceDateAscCreatedAtAsc(
+                        propertyId, from, toExclusive)
+                .stream().filter(ticket -> ticket.getFolio() == null && ticket.getPaymentMethod() != null)
+                .forEach(ticket -> ticket.getLines().forEach(line -> appendPosting(csv,
+                        ticket.getServiceDate().toString(), ticket.getTicketNumber(),
+                        paymentAccount(ticket.getPaymentMethod()), "3220", line.getDescription(),
+                        line.getGrossAmount(), ticket.getCurrencyCode(), line.getTaxRate())));
+        return csv.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private PmsExtensionsResponse response(HotelProperty property) {
+        BookingEngineSettings settings = bookingSettingsRepository.findByProperty_Id(property.getId()).orElse(null);
+        TourismTaxRule tax = tourismTaxRuleRepository.findByProperty_Id(property.getId()).orElse(null);
+        return new PmsExtensionsResponse(
+                settings == null ? new PmsExtensionsResponse.BookingSettingsView(null,
+                        property.getCode().toLowerCase(Locale.ROOT), false, false, null, null, null)
+                        : new PmsExtensionsResponse.BookingSettingsView(settings.getId(), settings.getPublicSlug(), settings.isEnabled(),
+                        settings.isRequireGuarantee(), settings.getTermsUrl(), settings.getPrivacyUrl(),
+                        settings.getConfirmationMessage()),
+                tax == null ? new PmsExtensionsResponse.TourismTaxRuleView(null, false, "Kurtaxe",
+                        BigDecimal.ZERO, BigDecimal.ZERO, 16, null)
+                        : new PmsExtensionsResponse.TourismTaxRuleView(tax.getId(), tax.isEnabled(), tax.getName(),
+                        tax.getAdultRate(), tax.getChildRate(), tax.getChildFreeUnder(), tax.getMaximumNights()),
+                posTicketRepository.findAllByProperty_IdOrderByCreatedAtDesc(property.getId()).stream()
+                        .limit(100).map(this::toPosTicket).toList(),
+                accessCredentialRepository.findAllByProperty_IdOrderByIssuedAtDesc(property.getId()).stream()
+                        .limit(100).map(this::toAccessCredential).toList(),
+                migrationBatchRepository.findAllByProperty_IdOrderByCreatedAtDesc(property.getId()).stream()
+                        .limit(50).map(this::toMigrationBatch).toList());
+    }
+
+    private PmsExtensionsResponse.PosTicketView toPosTicket(PosTicket ticket) {
+        String guestName = ticket.getFolio() == null ? null
+                : ticket.getFolio().getReservation().getGuest().getFirstName() + " "
+                + ticket.getFolio().getReservation().getGuest().getLastName();
+        return new PmsExtensionsResponse.PosTicketView(ticket.getId(), ticket.getTicketNumber(),
+                ticket.getOutletCode(), ticket.getTableReference(), ticket.getServiceDate(), ticket.getStatus().name(),
+                ticket.getPaymentMethod() == null ? "ROOM_CHARGE" : ticket.getPaymentMethod().name(),
+                ticket.getFolio() == null ? null : ticket.getFolio().getId(), guestName, ticket.getCurrencyCode(),
+                ticket.getNetAmount(), ticket.getTaxAmount(), ticket.getGrossAmount(), ticket.getCreatedAt(),
+                ticket.getLines().stream().map(line -> new PmsExtensionsResponse.PosLineView(line.getDescription(),
+                        line.getQuantity(), line.getUnitPrice(), line.getTaxRate(), line.getGrossAmount())).toList());
+    }
+
+    private PmsExtensionsResponse.AccessCredentialView toAccessCredential(AccessCredential credential) {
+        AccessCredentialStatus status = credential.getStatus() == AccessCredentialStatus.ACTIVE
+                && credential.getValidUntil().isBefore(LocalDateTime.now())
+                ? AccessCredentialStatus.EXPIRED : credential.getStatus();
+        Reservation reservation = credential.getReservation();
+        return new PmsExtensionsResponse.AccessCredentialView(credential.getId(), reservation.getId(),
+                reservation.getConfirmationCode(), reservation.getGuest().getFirstName() + " "
+                + reservation.getGuest().getLastName(), credential.getRoom().getNumber(), credential.getProviderCode(),
+                credential.getExternalReference(), status.name(), credential.getValidFrom(), credential.getValidUntil(),
+                credential.getIssuedAt());
+    }
+
+    private PmsExtensionsResponse.MigrationBatchView toMigrationBatch(MigrationBatch batch) {
+        return new PmsExtensionsResponse.MigrationBatchView(batch.getId(), batch.getIdempotencyKey(),
+                batch.getSourceSystem(), batch.getStatus().name(), batch.getImportedGuests(),
+                batch.getImportedReservations(), batch.getImportedPayments(), batch.getTotalOpeningBalance(),
+                batch.getReconciliationMessage(), batch.getCreatedAt(), batch.getCompletedAt());
+    }
+
+    private HotelProperty requireProperty(Company company, Long propertyId) {
+        return propertyRepository.findByIdAndCompany_Id(propertyId, company.getId())
+                .orElseThrow(() -> notFound("Hotel nicht gefunden."));
+    }
+
+    private HotelProperty requirePublicProperty(String code) {
+        return bookingSettingsRepository.findByPublicSlugIgnoreCaseAndEnabledTrue(required(code))
+                .map(BookingEngineSettings::getProperty)
+                .filter(HotelProperty::isActive)
+                .orElseThrow(() -> notFound("Die Onlinebuchung ist für dieses Hotel nicht aktiviert."));
+    }
+
+    private Reservation requireReservation(Company company, Long propertyId, Long reservationId) {
+        return reservationRepository.findByIdAndProperty_Company_Id(reservationId, company.getId())
+                .filter(value -> value.getProperty().getId().equals(propertyId))
+                .orElseThrow(() -> notFound("Reservierung nicht gefunden."));
+    }
+
+    private String nextTicketNumber(Long propertyId) {
+        String value;
+        do {
+            value = "POS-" + LocalDate.now().toString().replace("-", "") + "-"
+                    + UUID.randomUUID().toString().substring(0, 8).toUpperCase(Locale.ROOT);
+        } while (posTicketRepository.existsByProperty_IdAndTicketNumberIgnoreCase(propertyId, value));
+        return value;
+    }
+
+    private PublicBookingResponse publicBookingResponse(Reservation reservation, BookingEngineSettings settings,
+                                                        boolean verificationRequired) {
+        return new PublicBookingResponse(reservation.getConfirmationCode(), reservation.getProperty().getName(),
+                reservation.getRoomType().getName(), reservation.getRatePlan().getName(),
+                reservation.getCurrencyCode(), reservation.getTotalAmount(), clean(settings.getConfirmationMessage()),
+                reservation.getStatus().name(), verificationRequired, reservation.getHoldUntil());
+    }
+
+    private void validatePublicStay(LocalDate arrival, LocalDate departure) {
+        if (arrival == null || departure == null || !departure.isAfter(arrival)) {
+            throw badRequest("Abreise muss nach der Anreise liegen.");
+        }
+        long nights = ChronoUnit.DAYS.between(arrival, departure);
+        if (nights > publicMaxStayNights) {
+            throw badRequest("Onlinebuchungen sind auf maximal " + publicMaxStayNights + " Nächte begrenzt.");
+        }
+    }
+
+    private String validateIdempotencyKey(String value) {
+        String key = required(value);
+        if (!key.matches("^[A-Za-z0-9._:-]{16,80}$")) {
+            throw badRequest("Der Idempotency-Key muss 16 bis 80 sichere Zeichen enthalten.");
+        }
+        return key;
+    }
+
+    private String publicBookingFingerprint(PmsExtensionsRequests.PublicBooking request) {
+        String canonical = String.join("\n",
+                Objects.toString(request.arrivalDate(), ""),
+                Objects.toString(request.departureDate(), ""),
+                Objects.toString(request.ratePlanId(), ""),
+                String.valueOf(request.adults()),
+                String.valueOf(request.children()),
+                Objects.toString(clean(request.firstName()), ""),
+                Objects.toString(clean(request.lastName()), ""),
+                Objects.toString(clean(request.email()), "").toLowerCase(Locale.ROOT),
+                Objects.toString(clean(request.phone()), ""),
+                String.valueOf(request.termsAccepted()),
+                String.valueOf(request.privacyAccepted()));
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                    .digest(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    private String sha256(String value) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    private void emit(HotelProperty property, String eventType, String aggregateType, String aggregateId, String payload) {
+        IntegrationOutboxEvent event = new IntegrationOutboxEvent();
+        event.setProperty(property);
+        event.setEventType(eventType);
+        event.setAggregateType(aggregateType);
+        event.setAggregateId(aggregateId);
+        event.setPayload(payload);
+        outboxRepository.save(event);
+    }
+
+    private void appendPosting(StringBuilder csv, String date, String document, String debitAccount,
+                               String creditAccount, String description, BigDecimal signedAmount,
+                               String currency, BigDecimal taxRate) {
+        BigDecimal amount = signedAmount.abs().setScale(2, RoundingMode.HALF_UP);
+        String effectiveDebit = signedAmount.signum() < 0 ? creditAccount : debitAccount;
+        String effectiveCredit = signedAmount.signum() < 0 ? debitAccount : creditAccount;
+        csv.append(csv(date)).append(';').append(csv(document)).append(';').append(csv(effectiveDebit)).append(';')
+                .append(csv(effectiveCredit)).append(';').append(csv(description)).append(';')
+                .append(amount.toPlainString()).append(';').append(amount.toPlainString()).append(';')
+                .append(csv(currency)).append(';').append(taxRate.setScale(2, RoundingMode.HALF_UP).toPlainString())
+                .append('\n');
+    }
+
+    private String revenueAccount(FolioItemType type) {
+        return switch (type) {
+            case ROOM -> "3200";
+            case BREAKFAST -> "3210";
+            case SERVICE, OTHER -> "3220";
+            case TAX -> "3600";
+            case DISCOUNT -> "3290";
+        };
+    }
+
+    private String paymentAccount(PaymentMethod method) {
+        return switch (method) {
+            case CASH -> "1000";
+            case CARD -> "1020";
+            case BANK_TRANSFER -> "1021";
+            case VOUCHER -> "1090";
+            case OTHER -> "1099";
+        };
+    }
+
+    private String csv(String value) {
+        String safe = value == null ? "" : value;
+        int firstContent = 0;
+        while (firstContent < safe.length() && Character.isWhitespace(safe.charAt(firstContent))) {
+            firstContent++;
+        }
+        boolean leadingControl = !safe.isEmpty()
+                && (safe.charAt(0) == '\t' || safe.charAt(0) == '\r' || safe.charAt(0) == '\n');
+        boolean formula = firstContent < safe.length()
+                && "=+-@".indexOf(safe.charAt(firstContent)) >= 0;
+        if (leadingControl || formula) {
+            safe = "'" + safe;
+        }
+        return "\"" + safe.replace("\"", "\"\"") + "\"";
+    }
+
+    private String json(String value) { return value.replace("\\", "\\\\").replace("\"", "\\\""); }
+    private String actor(String value) { return clean(value) == null ? "system" : clean(value); }
+    private BigDecimal money(BigDecimal value) { return value.setScale(2, RoundingMode.HALF_UP); }
+    private String clean(String value) { return value == null || value.isBlank() ? null : value.trim(); }
+    private String required(String value) {
+        String result = clean(value);
+        if (result == null) throw badRequest("Ein Pflichtfeld fehlt.");
+        return result;
+    }
+    private void validatePublicUrl(String value, String label) {
+        if (clean(value) != null && !clean(value).toLowerCase(Locale.ROOT).startsWith("https://")) {
+            throw badRequest(label + " muss HTTPS verwenden.");
+        }
+    }
+    private ResponseStatusException badRequest(String message) { return new ResponseStatusException(HttpStatus.BAD_REQUEST, message); }
+    private ResponseStatusException notFound(String message) { return new ResponseStatusException(HttpStatus.NOT_FOUND, message); }
+    private ResponseStatusException conflict(String message) { return new ResponseStatusException(HttpStatus.CONFLICT, message); }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsPublicRateLimitStore.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PmsPublicRateLimitStore.java
@@ -1,0 +1,44 @@
+package com.chrono.chrono.services.pms;
+
+import com.chrono.chrono.entities.pms.PublicRateLimit;
+import com.chrono.chrono.repositories.pms.PublicRateLimitRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class PmsPublicRateLimitStore {
+    private final PublicRateLimitRepository repository;
+
+    public PmsPublicRateLimitStore(PublicRateLimitRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Consumption consume(String rateKey, LocalDateTime windowStartedAt, LocalDateTime now) {
+        PublicRateLimit quota = repository.findByRateKeyForUpdate(rateKey).orElse(null);
+        if (quota == null) {
+            quota = new PublicRateLimit();
+            quota.setRateKey(rateKey);
+            quota.setWindowStartedAt(windowStartedAt);
+            quota.setRequestCount(1);
+        } else if (!quota.getWindowStartedAt().equals(windowStartedAt)) {
+            quota.setWindowStartedAt(windowStartedAt);
+            quota.setRequestCount(1);
+        } else {
+            quota.setRequestCount(quota.getRequestCount() + 1);
+        }
+        quota.setUpdatedAt(now);
+        repository.saveAndFlush(quota);
+        return new Consumption(quota.getRequestCount(), quota.getWindowStartedAt());
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int deleteStale(LocalDateTime cutoff) {
+        return repository.deleteStale(cutoff);
+    }
+
+    public record Consumption(int requestCount, LocalDateTime windowStartedAt) {}
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PublicBookingVerificationMailer.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PublicBookingVerificationMailer.java
@@ -1,0 +1,49 @@
+package com.chrono.chrono.services.pms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class PublicBookingVerificationMailer {
+    private static final Logger log = LoggerFactory.getLogger(PublicBookingVerificationMailer.class);
+    private final JavaMailSender mailSender;
+    private final String publicBaseUrl;
+    private final String sender;
+
+    public PublicBookingVerificationMailer(JavaMailSender mailSender,
+            @Value("${app.public-base-url:https://chrono-logisch.ch}") String publicBaseUrl,
+            @Value("${app.mail.from:no-reply@chrono-logisch.ch}") String sender) {
+        this.mailSender = mailSender;
+        this.publicBaseUrl = publicBaseUrl.replaceAll("/+$", "");
+        this.sender = sender;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void send(PublicBookingVerificationRequested event) {
+        String link = publicBaseUrl + "/book/" + event.publicSlug() + "?verificationToken="
+                + URLEncoder.encode(event.token(), StandardCharsets.UTF_8);
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(sender);
+        message.setTo(event.recipient());
+        message.setSubject("Buchung bei " + event.hotelName() + " bestätigen");
+        message.setText("Bitte bestätigen Sie Ihre Buchungsanfrage " + event.confirmationCode()
+                + " innerhalb der angegebenen Frist:\n\n" + link
+                + "\n\nOhne Bestätigung wird die Zimmerreservierung automatisch freigegeben.");
+        try {
+            mailSender.send(message);
+        } catch (MailException exception) {
+            log.error("Public booking verification mail failed for confirmation {}",
+                    event.confirmationCode(), exception);
+        }
+    }
+}

--- a/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PublicBookingVerificationRequested.java
+++ b/Chrono-backend/src/main/java/com/chrono/chrono/services/pms/PublicBookingVerificationRequested.java
@@ -1,0 +1,9 @@
+package com.chrono.chrono.services.pms;
+
+public record PublicBookingVerificationRequested(
+        String recipient,
+        String hotelName,
+        String publicSlug,
+        String confirmationCode,
+        String token
+) {}

--- a/Chrono-backend/src/main/resources/db/migration/V16__pms_commercial_and_hotel_integrations.sql
+++ b/Chrono-backend/src/main/resources/db/migration/V16__pms_commercial_and_hotel_integrations.sql
@@ -1,0 +1,124 @@
+create table pms_booking_engine_settings (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    public_slug varchar(120) not null,
+    enabled boolean not null default false,
+    require_guarantee boolean not null default false,
+    terms_url varchar(500),
+    privacy_url varchar(500),
+    confirmation_message varchar(1000),
+    created_at timestamp not null,
+    updated_at timestamp not null,
+    constraint uk_pms_booking_engine_property unique (property_id),
+    constraint uk_pms_booking_engine_slug unique (public_slug),
+    constraint fk_pms_booking_engine_property foreign key (property_id) references pms_properties(id)
+);
+
+create table pms_tourism_tax_rules (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    enabled boolean not null default false,
+    name varchar(120) not null,
+    adult_rate decimal(12,2) not null,
+    child_rate decimal(12,2) not null,
+    child_free_under integer not null,
+    maximum_nights integer,
+    created_at timestamp not null,
+    updated_at timestamp not null,
+    constraint uk_pms_tourism_tax_property unique (property_id),
+    constraint fk_pms_tourism_tax_property foreign key (property_id) references pms_properties(id)
+);
+
+create table pms_tourism_tax_postings (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    reservation_id bigint not null,
+    folio_id bigint not null,
+    folio_item_id bigint not null,
+    amount decimal(12,2) not null,
+    nights integer not null,
+    posted_at timestamp not null,
+    posted_by varchar(120) not null,
+    constraint uk_pms_tourism_tax_reservation unique (reservation_id),
+    constraint fk_pms_tourism_tax_posting_property foreign key (property_id) references pms_properties(id),
+    constraint fk_pms_tourism_tax_posting_reservation foreign key (reservation_id) references pms_reservations(id),
+    constraint fk_pms_tourism_tax_posting_folio foreign key (folio_id) references pms_folios(id),
+    constraint fk_pms_tourism_tax_posting_item foreign key (folio_item_id) references pms_folio_items(id)
+);
+
+create table pms_pos_tickets (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    folio_id bigint,
+    ticket_number varchar(50) not null,
+    outlet_code varchar(32) not null,
+    table_reference varchar(60),
+    service_date date not null,
+    status varchar(20) not null,
+    payment_method varchar(24),
+    currency_code varchar(3) not null,
+    net_amount decimal(12,2) not null,
+    tax_amount decimal(12,2) not null,
+    gross_amount decimal(12,2) not null,
+    created_by varchar(120) not null,
+    created_at timestamp not null,
+    settled_at timestamp,
+    constraint uk_pms_pos_ticket_number unique (property_id, ticket_number),
+    constraint fk_pms_pos_ticket_property foreign key (property_id) references pms_properties(id),
+    constraint fk_pms_pos_ticket_folio foreign key (folio_id) references pms_folios(id)
+);
+
+create table pms_pos_ticket_lines (
+    id bigint not null auto_increment primary key,
+    ticket_id bigint not null,
+    description varchar(240) not null,
+    quantity decimal(10,2) not null,
+    unit_price decimal(12,2) not null,
+    tax_rate decimal(5,2) not null,
+    net_amount decimal(12,2) not null,
+    tax_amount decimal(12,2) not null,
+    gross_amount decimal(12,2) not null,
+    constraint fk_pms_pos_line_ticket foreign key (ticket_id) references pms_pos_tickets(id)
+);
+
+create table pms_access_credentials (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    reservation_id bigint not null,
+    room_id bigint not null,
+    provider_code varchar(50) not null,
+    external_reference varchar(160) not null,
+    status varchar(20) not null,
+    valid_from timestamp not null,
+    valid_until timestamp not null,
+    issued_by varchar(120) not null,
+    issued_at timestamp not null,
+    revoked_by varchar(120),
+    revoked_at timestamp,
+    constraint uk_pms_access_provider_ref unique (property_id, provider_code, external_reference),
+    constraint fk_pms_access_property foreign key (property_id) references pms_properties(id),
+    constraint fk_pms_access_reservation foreign key (reservation_id) references pms_reservations(id),
+    constraint fk_pms_access_room foreign key (room_id) references pms_rooms(id)
+);
+
+create table pms_migration_batches (
+    id bigint not null auto_increment primary key,
+    property_id bigint not null,
+    idempotency_key varchar(120) not null,
+    source_system varchar(100) not null,
+    status varchar(20) not null,
+    imported_guests integer not null,
+    imported_reservations integer not null,
+    imported_payments integer not null,
+    total_opening_balance decimal(14,2) not null,
+    reconciliation_message varchar(1000),
+    created_by varchar(120) not null,
+    created_at timestamp not null,
+    completed_at timestamp,
+    constraint uk_pms_migration_batch_key unique (property_id, idempotency_key),
+    constraint fk_pms_migration_property foreign key (property_id) references pms_properties(id)
+);
+
+create index idx_pms_pos_property_created on pms_pos_tickets(property_id, created_at);
+create index idx_pms_access_property_status on pms_access_credentials(property_id, status);
+create index idx_pms_migration_property_created on pms_migration_batches(property_id, created_at);

--- a/Chrono-backend/src/main/resources/db/migration/V17__pms_enterprise_booking_guards.sql
+++ b/Chrono-backend/src/main/resources/db/migration/V17__pms_enterprise_booking_guards.sql
@@ -1,0 +1,92 @@
+CREATE TABLE pms_public_booking_requests (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    property_id BIGINT NOT NULL,
+    reservation_id BIGINT NOT NULL,
+    idempotency_key VARCHAR(80) NOT NULL,
+    request_fingerprint CHAR(64) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_pms_public_booking_request UNIQUE (property_id, idempotency_key),
+    CONSTRAINT fk_pms_public_booking_request_property
+        FOREIGN KEY (property_id) REFERENCES pms_properties (id),
+    CONSTRAINT fk_pms_public_booking_request_reservation
+        FOREIGN KEY (reservation_id) REFERENCES pms_reservations (id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_pms_public_booking_request_created
+    ON pms_public_booking_requests (created_at);
+
+CREATE TABLE pms_public_rate_limits (
+    rate_key CHAR(64) NOT NULL,
+    window_started_at DATETIME(6) NOT NULL,
+    request_count INT NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (rate_key)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_pms_public_rate_limit_updated
+    ON pms_public_rate_limits (updated_at);
+
+CREATE INDEX idx_pms_folio_property_status_created
+    ON pms_folios (status, created_at);
+
+CREATE INDEX idx_pms_maintenance_property_status_reported
+    ON pms_maintenance_work_orders (property_id, status, reported_at);
+
+ALTER TABLE pms_payments
+    ADD COLUMN provider_transaction_id VARCHAR(160) NULL;
+
+CREATE UNIQUE INDEX uk_pms_payment_provider_transaction
+    ON pms_payments (provider_transaction_id);
+
+ALTER TABLE pms_audit_events
+    ADD COLUMN sequence_number BIGINT NULL;
+
+ALTER TABLE pms_audit_events
+    ADD COLUMN previous_hash CHAR(64) NULL;
+
+ALTER TABLE pms_audit_events
+    ADD COLUMN signature_version INT NOT NULL DEFAULT 1;
+
+CREATE UNIQUE INDEX uk_pms_audit_property_sequence
+    ON pms_audit_events (property_id, sequence_number);
+
+CREATE TABLE pms_webhook_deliveries (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    connection_id BIGINT NOT NULL,
+    delivery_id VARCHAR(100) NOT NULL,
+    received_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_pms_webhook_delivery UNIQUE (connection_id, delivery_id),
+    CONSTRAINT fk_pms_webhook_delivery_connection
+        FOREIGN KEY (connection_id) REFERENCES pms_channel_connections (id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_pms_webhook_delivery_received
+    ON pms_webhook_deliveries (received_at);
+
+ALTER TABLE pms_channel_connections
+    ADD COLUMN webhook_key VARCHAR(64) NULL;
+
+UPDATE pms_channel_connections
+SET webhook_key = CONCAT('legacy-', id)
+WHERE webhook_key IS NULL;
+
+CREATE UNIQUE INDEX uk_pms_channel_webhook_key
+    ON pms_channel_connections (webhook_key);
+
+CREATE TABLE pms_public_booking_verifications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    booking_request_id BIGINT NOT NULL,
+    token_hash CHAR(64) NOT NULL,
+    expires_at DATETIME(6) NOT NULL,
+    verified_at DATETIME(6) NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_pms_booking_verification_request UNIQUE (booking_request_id),
+    CONSTRAINT uk_pms_booking_verification_token UNIQUE (token_hash),
+    CONSTRAINT fk_pms_booking_verification_request
+        FOREIGN KEY (booking_request_id) REFERENCES pms_public_booking_requests (id)
+) ENGINE=InnoDB;
+
+CREATE INDEX idx_pms_booking_verification_expiry
+    ON pms_public_booking_verifications (expires_at);

--- a/Chrono-backend/src/test/java/com/chrono/chrono/config/ProductionDeploymentConfigurationTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/config/ProductionDeploymentConfigurationTest.java
@@ -185,13 +185,15 @@ class ProductionDeploymentConfigurationTest {
 
         assertThat(backend)
                 .contains("mvn -B clean verify")
-                .contains("distroless/java21-debian12:nonroot")
+                .contains("distroless/java21-debian13:nonroot")
                 .contains("EXPOSE 8081")
                 .doesNotContain("maven.test.skip");
         assertThat(frontend)
                 .contains("npm ci --legacy-peer-deps")
                 .contains("RUN npm test")
-                .contains("nginx-unprivileged")
+                .contains("RUN apk upgrade --no-cache")
+                .contains("apk add --no-cache nginx")
+                .contains("USER nginx")
                 .contains("EXPOSE 80");
         assertThat(frontendNginx)
                 .contains("listen 80 default_server")

--- a/Chrono-backend/src/test/java/com/chrono/chrono/controller/CompanyManagementControllerTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/controller/CompanyManagementControllerTest.java
@@ -1,0 +1,153 @@
+package com.chrono.chrono.controller;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.EmploymentModelType;
+import com.chrono.chrono.entities.Role;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.repositories.RoleRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.EmploymentModelHistoryService;
+import com.chrono.chrono.services.StripeService;
+import com.chrono.chrono.services.UserPermissionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyManagementControllerTest {
+
+    @Mock private CompanyRepository companyRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private RoleRepository roleRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private StripeService stripeService;
+    @Mock private UserPermissionService userPermissionService;
+    @Mock private EmploymentModelHistoryService employmentModelHistoryService;
+
+    private CompanyManagementController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new CompanyManagementController();
+        ReflectionTestUtils.setField(controller, "companyRepository", companyRepository);
+        ReflectionTestUtils.setField(controller, "userRepository", userRepository);
+        ReflectionTestUtils.setField(controller, "roleRepository", roleRepository);
+        ReflectionTestUtils.setField(controller, "passwordEncoder", passwordEncoder);
+        ReflectionTestUtils.setField(controller, "stripeService", stripeService);
+        ReflectionTestUtils.setField(controller, "userPermissionService", userPermissionService);
+        ReflectionTestUtils.setField(controller, "employmentModelHistoryService", employmentModelHistoryService);
+    }
+
+    @Test
+    void createCompanyWithAdmin_createsCompleteRegularAdminWithPmsAccess() {
+        LocalDate today = LocalDate.of(2026, 8, 4);
+        Role adminRole = new Role("ROLE_ADMIN");
+
+        when(userRepository.existsByUsername("hotel-test-admin")).thenReturn(false);
+        when(passwordEncoder.encode("SehrSicher!2026")).thenReturn("encoded-password");
+        when(roleRepository.findByRoleName("ROLE_ADMIN")).thenReturn(Optional.of(adminRole));
+        when(employmentModelHistoryService.currentBerlinDate()).thenReturn(today);
+        when(companyRepository.save(any(Company.class))).thenAnswer(invocation -> {
+            Company company = invocation.getArgument(0);
+            company.setId(41L);
+            return company;
+        });
+        when(userPermissionService.resolvePermissionsForPersistence(any(User.class), anyMap()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setId(77L);
+            return user;
+        });
+
+        CompanyManagementController.CreateCompanyWithAdminDTO dto = validDto();
+        dto.setAdminPmsAccess(true);
+
+        ResponseEntity<?> response = controller.createCompanyWithAdmin(dto);
+
+        assertEquals(201, response.getStatusCode().value());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        User savedAdmin = userCaptor.getValue();
+
+        assertEquals("hotel-test-admin", savedAdmin.getUsername());
+        assertEquals("encoded-password", savedAdmin.getPassword());
+        assertEquals("encoded-password", savedAdmin.getAdminPassword());
+        assertEquals("CH", savedAdmin.getCountry());
+        assertEquals("A0", savedAdmin.getTarifCode());
+        assertEquals("SG", savedAdmin.getCanton());
+        assertEquals("HOTEL-TEST-001", savedAdmin.getPersonnelNumber());
+        assertEquals("Direktion", savedAdmin.getDepartment());
+        assertFalse(savedAdmin.isIncludeInTimeTracking());
+        assertEquals(0, savedAdmin.getAnnualVacationDays());
+        assertEquals(5, savedAdmin.getExpectedWorkDays());
+        assertEquals(8.5, savedAdmin.getDailyWorkHours());
+        assertEquals(today, savedAdmin.getEntryDate());
+        assertNotNull(savedAdmin.getCompany());
+        assertEquals(41L, savedAdmin.getCompany().getId());
+        assertTrue(savedAdmin.getRoles().stream().anyMatch(role -> "ROLE_ADMIN".equals(role.getRoleName())));
+        assertFalse(savedAdmin.getRoles().stream().anyMatch(role -> "ROLE_SUPERADMIN".equals(role.getRoleName())));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> permissionCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(userPermissionService).resolvePermissionsForPersistence(eq(savedAdmin), permissionCaptor.capture());
+        assertEquals(
+                UserPermissionService.ACCESS_MANAGE,
+                permissionCaptor.getValue().get(UserPermissionService.PAGE_PMS)
+        );
+        verify(employmentModelHistoryService)
+                .ensureBaselineEntry(savedAdmin, EmploymentModelType.STANDARD, today);
+    }
+
+    @Test
+    void createCompanyWithAdmin_rejectsMissingPersonnelNumberBeforeSavingCompany() {
+        CompanyManagementController.CreateCompanyWithAdminDTO dto = validDto();
+        dto.setAdminPersonnelNumber(" ");
+
+        ResponseEntity<?> response = controller.createCompanyWithAdmin(dto);
+
+        assertEquals(400, response.getStatusCode().value());
+        verify(companyRepository, never()).save(any(Company.class));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    private static CompanyManagementController.CreateCompanyWithAdminDTO validDto() {
+        CompanyManagementController.CreateCompanyWithAdminDTO dto =
+                new CompanyManagementController.CreateCompanyWithAdminDTO();
+        dto.setCompanyName("Hotel Testbetrieb");
+        dto.setAdminUsername("hotel-test-admin");
+        dto.setAdminPassword("SehrSicher!2026");
+        dto.setAdminFirstName("Test");
+        dto.setAdminLastName("Hotel");
+        dto.setAdminDepartment("Direktion");
+        dto.setAdminCountry("CH");
+        dto.setAdminTarifCode("A0");
+        dto.setAdminCanton("SG");
+        dto.setAdminPersonnelNumber("HOTEL-TEST-001");
+        dto.setAdminIncludeInTimeTracking(false);
+        return dto;
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/controller/pms/PmsPrivacyControllerTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/controller/pms/PmsPrivacyControllerTest.java
@@ -1,0 +1,58 @@
+package com.chrono.chrono.controller.pms;
+
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.Role;
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserRepository;
+import com.chrono.chrono.services.UserPermissionService;
+import com.chrono.chrono.services.pms.PmsPrivacyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PmsPrivacyControllerTest {
+
+    @Mock private PmsPrivacyService privacyService;
+    @Mock private UserRepository userRepository;
+    @Mock private UserPermissionService permissionService;
+
+    @Test
+    void exportGuest_acceptsRegularRoleAdminWithPmsManagementPermission() {
+        Company company = new Company("Hotel Testbetrieb");
+        company.setId(41L);
+
+        User admin = new User();
+        admin.setUsername("hotel-test-admin");
+        admin.setCompany(company);
+        admin.setRoles(Set.of(new Role("ROLE_ADMIN")));
+
+        Principal principal = () -> "hotel-test-admin";
+        when(userRepository.findByUsernameWithPermissionContext("hotel-test-admin"))
+                .thenReturn(Optional.of(admin));
+
+        PmsPrivacyController controller =
+                new PmsPrivacyController(privacyService, userRepository, permissionService);
+
+        ResponseEntity<?> response = controller.exportGuest(7L, principal);
+
+        assertEquals(200, response.getStatusCode().value());
+        verify(permissionService).assertPageAccess(
+                admin,
+                UserPermissionService.PAGE_PMS,
+                UserPermissionService.ACCESS_MANAGE,
+                "PMS-Verwaltungsrecht erforderlich."
+        );
+        verify(privacyService).exportGuestData(company, 7L, "hotel-test-admin");
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/entities/listeners/UserAuditListenerIntegrationTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/entities/listeners/UserAuditListenerIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.chrono.chrono.entities.listeners;
+
+import com.chrono.chrono.entities.User;
+import com.chrono.chrono.repositories.UserAuditRepository;
+import com.chrono.chrono.repositories.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserAuditListenerIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserAuditRepository userAuditRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void writesAuditThroughTheCurrentApplicationContext() {
+        User user = new User();
+        user.setUsername("audit-listener-user");
+        user.setPassword("test-only-password");
+        user.setCountry("CH");
+        user.setPersonnelNumber("AUDIT-1");
+        user.setEmail("before@example.test");
+        Long userId = userRepository.saveAndFlush(user).getId();
+
+        entityManager.clear();
+        User managedUser = userRepository.findById(userId).orElseThrow();
+        managedUser.setEmail("after@example.test");
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(userAuditRepository.findAll()).anySatisfy(audit -> {
+            assertThat(audit.getUser().getId()).isEqualTo(userId);
+            assertThat(audit.getFieldName()).isEqualTo("email");
+            assertThat(audit.getOldValue()).isEqualTo("before@example.test");
+            assertThat(audit.getNewValue()).isEqualTo("after@example.test");
+        });
+    }
+}

--- a/Chrono-backend/src/test/java/com/chrono/chrono/services/pms/PmsExtensionsServiceIntegrationTest.java
+++ b/Chrono-backend/src/test/java/com/chrono/chrono/services/pms/PmsExtensionsServiceIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.chrono.chrono.services.pms;
+
+import com.chrono.chrono.dto.pms.PmsExtensionsRequests;
+import com.chrono.chrono.dto.pms.UpsertReservationRequest;
+import com.chrono.chrono.entities.Company;
+import com.chrono.chrono.entities.pms.*;
+import com.chrono.chrono.repositories.CompanyRepository;
+import com.chrono.chrono.repositories.pms.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+@Import({PmsExtensionsService.class, PmsOperationsService.class, PmsAuditWriter.class})
+@ActiveProfiles("test")
+@RecordApplicationEvents
+class PmsExtensionsServiceIntegrationTest {
+    @Autowired private PmsExtensionsService service;
+    @Autowired private PmsOperationsService operationsService;
+    @Autowired private CompanyRepository companyRepository;
+    @Autowired private HotelPropertyRepository propertyRepository;
+    @Autowired private RoomTypeRepository roomTypeRepository;
+    @Autowired private RoomRepository roomRepository;
+    @Autowired private GuestProfileRepository guestRepository;
+    @Autowired private RatePlanRepository ratePlanRepository;
+    @Autowired private ReservationRepository reservationRepository;
+    @Autowired private FolioRepository folioRepository;
+    @Autowired private FolioItemRepository folioItemRepository;
+    @Autowired private PosTicketRepository posTicketRepository;
+    @Autowired private AccessCredentialRepository accessCredentialRepository;
+    @Autowired private MigrationBatchRepository migrationBatchRepository;
+    @Autowired private ApplicationEvents applicationEvents;
+
+    private Company company;
+    private HotelProperty property;
+    private RoomType roomType;
+    private Room room;
+    private RatePlan ratePlan;
+    private GuestProfile guest;
+    private LocalDate arrival;
+
+    @BeforeEach
+    void setUp() {
+        company = companyRepository.save(new Company("Chrono Hotel AG"));
+        property = new HotelProperty();
+        property.setCompany(company);
+        property.setCode("ZRH");
+        property.setName("Chrono Zürich");
+        property.setCurrencyCode("CHF");
+        property.setTimezone("Europe/Zurich");
+        property = propertyRepository.save(property);
+        roomType = new RoomType();
+        roomType.setProperty(property);
+        roomType.setCode("DBL");
+        roomType.setName("Doppelzimmer");
+        roomType.setMaxOccupancy(3);
+        roomType = roomTypeRepository.save(roomType);
+        room = new Room();
+        room.setProperty(property);
+        room.setRoomType(roomType);
+        room.setNumber("101");
+        room.setHousekeepingStatus(HousekeepingStatus.CLEAN);
+        room = roomRepository.save(room);
+        ratePlan = new RatePlan();
+        ratePlan.setProperty(property);
+        ratePlan.setRoomType(roomType);
+        ratePlan.setCode("BAR");
+        ratePlan.setName("Beste Rate");
+        ratePlan.setCurrencyCode("CHF");
+        ratePlan.setNightlyRate(new BigDecimal("100.00"));
+        ratePlan.setMinStay(1);
+        ratePlan = ratePlanRepository.save(ratePlan);
+        guest = new GuestProfile();
+        guest.setCompany(company);
+        guest.setFirstName("Gabriela");
+        guest.setLastName("Tschopp");
+        guest.setEmail("gabriela@example.com");
+        guest = guestRepository.save(guest);
+        arrival = LocalDate.now().plusDays(2);
+    }
+
+    @Test
+    void exposesARealPublicBookingFlowUsingPmsAvailability() {
+        service.updateBookingSettings(company, property.getId(), new PmsExtensionsRequests.BookingSettings(
+                "chrono-zuerich", true, true, "https://hotel.example/agb", "https://hotel.example/datenschutz", "Bis bald"));
+
+        var request = new PmsExtensionsRequests.PublicBooking(
+                arrival, arrival.plusDays(2), ratePlan.getId(), 2, 0, "Raja", "Siefert",
+                "raja@example.com", "+41790000000", true, true);
+        var response = service.createPublicBooking(
+                "chrono-zuerich", "booking-test-00000001", request);
+        var repeated = service.createPublicBooking(
+                "chrono-zuerich", "booking-test-00000001", request);
+
+        assertThat(response.confirmationCode()).isNotBlank();
+        assertThat(repeated.confirmationCode()).isEqualTo(response.confirmationCode());
+        assertThat(response.totalAmount()).isEqualByComparingTo("200.00");
+        assertThat(response.status()).isEqualTo("TENTATIVE");
+        assertThat(response.verificationRequired()).isTrue();
+        assertThat(reservationRepository.findAll()).singleElement().satisfies(reservation -> {
+            assertThat(reservation.getSource()).isEqualTo(ReservationSource.BOOKING_ENGINE);
+            assertThat(reservation.getGuaranteeStatus()).isEqualTo(ReservationGuaranteeStatus.DEPOSIT_REQUIRED);
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.TENTATIVE);
+        });
+    }
+
+    @Test
+    void confirmsAnUnguaranteedPublicBookingOnlyAfterEmailVerification() {
+        service.updateBookingSettings(company, property.getId(), new PmsExtensionsRequests.BookingSettings(
+                "chrono-zuerich", true, false, "https://hotel.example/agb",
+                "https://hotel.example/datenschutz", "Bis bald"));
+        var request = new PmsExtensionsRequests.PublicBooking(
+                arrival, arrival.plusDays(2), ratePlan.getId(), 2, 0, "Raja", "Siefert",
+                "raja@example.com", null, true, true);
+
+        service.createPublicBooking("chrono-zuerich", "booking-test-verify-001", request);
+        String token = applicationEvents.stream(PublicBookingVerificationRequested.class)
+                .findFirst().orElseThrow().token();
+        var verified = service.verifyPublicBooking("chrono-zuerich", token);
+
+        assertThat(verified.verificationRequired()).isFalse();
+        assertThat(verified.status()).isEqualTo("CONFIRMED");
+        assertThat(reservationRepository.findAll()).singleElement()
+                .extracting(Reservation::getStatus).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Test
+    void rejectsUnboundedPublicAvailabilityWindows() {
+        service.updateBookingSettings(company, property.getId(), new PmsExtensionsRequests.BookingSettings(
+                "chrono-zuerich", true, false, "https://hotel.example/agb",
+                "https://hotel.example/datenschutz", "Bis bald"));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.publicAvailability(
+                        "chrono-zuerich", arrival, arrival.plusDays(31)))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void postsTourismTaxPosChargesAndProviderNeutralRoomAccess() {
+        Reservation reservation = operationsService.createReservationRecord(company,
+                new UpsertReservationRequest(property.getId(), guest.getId(), roomType.getId(), room.getId(),
+                        ratePlan.getId(), arrival, arrival.plusDays(2), 2, 1, ReservationStatus.CONFIRMED,
+                        ReservationSource.DIRECT, null), "Christopher");
+        Long folioId = folioRepository.findFirstByReservation_IdOrderByIdAsc(reservation.getId()).orElseThrow().getId();
+        service.updateTourismTax(company, property.getId(), new PmsExtensionsRequests.TourismTaxRuleRequest(
+                true, "Kurtaxe Zürich", new BigDecimal("3.50"), new BigDecimal("1.50"), 16, 10));
+        service.postTourismTax(company, property.getId(),
+                new PmsExtensionsRequests.PostTourismTax(reservation.getId(), 1), "Christopher");
+        service.createPosTicket(company, property.getId(), new PmsExtensionsRequests.CreatePosTicket(
+                folioId, "BAR", "12", arrival, null, List.of(new PmsExtensionsRequests.PosLine(
+                "Abendessen", BigDecimal.ONE, new BigDecimal("40.00"), new BigDecimal("8.10")))), "Christopher");
+        service.issueAccessCredential(company, property.getId(), new PmsExtensionsRequests.IssueAccessCredential(
+                reservation.getId(), "SALTO", "secret-manager:key-4711", LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2)), "Christopher");
+
+        assertThat(folioItemRepository.findAllByFolio_IdOrderByServiceDateAscIdAsc(folioId))
+                .extracting(FolioItem::getType).contains(FolioItemType.TAX, FolioItemType.SERVICE);
+        assertThat(posTicketRepository.findAll()).singleElement()
+                .extracting(PosTicket::getGrossAmount).isEqualTo(new BigDecimal("43.24"));
+        assertThat(accessCredentialRepository.findAll()).singleElement()
+                .extracting(AccessCredential::getStatus).isEqualTo(AccessCredentialStatus.ACTIVE);
+        String export = new String(service.accountingExport(company, property.getId(), LocalDate.now(),
+                arrival.plusDays(3)), StandardCharsets.UTF_8);
+        assertThat(export).contains("debitAccount;creditAccount", "Kurtaxe Zürich", "POS BAR");
+        export.lines().skip(1).filter(line -> !line.isBlank()).forEach(line -> {
+            String[] fields = line.split(";", -1);
+            assertThat(fields[5]).isEqualTo(fields[6]);
+        });
+    }
+
+    @Test
+    void importsMigrationRowsIdempotentlyAndFlagsPriceDifferences() {
+        var importRequest = new PmsExtensionsRequests.MigrationImport("batch-001", "LegacyPMS", List.of(
+                new PmsExtensionsRequests.MigrationReservation("LEG-1", "Alex", "Meier", "alex@example.com",
+                        null, roomType.getId(), ratePlan.getId(), arrival, arrival.plusDays(2), 1, 0,
+                        new BigDecimal("210.00"), new BigDecimal("50.00"))));
+
+        service.importMigration(company, property.getId(), importRequest, "Christopher");
+        service.importMigration(company, property.getId(), importRequest, "Christopher");
+
+        assertThat(migrationBatchRepository.findAll()).singleElement().satisfies(batch -> {
+            assertThat(batch.getStatus()).isEqualTo(MigrationBatchStatus.RECONCILIATION_REQUIRED);
+            assertThat(batch.getImportedReservations()).isEqualTo(1);
+            assertThat(batch.getImportedPayments()).isEqualTo(1);
+            assertThat(batch.getTotalOpeningBalance()).isEqualByComparingTo("160.00");
+        });
+        assertThat(reservationRepository.findAll()).hasSize(1);
+    }
+}

--- a/Chrono-frontend/Dockerfile
+++ b/Chrono-frontend/Dockerfile
@@ -19,10 +19,16 @@ RUN npm run audit:prod
 RUN npm test
 RUN npm run build:prod
 
-FROM nginxinc/nginx-unprivileged:1.28.0-alpine
+FROM alpine:3.23
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache nginx \
+    && mkdir -p /usr/share/nginx/html \
+    && chown -R nginx:nginx /usr/share/nginx/html
 
 COPY --from=builder /frontend/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
+USER nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/Chrono-frontend/e2e/pms.spec.ts
+++ b/Chrono-frontend/e2e/pms.spec.ts
@@ -50,9 +50,10 @@ test.describe.serial('Chrono PMS local end-to-end', () => {
         await expect(page.getByText(/^(Betriebsprüfung mit Hinweisen|Bereit für den Hotelbetrieb)$/)).toBeVisible();
 
         await page.getByRole('button', { name: 'Zimmerplan' }).first().click();
-        await expect(page.getByRole('heading', { name: /Zimmerplan für/ })).toBeVisible();
-        await expect(page.getByText('101', { exact: true })).toBeVisible();
-        await expect(page.getByText('Gabriela Tschopp')).toBeVisible();
+        const operationsDialog = page.getByRole('dialog', { name: 'Hotelbetrieb' });
+        await expect(operationsDialog.getByRole('heading', { name: /Zimmerplan für/ })).toBeVisible();
+        await expect(operationsDialog.getByText('101', { exact: true })).toBeVisible();
+        await expect(operationsDialog.getByRole('button', { name: /^Gabriela Tschopp/ })).toBeVisible();
     });
 
     test('creates a guest and reservation through the real UI and API', async ({ page }) => {

--- a/Chrono-frontend/nginx.conf
+++ b/Chrono-frontend/nginx.conf
@@ -1,38 +1,63 @@
-server {
-  # Production Nginx Proxy Manager already forwards to frontend:80.
-  # The container remains non-root; Compose lowers the unprivileged-port
-  # threshold only inside this container's network namespace.
-  listen 80 default_server;
-  server_name _;
-  server_tokens off;
+worker_processes auto;
+pid /tmp/nginx.pid;
+error_log /dev/stderr notice;
 
-  root /usr/share/nginx/html;
-  index index.html;
+events {
+  worker_connections 1024;
+}
 
-  add_header X-Content-Type-Options "nosniff" always;
-  add_header X-Frame-Options "DENY" always;
-  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-  add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'; img-src 'self' data: blob: https://app.privacybee.io; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://app.privacybee.io; connect-src 'self' https://api.chrono-logisch.ch wss://api.chrono-logisch.ch https://app.privacybee.io; frame-src https://app.privacybee.io" always;
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  access_log /dev/stdout;
+  sendfile on;
+  keepalive_timeout 65;
 
-  location = /healthz {
-    access_log off;
-    default_type text/plain;
-    return 200 "ok\n";
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path /tmp/proxy_temp;
+  fastcgi_temp_path /tmp/fastcgi_temp;
+  uwsgi_temp_path /tmp/uwsgi_temp;
+  scgi_temp_path /tmp/scgi_temp;
+
+  map $uri $cache_control {
+    default "no-store";
+    ~^/assets/ "public, max-age=31536000, immutable";
   }
 
-  location /assets/ {
-    try_files $uri =404;
-    expires 1y;
-    add_header Cache-Control "public, immutable";
-  }
+  server {
+    # Production Nginx Proxy Manager already forwards to frontend:80.
+    # The container remains non-root; Compose lowers the unprivileged-port
+    # threshold only inside this container's network namespace.
+    listen 80 default_server;
+    server_name _;
+    server_tokens off;
 
-  location / {
-    try_files $uri /index.html;
-    add_header Cache-Control "no-store";
-  }
+    root /usr/share/nginx/html;
+    index index.html;
 
-  location ~* \.(?:php|asp|aspx|jsp)$ {
-    return 404;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'self'; img-src 'self' data: blob: https://app.privacybee.io; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://app.privacybee.io; connect-src 'self' https://api.chrono-logisch.ch wss://api.chrono-logisch.ch https://app.privacybee.io; frame-src https://app.privacybee.io" always;
+    add_header Cache-Control $cache_control always;
+
+    location = /healthz {
+      access_log off;
+      default_type text/plain;
+      return 200 "ok\n";
+    }
+
+    location /assets/ {
+      try_files $uri =404;
+    }
+
+    location / {
+      try_files $uri /index.html;
+    }
+
+    location ~* \.(?:php|asp|aspx|jsp)$ {
+      return 404;
+    }
   }
 }

--- a/Chrono-frontend/src/pages/Pms/PmsBookingPage.jsx
+++ b/Chrono-frontend/src/pages/Pms/PmsBookingPage.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import api from '../../utils/api.js';
+import '../../styles/PmsBookingPage.css';
+
+const dateKey = (offset = 0) => {
+    const value = new Date();
+    value.setDate(value.getDate() + offset);
+    return value.toISOString().slice(0, 10);
+};
+
+const errorMessage = (error) => error?.response?.data?.detail
+    || error?.response?.data?.message || error?.message || 'Die Buchung konnte nicht abgeschlossen werden.';
+
+const PmsBookingPage = () => {
+    const { propertyCode } = useParams();
+    const location = useLocation();
+    const [config, setConfig] = useState(null);
+    const [availability, setAvailability] = useState(null);
+    const [selectedRateId, setSelectedRateId] = useState('');
+    const [stay, setStay] = useState({ arrival: dateKey(1), departure: dateKey(2), adults: 1, children: 0 });
+    const [guest, setGuest] = useState({
+        firstName: '', lastName: '', email: '', phone: '', termsAccepted: false, privacyAccepted: false,
+    });
+    const [confirmation, setConfirmation] = useState(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState('');
+    const bookingKeyRef = useRef(null);
+    const verificationToken = useMemo(() => new URLSearchParams(location.search)
+        .get('verificationToken'), [location.search]);
+
+    useEffect(() => {
+        setBusy(true);
+        api.get(`/api/public/pms/booking/${propertyCode}`)
+            .then((response) => setConfig(response.data))
+            .catch((loadError) => setError(errorMessage(loadError)))
+            .finally(() => setBusy(false));
+    }, [propertyCode]);
+
+    useEffect(() => {
+        if (!verificationToken) return;
+        setBusy(true);
+        setError('');
+        api.post(`/api/public/pms/booking/${propertyCode}/verify`, { token: verificationToken })
+            .then((response) => setConfirmation(response.data))
+            .catch((verifyError) => setError(errorMessage(verifyError)))
+            .finally(() => setBusy(false));
+    }, [propertyCode, verificationToken]);
+
+    useEffect(() => {
+        bookingKeyRef.current = null;
+    }, [stay, guest, selectedRateId]);
+
+    const selectedRate = useMemo(() => availability?.roomTypes
+        ?.flatMap((roomType) => roomType.rates.map((rate) => ({ ...rate, roomTypeName: roomType.name })))
+        .find((rate) => String(rate.ratePlanId) === String(selectedRateId)), [availability, selectedRateId]);
+
+    const search = async (event) => {
+        event?.preventDefault();
+        setBusy(true);
+        setError('');
+        setConfirmation(null);
+        try {
+            const response = await api.get(`/api/public/pms/booking/${propertyCode}/availability`, {
+                params: { arrival: stay.arrival, departure: stay.departure },
+            });
+            setAvailability(response.data);
+            setSelectedRateId('');
+        } catch (searchError) {
+            setError(errorMessage(searchError));
+        } finally { setBusy(false); }
+    };
+
+    const book = async (event) => {
+        event.preventDefault();
+        setBusy(true);
+        setError('');
+        try {
+            if (!bookingKeyRef.current) {
+                bookingKeyRef.current = globalThis.crypto?.randomUUID?.()
+                    || `booking-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            }
+            const response = await api.post(`/api/public/pms/booking/${propertyCode}/reservations`, {
+                arrivalDate: stay.arrival,
+                departureDate: stay.departure,
+                ratePlanId: Number(selectedRateId),
+                adults: Number(stay.adults),
+                children: Number(stay.children),
+                ...guest,
+            }, {
+                headers: { 'Idempotency-Key': bookingKeyRef.current },
+            });
+            setConfirmation(response.data);
+            setAvailability(null);
+            bookingKeyRef.current = null;
+        } catch (bookingError) {
+            setError(errorMessage(bookingError));
+        } finally { setBusy(false); }
+    };
+
+    return (
+        <main className="pms-booking-page">
+            <header className="pms-booking-hero">
+                <span>Direkt beim Hotel buchen</span>
+                <h1>{config?.hotelName || 'Onlinebuchung'}</h1>
+                {config?.city && <p>{config.city}</p>}
+            </header>
+
+            {error && <div className="pms-booking-message is-error" role="alert">{error}</div>}
+            {confirmation ? (
+                <section className="pms-booking-card pms-booking-confirmation">
+                    <span>{confirmation.verificationRequired
+                        ? 'E-Mail-Bestätigung erforderlich'
+                        : confirmation.status === 'CONFIRMED'
+                            ? 'Reservierung bestätigt'
+                            : 'E-Mail bestätigt – Garantie ausstehend'}</span>
+                    <h2>{confirmation.confirmationCode}</h2>
+                    <p>{confirmation.roomTypeName} · {confirmation.rateName}</p>
+                    <strong>{new Intl.NumberFormat('de-CH', { style: 'currency', currency: confirmation.currencyCode }).format(confirmation.totalAmount)}</strong>
+                    {confirmation.verificationRequired && <p>Wir haben dir einen Bestätigungslink per E-Mail gesendet. Bis zur Bestätigung bleibt das Zimmer kurzzeitig vorgemerkt.</p>}
+                    {!confirmation.verificationRequired && confirmation.status === 'TENTATIVE' && <p>Deine E-Mail ist bestätigt. Das Hotel bestätigt die Reservierung nach Eingang der erforderlichen Garantie oder Anzahlung.</p>}
+                    {confirmation.holdUntil && confirmation.status === 'TENTATIVE' && <p>Vorgemerkt bis {new Intl.DateTimeFormat('de-CH', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(confirmation.holdUntil))}.</p>}
+                    {confirmation.confirmationMessage && <p>{confirmation.confirmationMessage}</p>}
+                    <button type="button" onClick={() => { setConfirmation(null); setGuest({ firstName: '', lastName: '', email: '', phone: '', termsAccepted: false, privacyAccepted: false }); }}>Weitere Buchung</button>
+                </section>
+            ) : (
+                <>
+                    <section className="pms-booking-card">
+                        <h2>Aufenthalt suchen</h2>
+                        <form className="pms-booking-grid" onSubmit={search}>
+                            <label>Anreise<input type="date" min={dateKey()} value={stay.arrival} onChange={(e) => setStay({ ...stay, arrival: e.target.value })} required /></label>
+                            <label>Abreise<input type="date" min={stay.arrival} value={stay.departure} onChange={(e) => setStay({ ...stay, departure: e.target.value })} required /></label>
+                            <label>Erwachsene<input type="number" min="1" max="20" value={stay.adults} onChange={(e) => setStay({ ...stay, adults: e.target.value })} /></label>
+                            <label>Kinder<input type="number" min="0" max="20" value={stay.children} onChange={(e) => setStay({ ...stay, children: e.target.value })} /></label>
+                            <button className="is-primary" disabled={busy}>{busy ? 'Suche…' : 'Verfügbarkeit prüfen'}</button>
+                        </form>
+                    </section>
+
+                    {availability && (
+                        <section className="pms-booking-card">
+                            <h2>Zimmer und Rate wählen</h2>
+                            <div className="pms-booking-rates">
+                                {availability.roomTypes.flatMap((roomType) => roomType.rates.map((rate) => (
+                                    <label className={`pms-booking-rate ${!rate.available ? 'is-disabled' : ''}`} key={rate.ratePlanId}>
+                                        <input type="radio" name="rate" disabled={!rate.available} checked={String(selectedRateId) === String(rate.ratePlanId)} onChange={() => setSelectedRateId(rate.ratePlanId)} />
+                                        <span><strong>{roomType.name}</strong><small>{rate.name}{rate.restriction ? ` · ${rate.restriction}` : ''}</small></span>
+                                        <b>{new Intl.NumberFormat('de-CH', { style: 'currency', currency: rate.currencyCode }).format(rate.totalAmount)}</b>
+                                    </label>
+                                )))}
+                            </div>
+                        </section>
+                    )}
+
+                    {selectedRate && (
+                        <section className="pms-booking-card">
+                            <h2>Kontaktdaten</h2>
+                            <form className="pms-booking-grid" onSubmit={book}>
+                                <label>Vorname<input value={guest.firstName} onChange={(e) => setGuest({ ...guest, firstName: e.target.value })} required /></label>
+                                <label>Nachname<input value={guest.lastName} onChange={(e) => setGuest({ ...guest, lastName: e.target.value })} required /></label>
+                                <label>E-Mail<input type="email" value={guest.email} onChange={(e) => setGuest({ ...guest, email: e.target.value })} required /></label>
+                                <label>Telefon<input value={guest.phone} onChange={(e) => setGuest({ ...guest, phone: e.target.value })} /></label>
+                                <label className="pms-booking-consent"><input type="checkbox" checked={guest.termsAccepted} onChange={(e) => setGuest({ ...guest, termsAccepted: e.target.checked })} required /> Ich akzeptiere {config?.termsUrl ? <a href={config.termsUrl} target="_blank" rel="noreferrer">die AGB</a> : 'die Buchungsbedingungen'}.</label>
+                                <label className="pms-booking-consent"><input type="checkbox" checked={guest.privacyAccepted} onChange={(e) => setGuest({ ...guest, privacyAccepted: e.target.checked })} required /> Ich akzeptiere {config?.privacyUrl ? <a href={config.privacyUrl} target="_blank" rel="noreferrer">die Datenschutzhinweise</a> : 'die Datenschutzhinweise'}.</label>
+                                {config?.requireGuarantee && <p className="pms-booking-hint">Das Hotel wird sich zur Garantie oder Anzahlung mit dir in Verbindung setzen.</p>}
+                                <button className="is-primary" disabled={busy}>Kostenpflichtig buchen · {new Intl.NumberFormat('de-CH', { style: 'currency', currency: selectedRate.currencyCode }).format(selectedRate.totalAmount)}</button>
+                            </form>
+                        </section>
+                    )}
+                </>
+            )}
+        </main>
+    );
+};
+
+export default PmsBookingPage;

--- a/Chrono-frontend/src/pages/Pms/PmsBookingPage.test.jsx
+++ b/Chrono-frontend/src/pages/Pms/PmsBookingPage.test.jsx
@@ -1,0 +1,75 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PmsBookingPage from './PmsBookingPage.jsx';
+
+const apiMock = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }));
+vi.mock('../../utils/api.js', () => ({ default: apiMock }));
+
+const renderPage = (entry = '/book/ZRH') => render(<MemoryRouter initialEntries={[entry]}><Routes>
+    <Route path="/book/:propertyCode" element={<PmsBookingPage />} />
+</Routes></MemoryRouter>);
+
+describe('PmsBookingPage', () => {
+    beforeEach(() => {
+        apiMock.get.mockReset();
+        apiMock.post.mockReset();
+        apiMock.get.mockImplementation((url) => {
+            if (url.endsWith('/availability')) return Promise.resolve({ data: {
+                roomTypes: [{ name: 'Doppelzimmer', rates: [{ ratePlanId: 9, name: 'Beste Rate', currencyCode: 'CHF', totalAmount: 220, available: true, restriction: null }] }],
+            } });
+            return Promise.resolve({ data: {
+                hotelName: 'Chrono Zürich', city: 'Zürich', currencyCode: 'CHF',
+                termsUrl: 'https://hotel.example/agb', privacyUrl: 'https://hotel.example/privacy', requireGuarantee: false,
+            } });
+        });
+        apiMock.post.mockResolvedValue({ data: {
+            confirmationCode: 'CHR-ABC123', roomTypeName: 'Doppelzimmer', rateName: 'Beste Rate',
+            currencyCode: 'CHF', totalAmount: 220, confirmationMessage: 'Bis bald',
+            status: 'TENTATIVE', verificationRequired: true, holdUntil: '2026-08-07T17:00:00',
+        } });
+    });
+
+    it('searches availability and creates a direct reservation', async () => {
+        renderPage();
+        expect(await screen.findByText('Chrono Zürich')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Verfügbarkeit prüfen' }));
+        await screen.findByText('Doppelzimmer');
+        fireEvent.click(screen.getByRole('radio'));
+        fireEvent.change(screen.getByLabelText('Vorname'), { target: { value: 'Raja' } });
+        fireEvent.change(screen.getByLabelText('Nachname'), { target: { value: 'Siefert' } });
+        fireEvent.change(screen.getByLabelText('E-Mail'), { target: { value: 'raja@example.com' } });
+        const consentLabels = screen.getAllByText(/Ich akzeptiere/);
+        fireEvent.click(consentLabels[0].closest('label').querySelector('input'));
+        fireEvent.click(consentLabels[1].closest('label').querySelector('input'));
+        fireEvent.click(screen.getByRole('button', { name: /Kostenpflichtig buchen/ }));
+
+        await waitFor(() => expect(apiMock.post).toHaveBeenCalledWith(
+            '/api/public/pms/booking/ZRH/reservations',
+            expect.objectContaining({
+                ratePlanId: 9, firstName: 'Raja', lastName: 'Siefert', email: 'raja@example.com',
+                termsAccepted: true, privacyAccepted: true,
+            }),
+            expect.objectContaining({ headers: { 'Idempotency-Key': expect.any(String) } }),
+        ));
+        expect(await screen.findByText('CHR-ABC123')).toBeInTheDocument();
+        expect(screen.getByText('E-Mail-Bestätigung erforderlich')).toBeInTheDocument();
+    });
+
+    it('verifies a booking from the email link', async () => {
+        apiMock.post.mockResolvedValueOnce({ data: {
+            confirmationCode: 'CHR-VERIFIED', roomTypeName: 'Doppelzimmer', rateName: 'Beste Rate',
+            currencyCode: 'CHF', totalAmount: 220, status: 'CONFIRMED', verificationRequired: false,
+        } });
+
+        renderPage('/book/ZRH?verificationToken=abcdefghijklmnopqrstuvwxyz123456');
+
+        await waitFor(() => expect(apiMock.post).toHaveBeenCalledWith(
+            '/api/public/pms/booking/ZRH/verify',
+            { token: 'abcdefghijklmnopqrstuvwxyz123456' },
+        ));
+        expect(await screen.findByText('Reservierung bestätigt')).toBeInTheDocument();
+    });
+});

--- a/Chrono-frontend/src/pages/Pms/PmsExtensionsWorkspace.jsx
+++ b/Chrono-frontend/src/pages/Pms/PmsExtensionsWorkspace.jsx
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import api from '../../utils/api.js';
+import { formatPmsDateTime } from './pmsFormatting.js';
+import { getFolioDisplayLabel } from './pmsTerminology.js';
+
+const errorMessage = (error) => error?.response?.data?.detail
+    || error?.response?.data?.message || error?.message || 'Die Aktion konnte nicht abgeschlossen werden.';
+
+const money = (value, currency = 'CHF') => new Intl.NumberFormat('de-CH', {
+    style: 'currency', currency,
+}).format(Number(value ?? 0));
+
+const PmsExtensionsWorkspace = ({ property, operations, businessDate, canManage, onOperationsChange }) => {
+    const [data, setData] = useState(null);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState('');
+    const [notice, setNotice] = useState('');
+    const [booking, setBooking] = useState({
+        publicSlug: property?.code?.toLowerCase() ?? '', enabled: false, requireGuarantee: false, termsUrl: '', privacyUrl: '', confirmationMessage: '',
+    });
+    const [tax, setTax] = useState({
+        enabled: false, name: 'Kurtaxe', adultRate: 0, childRate: 0, childFreeUnder: 16, maximumNights: '',
+    });
+    const [taxPosting, setTaxPosting] = useState({ reservationId: '', chargeableChildren: 0 });
+    const [pos, setPos] = useState({
+        folioId: '', outletCode: 'RESTAURANT', tableReference: '', paymentMethod: 'CASH',
+        description: '', quantity: 1, unitPrice: 0, taxRate: 8.1,
+    });
+    const [access, setAccess] = useState({
+        reservationId: '', providerCode: '', externalReference: '',
+        validFrom: `${businessDate}T15:00`, validUntil: `${businessDate}T23:00`,
+    });
+    const [migration, setMigration] = useState({
+        idempotencyKey: `migration-${businessDate}`, sourceSystem: '', reservationsJson: '[]',
+    });
+    const [accounting, setAccounting] = useState({
+        from: `${businessDate.slice(0, 7)}-01`, toExclusive: businessDate,
+    });
+
+    const activeReservations = useMemo(() => (operations?.reservations ?? [])
+        .filter((entry) => !['CANCELLED', 'NO_SHOW', 'CHECKED_OUT'].includes(entry.status)), [operations]);
+    const openFolios = useMemo(() => (operations?.folios ?? []).filter((entry) => entry.status === 'OPEN'), [operations]);
+
+    const applyData = useCallback((next) => {
+        setData(next);
+        if (next?.bookingEngine) setBooking({
+            publicSlug: next.bookingEngine.publicSlug ?? property?.code?.toLowerCase() ?? '',
+            enabled: next.bookingEngine.enabled,
+            requireGuarantee: next.bookingEngine.requireGuarantee,
+            termsUrl: next.bookingEngine.termsUrl ?? '',
+            privacyUrl: next.bookingEngine.privacyUrl ?? '',
+            confirmationMessage: next.bookingEngine.confirmationMessage ?? '',
+        });
+        if (next?.tourismTax) setTax({
+            enabled: next.tourismTax.enabled,
+            name: next.tourismTax.name ?? 'Kurtaxe',
+            adultRate: next.tourismTax.adultRate ?? 0,
+            childRate: next.tourismTax.childRate ?? 0,
+            childFreeUnder: next.tourismTax.childFreeUnder ?? 16,
+            maximumNights: next.tourismTax.maximumNights ?? '',
+        });
+    }, [property?.code]);
+
+    const load = useCallback(async () => {
+        if (!property?.id) return;
+        setBusy(true);
+        setError('');
+        try {
+            const response = await api.get('/api/pms/extensions', { params: { propertyId: property.id } });
+            applyData(response.data);
+        } catch (loadError) {
+            setError(errorMessage(loadError));
+        } finally {
+            setBusy(false);
+        }
+    }, [applyData, property?.id]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const mutate = async (method, url, payload, success, refreshOperations = false) => {
+        setBusy(true);
+        setError('');
+        setNotice('');
+        try {
+            const response = await api[method](url, payload);
+            applyData(response.data);
+            if (refreshOperations) {
+                const operationsResponse = await api.get('/api/pms/operations', {
+                    params: { propertyId: property.id, businessDate },
+                });
+                onOperationsChange(operationsResponse.data);
+            }
+            setNotice(success);
+            return true;
+        } catch (mutationError) {
+            setError(errorMessage(mutationError));
+            return false;
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const submitBooking = (event) => {
+        event.preventDefault();
+        return mutate('put', `/api/pms/properties/${property.id}/booking-engine`, booking,
+            booking.enabled ? `Onlinebuchung ist aktiv: /book/${booking.publicSlug}` : 'Onlinebuchung deaktiviert.');
+    };
+
+    const submitTax = (event) => {
+        event.preventDefault();
+        return mutate('put', `/api/pms/properties/${property.id}/tourism-tax`, {
+            ...tax, maximumNights: tax.maximumNights === '' ? null : Number(tax.maximumNights),
+        }, 'Kurtaxenregel gespeichert.');
+    };
+
+    const postTax = async (event) => {
+        event.preventDefault();
+        const ok = await mutate('post', `/api/pms/properties/${property.id}/tourism-tax/postings`, {
+            reservationId: Number(taxPosting.reservationId),
+            chargeableChildren: Number(taxPosting.chargeableChildren),
+        }, 'Kurtaxe auf das Gastkonto verbucht.', true);
+        if (ok) setTaxPosting({ reservationId: '', chargeableChildren: 0 });
+    };
+
+    const submitPos = async (event) => {
+        event.preventDefault();
+        const roomCharge = Boolean(pos.folioId);
+        const ok = await mutate('post', `/api/pms/properties/${property.id}/pos/tickets`, {
+            folioId: roomCharge ? Number(pos.folioId) : null,
+            outletCode: pos.outletCode,
+            tableReference: pos.tableReference || null,
+            serviceDate: businessDate,
+            paymentMethod: roomCharge ? null : pos.paymentMethod,
+            lines: [{
+                description: pos.description,
+                quantity: Number(pos.quantity),
+                unitPrice: Number(pos.unitPrice),
+                taxRate: Number(pos.taxRate),
+            }],
+        }, roomCharge ? 'POS-Beleg auf das Gastkonto gebucht.' : 'POS-Beleg direkt bezahlt.', true);
+        if (ok) setPos((current) => ({ ...current, description: '', quantity: 1, unitPrice: 0 }));
+    };
+
+    const issueAccess = async (event) => {
+        event.preventDefault();
+        const ok = await mutate('post', `/api/pms/properties/${property.id}/access-credentials`, {
+            ...access, reservationId: Number(access.reservationId),
+        }, 'Digitaler Schlüssel beim Anbieter eingeplant.');
+        if (ok) setAccess((current) => ({ ...current, externalReference: '' }));
+    };
+
+    const importMigration = async (event) => {
+        event.preventDefault();
+        let reservations;
+        try { reservations = JSON.parse(migration.reservationsJson); } catch {
+            setError('Die Migrationsdaten sind kein gültiges JSON-Array.');
+            return;
+        }
+        await mutate('post', `/api/pms/properties/${property.id}/migration-batches`, {
+            idempotencyKey: migration.idempotencyKey,
+            sourceSystem: migration.sourceSystem,
+            reservations,
+        }, 'Migrationsbatch importiert und abgestimmt.', true);
+    };
+
+    const downloadAccounting = async (event) => {
+        event.preventDefault();
+        setBusy(true);
+        setError('');
+        try {
+            const response = await api.get(`/api/pms/properties/${property.id}/accounting-export.csv`, {
+                params: accounting, responseType: 'blob',
+            });
+            const url = URL.createObjectURL(response.data);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `chrono-pms-accounting-${accounting.from}.csv`;
+            link.click();
+            URL.revokeObjectURL(url);
+            setNotice('Buchhaltungsexport erstellt.');
+        } catch (downloadError) {
+            setError(errorMessage(downloadError));
+        } finally { setBusy(false); }
+    };
+
+    return (
+        <div className="pms-operations-stack">
+            {error && <div className="pms-inline-message is-error" role="alert">{error}</div>}
+            {notice && <div className="pms-inline-message is-success" role="status">{notice}</div>}
+            <div className="pms-operations-layout">
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Direktvertrieb</span><h3>Booking Engine</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={submitBooking}>
+                        <label className="pms-checkbox-row"><input type="checkbox" checked={booking.enabled} onChange={(e) => setBooking({ ...booking, enabled: e.target.checked })} /> Onlinebuchung aktiv</label>
+                        <label className="pms-checkbox-row"><input type="checkbox" checked={booking.requireGuarantee} onChange={(e) => setBooking({ ...booking, requireGuarantee: e.target.checked })} /> Garantie/Anzahlung verlangen</label>
+                        <label className="is-wide">Öffentlicher Buchungsname<input value={booking.publicSlug} pattern="[a-z0-9](?:[a-z0-9-]{1,118}[a-z0-9])?" onChange={(e) => setBooking({ ...booking, publicSlug: e.target.value.toLowerCase() })} required /><small>/book/{booking.publicSlug || 'hotelname'}</small></label>
+                        <label className="is-wide">AGB-Adresse<input type="url" value={booking.termsUrl} onChange={(e) => setBooking({ ...booking, termsUrl: e.target.value })} placeholder="https://…" /></label>
+                        <label className="is-wide">Datenschutz-Adresse<input type="url" value={booking.privacyUrl} onChange={(e) => setBooking({ ...booking, privacyUrl: e.target.value })} placeholder="https://…" /></label>
+                        <label className="is-wide">Bestätigungstext<textarea value={booking.confirmationMessage} onChange={(e) => setBooking({ ...booking, confirmationMessage: e.target.value })} /></label>
+                        <div className="pms-form-actions is-wide"><button className="is-primary" disabled={!canManage || busy}>Booking Engine speichern</button></div>
+                    </form>
+                </section>
+
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Gemeindeabgaben</span><h3>Kurtaxe</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={submitTax}>
+                        <label className="pms-checkbox-row"><input type="checkbox" checked={tax.enabled} onChange={(e) => setTax({ ...tax, enabled: e.target.checked })} /> Regel aktiv</label>
+                        <label>Name<input value={tax.name} onChange={(e) => setTax({ ...tax, name: e.target.value })} required /></label>
+                        <label>Erwachsene/Nacht<input type="number" min="0" step="0.01" value={tax.adultRate} onChange={(e) => setTax({ ...tax, adultRate: e.target.value })} /></label>
+                        <label>Kinder/Nacht<input type="number" min="0" step="0.01" value={tax.childRate} onChange={(e) => setTax({ ...tax, childRate: e.target.value })} /></label>
+                        <label>Kinder frei unter<input type="number" min="0" max="21" value={tax.childFreeUnder} onChange={(e) => setTax({ ...tax, childFreeUnder: e.target.value })} /></label>
+                        <label>Max. Nächte<input type="number" min="1" value={tax.maximumNights} onChange={(e) => setTax({ ...tax, maximumNights: e.target.value })} /></label>
+                        <div className="pms-form-actions is-wide"><button disabled={!canManage || busy}>Regel speichern</button></div>
+                    </form>
+                    <hr />
+                    <form className="pms-form-grid" onSubmit={postTax}>
+                        <label className="is-wide">Reservierung<select value={taxPosting.reservationId} onChange={(e) => setTaxPosting({ ...taxPosting, reservationId: e.target.value })} required><option value="">Reservierung wählen</option>{activeReservations.map((entry) => <option key={entry.id} value={entry.id}>{entry.confirmationCode} · {entry.guestName}</option>)}</select></label>
+                        <label>Steuerpflichtige Kinder<input type="number" min="0" max="20" value={taxPosting.chargeableChildren} onChange={(e) => setTaxPosting({ ...taxPosting, chargeableChildren: e.target.value })} /></label>
+                        <div className="pms-form-actions"><button className="is-primary" disabled={!canManage || busy}>Kurtaxe verbuchen</button></div>
+                    </form>
+                </section>
+            </div>
+
+            <div className="pms-operations-layout">
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Restaurant, Bar & Spa</span><h3>POS-Beleg</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={submitPos}>
+                        <label>Outlet<input value={pos.outletCode} onChange={(e) => setPos({ ...pos, outletCode: e.target.value })} required /></label>
+                        <label>Tisch/Referenz<input value={pos.tableReference} onChange={(e) => setPos({ ...pos, tableReference: e.target.value })} /></label>
+                        <label className="is-wide">Gastkonto (leer = direkt bezahlt)<select value={pos.folioId} onChange={(e) => setPos({ ...pos, folioId: e.target.value })}><option value="">Direktzahlung</option>{openFolios.map((folio) => <option key={folio.id} value={folio.id}>{getFolioDisplayLabel(folio.label)} · {folio.guestName}</option>)}</select></label>
+                        {!pos.folioId && <label>Zahlungsart<select value={pos.paymentMethod} onChange={(e) => setPos({ ...pos, paymentMethod: e.target.value })}><option value="CASH">Bar</option><option value="CARD">Karte</option><option value="BANK_TRANSFER">Überweisung</option><option value="VOUCHER">Gutschein</option></select></label>}
+                        <label className="is-wide">Leistung<input value={pos.description} onChange={(e) => setPos({ ...pos, description: e.target.value })} required /></label>
+                        <label>Menge<input type="number" min="0.01" step="0.01" value={pos.quantity} onChange={(e) => setPos({ ...pos, quantity: e.target.value })} /></label>
+                        <label>Einzelpreis<input type="number" min="0" step="0.01" value={pos.unitPrice} onChange={(e) => setPos({ ...pos, unitPrice: e.target.value })} /></label>
+                        <label>MWST %<input type="number" min="0" max="100" step="0.01" value={pos.taxRate} onChange={(e) => setPos({ ...pos, taxRate: e.target.value })} /></label>
+                        <div className="pms-form-actions"><button className="is-primary" disabled={!canManage || busy}>Beleg abschliessen</button></div>
+                    </form>
+                    <div className="pms-record-list">{data?.posTickets?.slice(0, 10).map((ticket) => <article className="pms-record" key={ticket.id}><div><span>{ticket.ticketNumber} · {ticket.paymentMethod}</span><strong>{ticket.outletCode} · {money(ticket.grossAmount, ticket.currencyCode)}</strong><small>{ticket.guestName || ticket.tableReference || 'Direktverkauf'} · {formatPmsDateTime(ticket.createdAt)}</small></div></article>)}</div>
+                </section>
+
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Zutrittssystem</span><h3>Digitale Zimmerschlüssel</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={issueAccess}>
+                        <label className="is-wide">Reservierung<select value={access.reservationId} onChange={(e) => setAccess({ ...access, reservationId: e.target.value })} required><option value="">Reservierung mit Zimmer wählen</option>{activeReservations.filter((entry) => entry.roomNumber).map((entry) => <option key={entry.id} value={entry.id}>{entry.roomNumber} · {entry.guestName}</option>)}</select></label>
+                        <label>Anbieter<input value={access.providerCode} onChange={(e) => setAccess({ ...access, providerCode: e.target.value })} placeholder="SALTO" required /></label>
+                        <label>Externe Referenz<input value={access.externalReference} onChange={(e) => setAccess({ ...access, externalReference: e.target.value })} placeholder="secret-manager:key-…" required /></label>
+                        <label>Gültig ab<input type="datetime-local" value={access.validFrom} onChange={(e) => setAccess({ ...access, validFrom: e.target.value })} required /></label>
+                        <label>Gültig bis<input type="datetime-local" value={access.validUntil} onChange={(e) => setAccess({ ...access, validUntil: e.target.value })} required /></label>
+                        <div className="pms-form-actions is-wide"><button className="is-primary" disabled={!canManage || busy}>Schlüssel ausstellen</button></div>
+                    </form>
+                    <div className="pms-record-list">{data?.accessCredentials?.map((credential) => <article className="pms-record" key={credential.id}><div><span>{credential.status} · Zimmer {credential.roomNumber}</span><strong>{credential.guestName}</strong><small>{credential.providerCode} · bis {formatPmsDateTime(credential.validUntil)}</small></div>{credential.status === 'ACTIVE' && <button type="button" disabled={!canManage || busy} onClick={() => mutate('post', `/api/pms/properties/${property.id}/access-credentials/${credential.id}/revoke`, undefined, 'Schlüsselwiderruf eingeplant.')}>Widerrufen</button>}</article>)}</div>
+                </section>
+            </div>
+
+            <div className="pms-operations-layout">
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Finanzübergabe</span><h3>Buchhaltungsexport</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={downloadAccounting}>
+                        <label>Von<input type="date" value={accounting.from} onChange={(e) => setAccounting({ ...accounting, from: e.target.value })} required /></label>
+                        <label>Bis exklusiv<input type="date" value={accounting.toExclusive} onChange={(e) => setAccounting({ ...accounting, toExclusive: e.target.value })} required /></label>
+                        <div className="pms-form-actions is-wide"><button disabled={busy}>CSV herunterladen</button></div>
+                    </form>
+                </section>
+                <section className="pms-work-card">
+                    <div className="pms-work-card-heading"><div><span className="pms-eyebrow">Systemwechsel</span><h3>Datenmigration</h3></div></div>
+                    <form className="pms-form-grid" onSubmit={importMigration}>
+                        <label>Quellsystem<input value={migration.sourceSystem} onChange={(e) => setMigration({ ...migration, sourceSystem: e.target.value })} required /></label>
+                        <label>Idempotenzschlüssel<input value={migration.idempotencyKey} onChange={(e) => setMigration({ ...migration, idempotencyKey: e.target.value })} required /></label>
+                        <label className="is-wide">Reservationen als JSON<textarea rows="8" value={migration.reservationsJson} onChange={(e) => setMigration({ ...migration, reservationsJson: e.target.value })} required /></label>
+                        <div className="pms-form-actions is-wide"><button className="is-primary" disabled={!canManage || busy}>Importieren & abstimmen</button></div>
+                    </form>
+                    <div className="pms-record-list">{data?.migrationBatches?.map((batch) => <article className="pms-record" key={batch.id}><div><span>{batch.status} · {batch.sourceSystem}</span><strong>{batch.importedReservations} Reservationen · {money(batch.totalOpeningBalance, property.currencyCode)} offen</strong><small>{batch.reconciliationMessage}</small></div></article>)}</div>
+                </section>
+            </div>
+        </div>
+    );
+};
+
+export default PmsExtensionsWorkspace;

--- a/Chrono-frontend/src/pages/Pms/PmsExtensionsWorkspace.test.jsx
+++ b/Chrono-frontend/src/pages/Pms/PmsExtensionsWorkspace.test.jsx
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PmsExtensionsWorkspace from './PmsExtensionsWorkspace.jsx';
+
+const apiMock = vi.hoisted(() => ({ get: vi.fn(), put: vi.fn(), post: vi.fn() }));
+vi.mock('../../utils/api.js', () => ({ default: apiMock }));
+
+const extensionData = {
+    bookingEngine: { publicSlug: 'chrono-zuerich', enabled: false, requireGuarantee: false, termsUrl: null, privacyUrl: null, confirmationMessage: null },
+    tourismTax: { enabled: false, name: 'Kurtaxe', adultRate: 0, childRate: 0, childFreeUnder: 16, maximumNights: null },
+    posTickets: [], accessCredentials: [], migrationBatches: [],
+};
+
+describe('PmsExtensionsWorkspace', () => {
+    beforeEach(() => {
+        apiMock.get.mockReset();
+        apiMock.put.mockReset();
+        apiMock.post.mockReset();
+        apiMock.get.mockResolvedValue({ data: extensionData });
+        apiMock.put.mockResolvedValue({ data: { ...extensionData, bookingEngine: { ...extensionData.bookingEngine, enabled: true } } });
+    });
+
+    it('activates the public booking engine with HTTPS policy links', async () => {
+        render(<PmsExtensionsWorkspace property={{ id: 7, code: 'ZRH', currencyCode: 'CHF' }}
+            operations={{ reservations: [], folios: [] }} businessDate="2026-08-07"
+            canManage onOperationsChange={vi.fn()} />);
+
+        await screen.findByText('Booking Engine');
+        fireEvent.click(screen.getByLabelText('Onlinebuchung aktiv'));
+        fireEvent.change(screen.getByLabelText('AGB-Adresse'), { target: { value: 'https://hotel.example/agb' } });
+        fireEvent.change(screen.getByLabelText('Datenschutz-Adresse'), { target: { value: 'https://hotel.example/privacy' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Booking Engine speichern' }));
+
+        await waitFor(() => expect(apiMock.put).toHaveBeenCalledWith('/api/pms/properties/7/booking-engine', expect.objectContaining({
+            enabled: true,
+            termsUrl: 'https://hotel.example/agb',
+            privacyUrl: 'https://hotel.example/privacy',
+        })));
+        expect(await screen.findByText('Onlinebuchung ist aktiv: /book/chrono-zuerich')).toBeInTheDocument();
+    });
+});

--- a/Chrono-frontend/src/pages/__tests__/CompanyManagementPage.test.jsx
+++ b/Chrono-frontend/src/pages/__tests__/CompanyManagementPage.test.jsx
@@ -1,0 +1,158 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import CompanyManagementPage from '../CompanyManagementPage';
+import api from '../../utils/api';
+
+vi.mock('../../utils/api', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+vi.mock('../../components/Navbar', () => ({
+    default: () => <nav aria-label="Navbar" />,
+}));
+
+vi.mock('../../context/LanguageContext', () => ({
+    useTranslation: () => ({ t: (_key, fallback) => fallback ?? _key }),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+    useAuth: () => ({ currentUser: { roles: ['ROLE_SUPERADMIN'] } }),
+}));
+
+vi.mock('../../utils/analytics', () => ({
+    isAnalyticsExcluded: vi.fn(() => true),
+    setAnalyticsExcluded: vi.fn(),
+}));
+
+const analyticsSummary = {
+    totalPageViews: 0,
+    todayPageViews: 0,
+    uniqueVisitors: 0,
+    todayUniqueVisitors: 0,
+    totalClicks: 0,
+    todayClicks: 0,
+    dailyStats: [],
+    topPages: [],
+    topClicks: [],
+};
+
+const company = {
+    id: 1,
+    name: 'Chrono Testhotel',
+    active: true,
+    paid: false,
+    canceled: false,
+    userCount: 1,
+    enabledFeatures: [],
+};
+
+const resolvedGet = (url) => {
+    if (url === '/api/superadmin/companies') {
+        return Promise.resolve({ data: [company] });
+    }
+    if (url.startsWith('/api/superadmin/analytics/summary')) {
+        return Promise.resolve({ data: analyticsSummary });
+    }
+    if (url === '/api/superadmin/analytics/excluded-ips') {
+        return Promise.resolve({ data: [] });
+    }
+    return Promise.resolve({ data: {} });
+};
+
+describe('CompanyManagementPage', () => {
+    beforeEach(() => {
+        api.get.mockReset();
+        api.post.mockReset();
+        api.put.mockReset();
+        api.delete.mockReset();
+        api.get.mockImplementation(resolvedGet);
+        api.post.mockResolvedValue({ data: {} });
+        vi.spyOn(window, 'alert').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps the rendered company list visible during the 30-second background refresh', async () => {
+        vi.useFakeTimers();
+        let companyRequestCount = 0;
+        let resolveBackgroundRefresh;
+        const backgroundRefresh = new Promise((resolve) => {
+            resolveBackgroundRefresh = resolve;
+        });
+
+        api.get.mockImplementation((url) => {
+            if (url === '/api/superadmin/companies') {
+                companyRequestCount += 1;
+                return companyRequestCount === 1
+                    ? Promise.resolve({ data: [company] })
+                    : backgroundRefresh;
+            }
+            return resolvedGet(url);
+        });
+
+        render(<CompanyManagementPage />);
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(screen.getByText('Chrono Testhotel')).toBeInTheDocument();
+
+        await act(async () => {
+            vi.advanceTimersByTime(30000);
+            await Promise.resolve();
+        });
+
+        expect(companyRequestCount).toBe(2);
+        expect(screen.getByText('Chrono Testhotel')).toBeInTheDocument();
+
+        await act(async () => {
+            resolveBackgroundRefresh({ data: [company] });
+            await Promise.resolve();
+        });
+    });
+
+    it('submits a complete regular admin with optional PMS management access', async () => {
+        render(<CompanyManagementPage />);
+
+        const form = await screen.findByTestId('company-admin-create-form');
+        const user = userEvent.setup();
+
+        await user.type(within(form).getByLabelText('Firmenname'), 'Hotel Testbetrieb');
+        await user.type(within(form).getByLabelText('Admin Benutzername'), 'hotel-test-admin');
+        await user.type(within(form).getByLabelText('Admin Passwort'), 'SehrSicher!2026');
+        await user.type(within(form).getByLabelText('Vorname'), 'Test');
+        await user.type(within(form).getByLabelText('Nachname'), 'Hotel');
+        await user.type(within(form).getByLabelText('Abteilung / Funktion'), 'Direktion');
+        await user.type(within(form).getByLabelText('Personalnummer'), 'HOTEL-TEST-001');
+        await user.click(within(form).getByLabelText('Hotelverwaltung (PMS) verwalten'));
+        await user.click(within(form).getByRole('button', { name: 'Firma + Admin erstellen' }));
+
+        await waitFor(() => {
+            expect(api.post).toHaveBeenCalledWith(
+                '/api/superadmin/companies/create-with-admin',
+                expect.objectContaining({
+                    companyName: 'Hotel Testbetrieb',
+                    adminUsername: 'hotel-test-admin',
+                    adminPassword: 'SehrSicher!2026',
+                    adminDepartment: 'Direktion',
+                    adminCountry: 'CH',
+                    adminTarifCode: 'A0',
+                    adminCanton: 'SG',
+                    adminPersonnelNumber: 'HOTEL-TEST-001',
+                    adminIncludeInTimeTracking: false,
+                    adminPmsAccess: true,
+                })
+            );
+        });
+    });
+});

--- a/Chrono-frontend/src/styles/PmsBookingPage.css
+++ b/Chrono-frontend/src/styles/PmsBookingPage.css
@@ -1,0 +1,45 @@
+.pms-booking-page {
+    min-height: 100vh;
+    padding: clamp(24px, 6vw, 72px) 18px;
+    color: #172033;
+    background: radial-gradient(circle at top left, #dff6ef 0, transparent 34%), linear-gradient(145deg, #f7faf9, #eef3f5);
+}
+
+.pms-booking-page > * { max-width: 920px; margin-left: auto; margin-right: auto; }
+.pms-booking-hero { margin-bottom: 28px; }
+.pms-booking-hero span { color: #087e68; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.pms-booking-hero h1 { margin: 8px 0 4px; font-size: clamp(2rem, 6vw, 4rem); }
+.pms-booking-hero p { margin: 0; color: #5a6878; }
+.pms-booking-card { margin-bottom: 18px; padding: clamp(20px, 4vw, 34px); border: 1px solid #d9e3e5; border-radius: 22px; background: rgba(255,255,255,.94); box-shadow: 0 18px 55px rgba(30,55,70,.08); }
+.pms-booking-card h2 { margin-top: 0; }
+.pms-booking-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.pms-booking-grid label { display: grid; gap: 7px; font-weight: 700; }
+.pms-booking-grid input { min-height: 46px; padding: 10px 12px; border: 1px solid #bdcbd0; border-radius: 11px; font: inherit; }
+.pms-booking-grid button { grid-column: 1 / -1; min-height: 48px; border: 0; border-radius: 12px; background: #087e68; color: white; font-weight: 800; cursor: pointer; }
+.pms-booking-grid button:disabled { opacity: .55; cursor: wait; }
+.pms-booking-rates { display: grid; gap: 12px; }
+.pms-booking-rate { display: grid; grid-template-columns: auto 1fr auto; gap: 14px; align-items: center; padding: 16px; border: 1px solid #cfdadd; border-radius: 14px; cursor: pointer; }
+.pms-booking-rate:has(input:checked) { border-color: #087e68; background: #eefaf7; box-shadow: 0 0 0 2px rgba(8,126,104,.14); }
+.pms-booking-rate span { display: grid; gap: 4px; }
+.pms-booking-rate small { color: #657384; }
+.pms-booking-rate.is-disabled { opacity: .55; cursor: not-allowed; }
+.pms-booking-consent { grid-column: 1 / -1; display: flex !important; grid-template-columns: none; align-items: center; gap: 10px !important; font-weight: 500 !important; }
+.pms-booking-consent input { min-height: auto; }
+.pms-booking-hint { grid-column: 1 / -1; margin: 0; padding: 12px; border-radius: 10px; background: #fff6df; }
+.pms-booking-message { padding: 16px; margin-bottom: 18px; border-radius: 12px; background: #fff0f0; color: #9c2929; }
+.pms-booking-confirmation { text-align: center; }
+.pms-booking-confirmation h2 { font-size: clamp(2rem, 7vw, 4rem); color: #087e68; }
+.pms-booking-confirmation strong { display: block; margin: 18px 0; font-size: 1.4rem; }
+.pms-booking-confirmation button { padding: 12px 18px; border: 0; border-radius: 11px; background: #172033; color: white; }
+
+[data-theme="dark"] .pms-booking-page { color: #edf5f4; background: radial-gradient(circle at top left, #123d37 0, transparent 36%), #101722; }
+[data-theme="dark"] .pms-booking-card { background: rgba(24,34,48,.96); border-color: #344353; }
+[data-theme="dark"] .pms-booking-grid input { color: #f2f6f6; background: #101722; border-color: #46586a; }
+[data-theme="dark"] .pms-booking-rate { border-color: #46586a; }
+[data-theme="dark"] .pms-booking-rate:has(input:checked) { background: #123d37; }
+
+@media (max-width: 620px) {
+    .pms-booking-grid { grid-template-columns: 1fr; }
+    .pms-booking-rate { grid-template-columns: auto 1fr; }
+    .pms-booking-rate b { grid-column: 2; }
+}

--- a/docs/operations/ENTERPRISE_READINESS.md
+++ b/docs/operations/ENTERPRISE_READINESS.md
@@ -1,0 +1,55 @@
+# Enterprise-PMS-Abnahme
+
+Dieses Dokument definiert die technische Freigabe für größere Hotels und Hotelgruppen. Eine Freigabe gilt nur für die konkret geprüfte Infrastruktur, Datenmigration und Anbieterlandschaft.
+
+## Bereits im Produkt abgesichert
+
+- Mandanten- und Hotelzuordnung wird serverseitig geprüft; öffentliche Webhooks verwenden global eindeutige, nicht erratbare Schlüssel.
+- Reservierungen sperren den Hotelbestand beim Schreiben. Dadurch können parallele Buchungen das letzte Zimmer nicht doppelt verkaufen.
+- Öffentliche Buchungen sind idempotent, rate-limitiert und zunächst nur zeitlich begrenzte Vormerkungen. Die E-Mail-Adresse muss bestätigt werden.
+- Verfügbarkeiten werden mit gebündelten Datenbankzugriffen berechnet. Öffentliche Aufenthalte sind standardmäßig auf 30 Nächte begrenzt.
+- Kartenreferenzen sind einmalig, Zahlungen und Rückerstattungen werden pessimistisch gesperrt, Übererstattungen werden verhindert.
+- Eingehende Webhooks brauchen Zeitstempel, Delivery-ID und HMAC-Signatur; Replay-IDs werden gespeichert.
+- Audit-Ereignisse bilden eine HMAC-signierte Sequenzkette. Dokumentfingerprints werden ebenfalls mit einem separaten HMAC-Schlüssel gebildet.
+- Das Live-Profil verlangt verifiziertes MySQL-TLS, starke Geheimnisse, echte Zahlungsanbieter und deaktivierte Demo-/Simulationsfunktionen.
+- Management- und Prometheus-Endpunkte laufen auf Port 8082 und werden nicht über den öffentlichen Gateway veröffentlicht.
+- Backups, Restore-Drills, Outbox-Zustellung, Alertmanager und Grafana sind Bestandteil der Betriebsumgebung.
+
+## Verbindliche Go-live-Gates pro Hotel
+
+1. `ops/preflight.ps1` läuft mit der echten, nicht eingecheckten Produktionsumgebung ohne Fehler.
+2. Fresh- und Legacy-Migrationen laufen gegen dieselbe MySQL-Hauptversion wie Produktion.
+3. Ein vollständiger Restore-Drill erfüllt die vereinbarten RPO-/RTO-Werte und der Nachweis ist jünger als 30 Tage.
+4. Der Lasttest wird mit einer anonymisierten, produktionsähnlichen Zimmer-, Raten- und Reservierungsmenge ausgeführt. P95 bleibt unter 1 Sekunde, Fehlerquote unter 1 Prozent und es entsteht kein Overselling.
+5. OTA-, Payment-, Schließsystem-, POS-, E-Mail- und Finanzschnittstellen bestehen ihre Anbieter-Zertifizierung und Sandbox-UAT.
+6. Datenschutz, Aufbewahrung, Fiskalisierung, Kurtaxe, Meldewesen und Zahlungsbedingungen werden für Land/Kanton/Gemeinde juristisch abgenommen.
+7. Monitoring, Bereitschaftsdienst, Eskalationswege und ein Rollback-Fenster sind für den Einführungstag besetzt.
+
+## Lasttest
+
+Nur gegen eine isolierte Lasttestumgebung ausführen. Schreiblast erzeugt echte Testreservierungen.
+
+```powershell
+$env:LOAD_BASE_URL='https://pms-load.example'
+$env:LOAD_PROPERTY_CODE='load-hotel'
+$env:LOAD_ARRIVAL='2026-10-12'
+$env:LOAD_DEPARTURE='2026-10-14'
+k6 run ops/load/pms-booking.js
+```
+
+Für Buchungskonkurrenz zusätzlich `LOAD_RATE_PLAN_ID` setzen und `LOAD_ALLOW_WRITES=true` verwenden. Danach Reservierungsanzahl, verfügbaren Bestand, Datenbank-Locks, Hikari-Auslastung, P95/P99 und Outbox-Rückstand prüfen.
+
+Die Standardlast steigt bis 75 Anfragen pro Sekunde und dauert fünf Minuten.
+Für kurze Pipeline-Smoke-Tests können `LOAD_START_RATE`, `LOAD_PEAK_RATE`,
+`LOAD_RAMP_DURATION`, `LOAD_PEAK_DURATION` und `LOAD_COOLDOWN_DURATION`
+überschrieben werden. HTTP 429 gilt bewusst als Fehler: Die isolierte
+Lasttestumgebung muss ein zur Zielkapazität passendes Rate-Limit besitzen,
+damit Drosselung keine langsame oder überlastete Anwendung verdeckt.
+
+## Kapazitätsstartwert
+
+Das Live-Profil startet mit 300 Tomcat-Threads, 40 Datenbankverbindungen und 8.192 maximalen Verbindungen. Das sind sichere Ausgangswerte, keine universelle Kapazitätsgarantie. Sie müssen anhand des Lasttests, der MySQL-Latenz und der Anzahl gleichzeitig aktiver Hotels angepasst werden.
+
+## Architekturgrenze
+
+Die Eigenschaftssperre priorisiert korrekten Bestand gegenüber maximalem Buchungsdurchsatz. Bei sehr hoher Buchungsrate für ein einzelnes Hotel kann sie zum Engpass werden. Vor einem Betrieb mit mehreren hundert Buchungen pro Sekunde pro Hotel ist eine verteilte Bestands-/Kontingentarchitektur mit dediziertem Lasttest erforderlich.

--- a/docs/operations/PMS_EXTENSIONS.md
+++ b/docs/operations/PMS_EXTENSIONS.md
@@ -1,0 +1,110 @@
+# PMS commercial and hotel integrations
+
+Chrono PMS includes provider-neutral workflows for direct booking, POS,
+tourism tax, digital room access, accounting export and source-system
+migration. Provider credentials remain outside the PMS and all provider side
+effects use the signed integration outbox.
+
+## Direct booking engine
+
+Configure the public slug, HTTPS terms/privacy links and guarantee policy in
+`Verkauf & lokale Integrationen`. The public page is then available at
+`/book/<public-slug>`.
+
+Public requests are rate-limited through the shared database. Availability is
+calculated with bounded, batched inventory reads and public stays are limited
+to 30 nights by default. Every booking write requires an `Idempotency-Key`,
+repeats the availability check under the property lock and creates guest,
+reservation, folio, history and outbox records in one transaction. A public
+slug is globally unique and therefore cannot cross tenant boundaries.
+
+New public bookings remain `TENTATIVE` for 15 minutes and receive a one-time
+email verification link. An unguaranteed booking becomes `CONFIRMED` only after
+verification. When a guarantee is required, verification extends the hold for
+24 hours while the certified payment/guarantee workflow completes.
+
+The guarantee flag creates a `DEPOSIT_REQUIRED` reservation. Payment capture
+is intentionally not simulated: a live hotel must complete the hosted checkout
+or terminal workflow with its certified payment provider before treating the
+reservation as financially guaranteed.
+
+## POS
+
+POS tickets can be settled directly using a recorded payment method or posted
+to an open guest folio as a service charge. Each ticket stores immutable line,
+tax and gross totals. Direct card settlement represents a completed external
+terminal transaction; card details must never be entered in Chrono.
+
+## Tourism tax and registration
+
+One property-specific tourism-tax rule defines adult/child nightly rates and
+an optional maximum number of nights. Staff explicitly record the number of
+chargeable children because age exemptions vary by municipality. A tax can be
+posted only once per reservation and is added to the main open folio.
+
+The existing digital registration workflow remains responsible for statutory
+guest-registration data. Local authority exports are jurisdiction-specific and
+must be approved against the hotel's municipality before go-live.
+
+## Digital room access
+
+Chrono stores only the provider name and an external credential reference. It
+never stores a door PIN or mobile-key secret. Issue and revoke operations enter
+the signed integration outbox as `access_credential.issue_requested` and
+`access_credential.revoke_requested`. The gateway must acknowledge successful
+delivery and reconcile active credentials with the lock provider.
+
+## Accounting CSV
+
+The export contains semicolon-separated, balanced debit/credit rows for folio
+services, payments and direct POS tickets. Invoices are document snapshots and
+are deliberately not exported as an additional revenue posting, which avoids
+double-posting the underlying folio services.
+Default Swiss-style accounts are:
+
+| Posting | Account | Counter-account |
+| --- | --- | --- |
+| Room charge | 1100 | 3200 |
+| Breakfast charge | 1100 | 3210 |
+| Other/POS service | 1100 or payment account | 3220 |
+| Cash payment | 1000 | 1100 |
+| Card payment | 1020 | 1100 |
+| Bank transfer | 1021 | 1100 |
+| Tourism tax | 1100 | 3600 |
+
+These are transport defaults, not accounting advice. The pilot hotel's chart
+of accounts and import format must be signed off by its fiduciary/accounting
+team before automated posting.
+
+## Migration batches
+
+Migration imports are transactional and idempotent per hotel and batch key.
+Each reservation row carries an external reference, guest identity, mapped room
+type/rate IDs, stay dates, expected gross amount and deposit. Chrono recalculates
+the stay from its own rates and marks any mismatch as
+`RECONCILIATION_REQUIRED`.
+
+Example `reservations` value:
+
+```json
+[
+  {
+    "externalReference": "LEGACY-4711",
+    "firstName": "Alex",
+    "lastName": "Meier",
+    "email": "alex@example.com",
+    "phone": "+41790000000",
+    "roomTypeId": 1,
+    "ratePlanId": 1,
+    "arrivalDate": "2026-09-01",
+    "departureDate": "2026-09-03",
+    "adults": 2,
+    "children": 0,
+    "expectedGrossAmount": 360.00,
+    "depositAmount": 100.00
+  }
+]
+```
+
+Never proceed with cutover while a batch is marked
+`RECONCILIATION_REQUIRED`.

--- a/ops/load/pms-booking.js
+++ b/ops/load/pms-booking.js
@@ -1,0 +1,87 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const baseUrl = __ENV.LOAD_BASE_URL || 'http://127.0.0.1:8081';
+const propertyCode = __ENV.LOAD_PROPERTY_CODE;
+const arrival = __ENV.LOAD_ARRIVAL;
+const departure = __ENV.LOAD_DEPARTURE;
+const ratePlanId = Number(__ENV.LOAD_RATE_PLAN_ID || 0);
+const allowWrites = (__ENV.LOAD_ALLOW_WRITES || 'false').toLowerCase() === 'true';
+const startRate = Number(__ENV.LOAD_START_RATE || 5);
+const peakRate = Number(__ENV.LOAD_PEAK_RATE || 75);
+const preAllocatedVUs = Number(__ENV.LOAD_PREALLOCATED_VUS || 40);
+const maxVUs = Number(__ENV.LOAD_MAX_VUS || 200);
+const rampDuration = __ENV.LOAD_RAMP_DURATION || '1m';
+const peakDuration = __ENV.LOAD_PEAK_DURATION || '3m';
+const cooldownDuration = __ENV.LOAD_COOLDOWN_DURATION || '1m';
+
+const bookingFailures = new Rate('pms_booking_failures');
+const availabilityLatency = new Trend('pms_availability_latency', true);
+
+export const options = {
+    scenarios: {
+        availability: {
+            executor: 'ramping-arrival-rate',
+            startRate,
+            timeUnit: '1s',
+            preAllocatedVUs,
+            maxVUs,
+            stages: [
+                { target: Math.max(startRate, Math.ceil(peakRate / 3)), duration: rampDuration },
+                { target: peakRate, duration: peakDuration },
+                { target: 0, duration: cooldownDuration },
+            ],
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<1000', 'p(99)<2000'],
+        pms_availability_latency: ['p(95)<750'],
+        pms_booking_failures: ['rate<0.01'],
+    },
+};
+
+export function setup() {
+    if (!propertyCode || !arrival || !departure) {
+        throw new Error('LOAD_PROPERTY_CODE, LOAD_ARRIVAL and LOAD_DEPARTURE are required.');
+    }
+    if (allowWrites && !ratePlanId) {
+        throw new Error('LOAD_RATE_PLAN_ID is required when LOAD_ALLOW_WRITES=true.');
+    }
+}
+
+export default function () {
+    const availability = http.get(
+        `${baseUrl}/api/public/pms/booking/${propertyCode}/availability?arrival=${arrival}&departure=${departure}`,
+        { tags: { operation: 'public-availability' } },
+    );
+    availabilityLatency.add(availability.timings.duration);
+    check(availability, { 'availability is successful': (r) => r.status === 200 });
+
+    if (allowWrites && availability.status === 200) {
+        const idempotencyKey = `load-${__VU}-${__ITER}-${Date.now()}`;
+        const response = http.post(
+            `${baseUrl}/api/public/pms/booking/${propertyCode}/reservations`,
+            JSON.stringify({
+                arrivalDate: arrival,
+                departureDate: departure,
+                ratePlanId,
+                adults: 1,
+                children: 0,
+                firstName: 'Load',
+                lastName: `Guest-${__VU}-${__ITER}`,
+                email: `load-${__VU}-${__ITER}@example.invalid`,
+                termsAccepted: true,
+                privacyAccepted: true,
+            }),
+            {
+                headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey },
+                tags: { operation: 'public-booking' },
+                responseCallback: http.expectedStatuses(201, 409),
+            },
+        );
+        bookingFailures.add(![201, 409].includes(response.status));
+    }
+    sleep(0.2);
+}


### PR DESCRIPTION
## What changed

- adds the 50 PMS source, migration, test, UI, operations, and readiness files that were missing from `PMS Final`
- completes public booking, POS, tourism tax, digital access, migration, rate-limit, webhook replay, and verification support
- includes Flyway V16/V17 plus enterprise readiness and load-test assets

## Why

The first `PMS Final` commit contained the tracked integrations but not the newly created files they depend on. This follow-up makes the published repository complete and buildable while deliberately excluding local artifacts.

## Validation

- 318 backend tests passed
- MySQL 8.0.42 and 8.4 fresh/legacy migrations passed
- backup/restore drill restored 110 tables, including 41 PMS tables, at Flyway V17
- 121 frontend tests and the production build passed
- k6 smoke load: 2,287 requests, 0% errors, P95 9.88 ms at up to 75 requests/s
- browser login and PMS dashboard flow passed

## Excluded intentionally

`tmp/`, `outputs/`, `node_modules/`, and `.env.local` are not part of this change.
